### PR TITLE
Adding Pod Antiaffinity e2e test

### DIFF
--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -78,7 +78,7 @@ func ListEvictablePodsOnNode(client clientset.Interface, node *v1.Node, evictLoc
 }
 
 func ListPodsOnANode(client clientset.Interface, node *v1.Node) ([]*v1.Pod, error) {
-	fieldSelector, err := fields.ParseSelector("spec.nodeName=" + node.Name + ",status.phase!=" + string(api.PodSucceeded) + ",status.phase!=" + string(api.PodFailed))
+	fieldSelector, err := fields.ParseSelector("spec.nodeName=" + node.Name + ",status.phase=" + string(api.PodRunning))
 	if err != nil {
 		return []*v1.Pod{}, err
 	}

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -36,7 +36,7 @@ type DuplicatePodsMap map[string][]*v1.Pod
 // RemoveDuplicatePods removes the duplicate pods on node. This strategy evicts all duplicate pods on node.
 // A pod is said to be a duplicate of other if both of them are from same creator, kind and are within the same
 // namespace. As of now, this strategy won't evict daemonsets, mirror pods, critical pods and pods with local storages.
-func RemoveDuplicatePods(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, policyGroupVersion string, nodes []*v1.Node, nodepodCount nodePodEvictedCount) {
+func RemoveDuplicatePods(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, policyGroupVersion string, nodes []*v1.Node, nodepodCount NodePodEvictedCount) {
 	if !strategy.Enabled {
 		return
 	}
@@ -44,7 +44,7 @@ func RemoveDuplicatePods(ds *options.DeschedulerServer, strategy api.Descheduler
 }
 
 // deleteDuplicatePods evicts the pod from node and returns the count of evicted pods.
-func deleteDuplicatePods(client clientset.Interface, policyGroupVersion string, nodes []*v1.Node, dryRun bool, nodepodCount nodePodEvictedCount, maxPodsToEvict int, evictLocalStoragePods bool) int {
+func deleteDuplicatePods(client clientset.Interface, policyGroupVersion string, nodes []*v1.Node, dryRun bool, nodepodCount NodePodEvictedCount, maxPodsToEvict int, evictLocalStoragePods bool) int {
 	podsEvicted := 0
 	for _, node := range nodes {
 		glog.V(1).Infof("Processing node: %#v", node.Name)

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -126,7 +126,7 @@ func TestFindDuplicatePods(t *testing.T) {
 
 	for _, testCase := range testCases {
 
-		npe := nodePodEvictedCount{}
+		npe := NodePodEvictedCount{}
 		npe[node] = 0
 		fakeClient := &fake.Clientset{}
 		fakeClient.Fake.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -44,7 +44,7 @@ type NodeUsageMap struct {
 
 type NodePodsMap map[*v1.Node][]*v1.Pod
 
-func LowNodeUtilization(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, evictionPolicyGroupVersion string, nodes []*v1.Node, nodepodCount nodePodEvictedCount) {
+func LowNodeUtilization(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, evictionPolicyGroupVersion string, nodes []*v1.Node, nodepodCount NodePodEvictedCount) {
 	if !strategy.Enabled {
 		return
 	}
@@ -155,7 +155,7 @@ func classifyNodes(npm NodePodsMap, thresholds api.ResourceThresholds, targetThr
 // evictPodsFromTargetNodes evicts pods based on priority, if all the pods on the node have priority, if not
 // evicts them based on QoS as fallback option.
 // TODO: @ravig Break this function into smaller functions.
-func evictPodsFromTargetNodes(client clientset.Interface, evictionPolicyGroupVersion string, targetNodes, lowNodes []NodeUsageMap, targetThresholds api.ResourceThresholds, dryRun bool, maxPodsToEvict int, nodepodCount nodePodEvictedCount) int {
+func evictPodsFromTargetNodes(client clientset.Interface, evictionPolicyGroupVersion string, targetNodes, lowNodes []NodeUsageMap, targetThresholds api.ResourceThresholds, dryRun bool, maxPodsToEvict int, nodepodCount NodePodEvictedCount) int {
 	podsEvicted := 0
 
 	SortNodesByUsage(targetNodes)

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -116,7 +116,7 @@ func TestLowNodeUtilizationWithoutPriority(t *testing.T) {
 	if len(lowNodes) != 1 {
 		t.Errorf("After ignoring unschedulable nodes, expected only one node to be under utilized.")
 	}
-	npe := nodePodEvictedCount{}
+	npe := NodePodEvictedCount{}
 	npe[n1] = 0
 	npe[n2] = 0
 	npe[n3] = 0
@@ -221,7 +221,7 @@ func TestLowNodeUtilizationWithPriorities(t *testing.T) {
 	if len(lowNodes) != 1 {
 		t.Errorf("After ignoring unschedulable nodes, expected only one node to be under utilized.")
 	}
-	npe := nodePodEvictedCount{}
+	npe := NodePodEvictedCount{}
 	npe[n1] = 0
 	npe[n2] = 0
 	npe[n3] = 0

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -26,11 +26,11 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-func RemovePodsViolatingNodeAffinity(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, evictionPolicyGroupVersion string, nodes []*v1.Node, nodePodCount nodePodEvictedCount) {
+func RemovePodsViolatingNodeAffinity(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, evictionPolicyGroupVersion string, nodes []*v1.Node, nodePodCount NodePodEvictedCount) {
 	removePodsViolatingNodeAffinityCount(ds, strategy, evictionPolicyGroupVersion, nodes, nodePodCount, ds.MaxNoOfPodsToEvictPerNode, ds.EvictLocalStoragePods)
 }
 
-func removePodsViolatingNodeAffinityCount(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, evictionPolicyGroupVersion string, nodes []*v1.Node, nodepodCount nodePodEvictedCount, maxPodsToEvict int, evictLocalStoragePods bool) int {
+func removePodsViolatingNodeAffinityCount(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, evictionPolicyGroupVersion string, nodes []*v1.Node, nodepodCount NodePodEvictedCount, maxPodsToEvict int, evictLocalStoragePods bool) int {
 	evictedPodCount := 0
 	if !strategy.Enabled {
 		return evictedPodCount

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -92,7 +92,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 		pods                    []v1.Pod
 		strategy                api.DeschedulerStrategy
 		expectedEvictedPodCount int
-		npe                     nodePodEvictedCount
+		npe                     NodePodEvictedCount
 		maxPodsToEvict          int
 	}{
 		{
@@ -108,7 +108,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			expectedEvictedPodCount: 0,
 			pods:                    addPodsToNode(nodeWithoutLabels),
 			nodes:                   []*v1.Node{nodeWithoutLabels, nodeWithLabels},
-			npe:                     nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
+			npe:                     NodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
 			maxPodsToEvict:          0,
 		},
 		{
@@ -124,7 +124,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			expectedEvictedPodCount: 0,
 			pods:                    addPodsToNode(nodeWithoutLabels),
 			nodes:                   []*v1.Node{nodeWithoutLabels, nodeWithLabels},
-			npe:                     nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
+			npe:                     NodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
 			maxPodsToEvict:          0,
 		},
 		{
@@ -133,7 +133,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			expectedEvictedPodCount: 0,
 			pods:                    addPodsToNode(nodeWithLabels),
 			nodes:                   []*v1.Node{nodeWithLabels},
-			npe:                     nodePodEvictedCount{nodeWithLabels: 0},
+			npe:                     NodePodEvictedCount{nodeWithLabels: 0},
 			maxPodsToEvict:          0,
 		},
 		{
@@ -142,7 +142,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			strategy:                requiredDuringSchedulingIgnoredDuringExecutionStrategy,
 			pods:                    addPodsToNode(nodeWithoutLabels),
 			nodes:                   []*v1.Node{nodeWithoutLabels, nodeWithLabels},
-			npe:                     nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
+			npe:                     NodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
 			maxPodsToEvict:          0,
 		},
 		{
@@ -151,7 +151,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			strategy:                requiredDuringSchedulingIgnoredDuringExecutionStrategy,
 			pods:                    addPodsToNode(nodeWithoutLabels),
 			nodes:                   []*v1.Node{nodeWithoutLabels, nodeWithLabels},
-			npe:                     nodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
+			npe:                     NodePodEvictedCount{nodeWithoutLabels: 0, nodeWithLabels: 0},
 			maxPodsToEvict:          1,
 		},
 		{
@@ -160,7 +160,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			strategy:                requiredDuringSchedulingIgnoredDuringExecutionStrategy,
 			pods:                    addPodsToNode(nodeWithoutLabels),
 			nodes:                   []*v1.Node{nodeWithoutLabels, unschedulableNodeWithLabels},
-			npe:                     nodePodEvictedCount{nodeWithoutLabels: 0, unschedulableNodeWithLabels: 0},
+			npe:                     NodePodEvictedCount{nodeWithoutLabels: 0, unschedulableNodeWithLabels: 0},
 			maxPodsToEvict:          0,
 		},
 	}

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -31,7 +31,7 @@ import (
 )
 
 // RemovePodsViolatingInterPodAntiAffinity with elimination strategy
-func RemovePodsViolatingInterPodAntiAffinity(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, policyGroupVersion string, nodes []*v1.Node, nodePodCount nodePodEvictedCount) {
+func RemovePodsViolatingInterPodAntiAffinity(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, policyGroupVersion string, nodes []*v1.Node, nodePodCount NodePodEvictedCount) {
 	if !strategy.Enabled {
 		return
 	}
@@ -39,7 +39,7 @@ func RemovePodsViolatingInterPodAntiAffinity(ds *options.DeschedulerServer, stra
 }
 
 // removePodsWithAffinityRules evicts pods on the node which are having a pod affinity rules.
-func removePodsWithAffinityRules(client clientset.Interface, policyGroupVersion string, nodes []*v1.Node, dryRun bool, nodePodCount nodePodEvictedCount, maxPodsToEvict int, evictLocalStoragePods bool) int {
+func removePodsWithAffinityRules(client clientset.Interface, policyGroupVersion string, nodes []*v1.Node, dryRun bool, nodePodCount NodePodEvictedCount, maxPodsToEvict int, evictLocalStoragePods bool) int {
 	podsEvicted := 0
 	for _, node := range nodes {
 		glog.V(1).Infof("Processing node: %#v\n", node.Name)

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -52,7 +52,7 @@ func TestPodAntiAffinity(t *testing.T) {
 	fakeClient.Fake.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
 		return true, node, nil
 	})
-	npe := nodePodEvictedCount{}
+	npe := NodePodEvictedCount{}
 	npe[node] = 0
 	expectedEvictedPodCount := 3
 	podsEvicted := removePodsWithAffinityRules(fakeClient, "v1", []*v1.Node{node}, false, npe, 0, false)

--- a/pkg/descheduler/strategies/util.go
+++ b/pkg/descheduler/strategies/util.go
@@ -23,12 +23,13 @@ import (
 // This file contains the datastructures, types & functions needed by all the strategies so that we don't have
 // to compute them again in each strategy.
 
-// nodePodEvictedCount keeps count of pods evicted on node. This is used in conjunction with strategies to
-type nodePodEvictedCount map[*v1.Node]int
+// NodePodEvictedCount keeps count of pods evicted on node. This is used in conjunction with strategies to
+// This type is made public for e2e testing purpose
+type NodePodEvictedCount map[*v1.Node]int
 
 // InitializeNodePodCount initializes the nodePodCount.
-func InitializeNodePodCount(nodeList []*v1.Node) nodePodEvictedCount {
-	var nodePodCount = make(nodePodEvictedCount)
+func InitializeNodePodCount(nodeList []*v1.Node) NodePodEvictedCount {
+	var nodePodCount = make(NodePodEvictedCount)
 	for _, node := range nodeList {
 		// Initialize podsEvicted till now with 0.
 		nodePodCount[node] = 0


### PR DESCRIPTION
Adding e2e test for descheduler strategy based on Pod Anti-Affinity rule. The RC is created with pod anti-affinity. After pods started to run on nodes, we label a pod that matches the anti-affinity label and then invoke evicting strategy. 

Pods will be evicted by checking if any pods within the node has a label that matches exactly the label from pod anti-affinity. By labeling one pod inside the node, all other pods will be evicted leaving the pod with the label change inside the node.

The NodePodEvictedCount is changed to a public type so that we can both pass the strategy functions

/cc @ravisantoshgudimetla
