### PR TITLE
Automate Container Image Builds Using GCB

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+
+# this must be specified in seconds. If omitted, defaults to 600s (10 mins)
+timeout: 1200s
+# this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
+# or any new substitutions added in the future.
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20190906-745fed4'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - push
+substitutions:
+  # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
+  # can be used as a substitution
+  _GIT_TAG: '12345'
+  # _PULL_BASE_REF will contain the ref that was pushed to to trigger this build -
+  # a branch like 'master' or 'release-0.2', or a tag like 'v0.2'.
+  _PULL_BASE_REF: 'master'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,21 @@
+# Release process
+
+## Semi-automatic
+
+1. Make sure your repo is clean by git's standards
+2. Tag the repository and push the tag `VERSION=v0.10.0 git tag -m $VERSION $VERSION; git push origin $VERSION`
+3. Publish a draft release using the tag you just created
+4. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter)
+5. Publish release
+6. Email `kubernetes-sig-scheduling@googlegroups.com` to announce the release
+
+## Manual
+
+1. Make sure your repo is clean by git's standards
+2. Tag the repository and push the tag `VERSION=v0.10.0 git tag -m $VERSION $VERSION; git push origin $VERSION`
+3. Checkout the tag you just created and make sure your repo is clean by git's standards `git checkout $VERSION`
+4. Build and push the container image to the staging registry `VERSION=$VERSION make push`
+5. Publish a draft release using the tag you just created
+6. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter)
+7. Publish release
+8. Email `kubernetes-sig-scheduling@googlegroups.com` to announce the release


### PR DESCRIPTION
Adds a GCB(Google Cloud Build) configuraiton file that automates the
building and pushing of descheduler container images to the official
Google Container Registry for k8s.

Reference documentation:
https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md