### PR TITLE
Respect Node taints with tolerations (if exist)

### DIFF
--- a/pkg/utils/predicates.go
+++ b/pkg/utils/predicates.go
@@ -19,7 +19,7 @@ package utils
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog"
@@ -125,4 +125,36 @@ func NodeSelectorRequirementsAsSelector(nsm []v1.NodeSelectorRequirement) (label
 		selector = selector.Add(*r)
 	}
 	return selector, nil
+}
+
+// TolerationsTolerateTaint checks if taint is tolerated by any of the tolerations.
+func TolerationsTolerateTaint(tolerations []v1.Toleration, taint *v1.Taint) bool {
+	for i := range tolerations {
+		if tolerations[i].ToleratesTaint(taint) {
+			return true
+		}
+	}
+	return false
+}
+
+type taintsFilterFunc func(*v1.Taint) bool
+
+// TolerationsTolerateTaintsWithFilter checks if given tolerations tolerates
+// all the taints that apply to the filter in given taint list.
+func TolerationsTolerateTaintsWithFilter(tolerations []v1.Toleration, taints []v1.Taint, applyFilter taintsFilterFunc) bool {
+	if len(taints) == 0 {
+		return true
+	}
+
+	for i := range taints {
+		if applyFilter != nil && !applyFilter(&taints[i]) {
+			continue
+		}
+
+		if !TolerationsTolerateTaint(tolerations, &taints[i]) {
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
If a node has a taint and is under-utilised, the descheduler will evict pods based on qos, priority etc but doesn't check if these "suitable" pods tolerate this taint, thus evicting and goes into an infinite loop of "reshuffling". This PR adds this check.

If multiple Nodes are under-utilised and both have taints, all the descheduler cares about if pods can tolerate taints of one of the nodes as then the default scheduler will schedule it onto one of the nodes.