### PR TITLE
Update examples to support v1.16.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,19 +133,18 @@ spec:
   template:
     metadata:
       name: descheduler-pod
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
-        containers:
+      priorityClassName: system-cluster-critical
+      containers:
         - name: descheduler
           image: descheduler
           volumeMounts:
-          - mountPath: /policy-dir
-            name: policy-volume
-          command: ["/bin/descheduler",  "--policy-config-file", "/policy-dir/policy.yaml"]
-        restartPolicy: "Never"
-        serviceAccountName: descheduler-sa
-        volumes:
+            - mountPath: /policy-dir
+              name: policy-volume
+          command: ["/bin/descheduler",  "--policy-config-file", "/policy-dir/policy.yaml", "-v", "1"]
+      restartPolicy: "Never"
+      serviceAccountName: descheduler-sa
+      volumes:
         - name: policy-volume
           configMap:
             name: descheduler-policy-configmap

--- a/examples/descheduler-job.yaml
+++ b/examples/descheduler-job.yaml
@@ -10,9 +10,8 @@ spec:
   template:
     metadata:
       name: descheduler-pod
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
     spec:
+      priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
           image: docker.io/aveshagarwal/descheduler:0.9.0


### PR DESCRIPTION
Support for using the `scheduler.alpha.kubernetes.io/critical-pod` annotation was
deprectated in 1.13 and finally removed in 1.16

Also alignes the format of the yaml-blob for descheduler-job.yaml in readme.md to the one in examples/descheduler-job.yaml 

I'm not sure if there was made consiuous decision made around the `image:` property here; is there a reason they differed? I kept that difference for the time being atleast. 