### PR TITLE
Normalize blank import

### DIFF
--- a/pkg/descheduler/client/client.go
+++ b/pkg/descheduler/client/client.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	clientset "k8s.io/client-go/kubernetes"
+	// Ensure to load all auth plugins.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"


### PR DESCRIPTION
* a blank import should be only in a main or test package, or have a comment justifying it

* add comment for blank import of clientauth in client.go