### PR TITLE
Wire --descheduling-interval to run descheduler on a loop

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -48,7 +48,7 @@ func NewDeschedulerServer() *DeschedulerServer {
 
 // AddFlags adds flags for a specific SchedulerServer to the specified FlagSet
 func (rs *DeschedulerServer) AddFlags(fs *pflag.FlagSet) {
-	fs.DurationVar(&rs.DeschedulingInterval, "descheduling-interval", rs.DeschedulingInterval, "time interval between two consecutive descheduler executions")
+	fs.DurationVar(&rs.DeschedulingInterval, "descheduling-interval", rs.DeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
 	fs.StringVar(&rs.KubeconfigFile, "kubeconfig", rs.KubeconfigFile, "File with  kube configuration.")
 	fs.StringVar(&rs.PolicyConfigFile, "policy-config-file", rs.PolicyConfigFile, "File with descheduler policy configuration.")
 	fs.BoolVar(&rs.DryRun, "dry-run", rs.DryRun, "execute descheduler in dry run mode.")


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/descheduler/issues/220

This wires the `--descheduling-interval` flag to actually run the descheduler on a loop in the interval specified. If the value is unset (which defaults to `0`) the descheduler only runs once, maintaining consistency with the current expectation. 

One benefit to this is that it removes the need to use a CronJob for a continuously running controller.