### PR TITLE
Update to Go 1.13.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13.5
+FROM golang:1.13.6
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .


### PR DESCRIPTION
The kubernetes project updated to Go 1.13.6, so it's time to update the
descheduler too.

https://github.com/kubernetes/kubernetes/pull/87106