### PR TITLE
Evict annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,9 @@ never evicted because these pods won't be recreated.
 * Pods associated with DaemonSets are never evicted.
 * Pods with local storage are never evicted.
 * Best efforts pods are evicted before Burstable and Guaranteed pods.
+* All types of pods with annotation descheduler.alpha.kubernetes.io/evict are evicted. This 
+annotation is used to override checks which prevent eviction and user can select which pod is evicted. 
+User should know how and if the pod will be recreated.
 
 ### Pod disruption Budget (PDB)
 Pods subject to Pod Disruption Budget (PDB) are not evicted if descheduling violates its pod

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -17,13 +17,17 @@ limitations under the License.
 package pod
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/kubelet/types"
+)
+
+const (
+	evictPodAnnotationKey = "descheduler.alpha.kubernetes.io/evict"
 )
 
 // checkLatencySensitiveResourcesForAContainer checks if there are any latency sensitive resources like GPUs.
@@ -54,7 +58,7 @@ func IsLatencySensitivePod(pod *v1.Pod) bool {
 // IsEvictable checks if a pod is evictable or not.
 func IsEvictable(pod *v1.Pod, evictLocalStoragePods bool) bool {
 	ownerRefList := OwnerRef(pod)
-	if IsMirrorPod(pod) || (!evictLocalStoragePods && IsPodWithLocalStorage(pod)) || len(ownerRefList) == 0 || IsDaemonsetPod(ownerRefList) || IsCriticalPod(pod) {
+	if !HaveEvictAnnotation(pod) && (IsMirrorPod(pod) || (!evictLocalStoragePods && IsPodWithLocalStorage(pod)) || len(ownerRefList) == 0 || IsDaemonsetPod(ownerRefList) || IsCriticalPod(pod)) {
 		return false
 	}
 	return true
@@ -124,6 +128,12 @@ func IsDaemonsetPod(ownerRefList []metav1.OwnerReference) bool {
 // IsMirrorPod checks whether the pod is a mirror pod.
 func IsMirrorPod(pod *v1.Pod) bool {
 	_, found := pod.ObjectMeta.Annotations[types.ConfigMirrorAnnotationKey]
+	return found
+}
+
+// HaveEvictAnnotation checks if the pod have evict annotation
+func HaveEvictAnnotation(pod *v1.Pod) bool {
+	_, found := pod.ObjectMeta.Annotations[evictPodAnnotationKey]
 	return found
 }
 


### PR DESCRIPTION
This PR adds new functionality, which enables special pod annotation. 
User can control which pods can be evicted by setting annotation descheduler.alpha.kubernetes.io/evict. With this annotation user can override checks, which prevents descheduler to evict pods (user should know what he is doing).

This PR is POC for this proposal: https://github.com/kubernetes-sigs/descheduler/issues/185

/cc @MarSik, @fromanirh, @aveshagarwal, @k82cn, @ravisantoshgudimetla