### PR TITLE
Typo in Duplicates strategy max-pods-to-evict check

### DIFF
--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -53,7 +53,7 @@ func deleteDuplicatePods(client clientset.Interface, policyGroupVersion string, 
 				klog.V(1).Infof("%#v", creator)
 				// i = 0 does not evict the first pod
 				for i := 1; i < len(pods); i++ {
-					if maxPodsToEvict > 0 && nodepodCount[node]+1 > maxPodsToEvict {
+					if nodepodCount[node]+1 > maxPodsToEvict {
 						break
 					}
 					success, err := evictions.EvictPod(client, pods[i], policyGroupVersion, dryRun)


### PR DESCRIPTION
The `Duplicates` strategy previously had a typo in this check, which would run the strategy and evict pods if `maxPodsToEvict` was 0.

The previous check:
```
if maxPodsToEvict > 0 && nodepodCount[node]+1 > maxPodsToEvict
```
evaluates to `false && true` (false) if `maxPodsToEvict` is 0. The only thing needed for this check is to see if nodepodCount+1>maxpodstoevict