### PR TITLE
Evict duplicate pods only if not all nodes are used

### DIFF
--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -165,3 +165,21 @@ func PodFitsCurrentNode(pod *v1.Pod, node *v1.Node) bool {
 	glog.V(3).Infof("Pod %v fits on node %v", pod.Name, node.Name)
 	return true
 }
+
+// PodToleratesNodeTaints check if the given pod tolerates the taints on the given node
+func PodToleratesNodeTaints(pod *v1.Pod, node *v1.Node) bool {
+	ok, err := utils.PodToleratesNodeTaints(pod, node)
+
+	if err != nil {
+		glog.Error(err)
+		return false
+	}
+
+	if !ok {
+		glog.V(1).Infof("Pod %v does not tolerate taints on node %v", pod.Name, node.Name)
+		return false
+	}
+
+	glog.V(3).Infof("Pod %v tolerates taints on node %v", pod.Name, node.Name)
+	return true
+}

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubernetes-incubator/descheduler/cmd/descheduler/app/options"
 	"github.com/kubernetes-incubator/descheduler/pkg/api"
 	"github.com/kubernetes-incubator/descheduler/pkg/descheduler/evictions"
+	nodeutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/node"
 	podutil "github.com/kubernetes-incubator/descheduler/pkg/descheduler/pod"
 )
 
@@ -46,11 +47,12 @@ func RemoveDuplicatePods(ds *options.DeschedulerServer, strategy api.Descheduler
 // deleteDuplicatePods evicts the pod from node and returns the count of evicted pods.
 func deleteDuplicatePods(client clientset.Interface, policyGroupVersion string, nodes []*v1.Node, dryRun bool, nodepodCount nodePodEvictedCount, maxPodsToEvict int) int {
 	podsEvicted := 0
+	dpmByNode, creatorIsSaturated := computeCreatorSaturation(client, nodes)
 	for _, node := range nodes {
 		glog.V(1).Infof("Processing node: %#v", node.Name)
-		dpm := ListDuplicatePodsOnANode(client, node)
+		dpm := dpmByNode[node]
 		for creator, pods := range dpm {
-			if len(pods) > 1 {
+			if len(pods) > 1 && !creatorIsSaturated[creator] {
 				glog.V(1).Infof("%#v", creator)
 				// i = 0 does not evict the first pod
 				for i := 1; i < len(pods); i++ {
@@ -70,6 +72,39 @@ func deleteDuplicatePods(client clientset.Interface, policyGroupVersion string, 
 		podsEvicted += nodepodCount[node]
 	}
 	return podsEvicted
+}
+
+// computeCreatorSaturation finds if creators in the cluster are _saturated_.
+// A creator is _saturated_ if atleast one pod is running on every possible nodes.
+// In such a case, pods of this creator are not evicted from any nodes even if duplicates are present.
+func computeCreatorSaturation(client clientset.Interface, nodes []*v1.Node) (map[*v1.Node]DuplicatePodsMap, map[string]bool) {
+	dpmByNode := make(map[*v1.Node]DuplicatePodsMap)
+	creatorAssignedNodes := make(map[string][]*v1.Node)
+	for _, node := range nodes {
+		dpmByNode[node] = ListDuplicatePodsOnANode(client, node)
+		for creator := range dpmByNode[node] {
+			creatorAssignedNodes[creator] = append(creatorAssignedNodes[creator], node)
+		}
+	}
+
+	creatorPossibleNodes := make(map[string][]*v1.Node)
+	for creator, nodeList := range creatorAssignedNodes {
+		creatorNode := nodeList[0]
+		creatorPod := dpmByNode[creatorNode][creator][0]
+		for _, node := range nodes {
+			if nodeutil.PodFitsCurrentNode(creatorPod, node) && nodeutil.PodToleratesNodeTaints(creatorPod, node) {
+				creatorPossibleNodes[creator] = append(creatorPossibleNodes[creator], node)
+			}
+		}
+	}
+
+	creatorIsSaturated := make(map[string]bool)
+	for creator, nodeList := range creatorAssignedNodes {
+		creatorIsSaturated[creator] = (len(creatorPossibleNodes[creator]) == len(nodeList))
+		glog.V(1).Infof("Creator %#v is saturated: %#v", creator, creatorIsSaturated[creator])
+	}
+
+	return dpmByNode, creatorIsSaturated
 }
 
 // ListDuplicatePodsOnANode lists duplicate pods on a given node.


### PR DESCRIPTION
Currently, if the total number of pods running on a cluster is greater than the number of nodes and each node has atleast one pod allocated, the descheduler will evict the pods from the nodes where duplicates are found. This behavior is unnecessary as the evicted pods will be allocated to some nodes again. Further, if the descheduler runs periodically as a CronJob, the cluster never stabilizes and remains in a constant state of flux.

This PR adds a condition to check if a _creator_ has its pods on all possible nodes (the pods satisfy the affinity and taints on these nodes). If it has, we call the creator _saturated_ and no pods of this creator would be evicted from any nodes. This helps stabilize the cluster.