### PR TITLE
Fix typos in kubernetes example

### DIFF
--- a/kubernetes/job.yaml
+++ b/kubernetes/job.yaml
@@ -12,7 +12,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
-        containers:
+      containers:
         - name: descheduler
           image: descheduler:latest
           volumeMounts:

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -24,7 +24,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: descehduler-cluster-role-binding
+  name: descheduler-cluster-role-binding
   namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fix small typo in cluster binding role and an extra space in job.yaml