### PR TITLE
Add notes section to release documentation

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,3 +19,21 @@
 6. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter)
 7. Publish release
 8. Email `kubernetes-sig-scheduling@googlegroups.com` to announce the release
+
+## Notes
+See [post-descheduler-push-images dashboard](https://testgrid.k8s.io/sig-scheduling#post-descheduler-push-images) for staging registry image build job status.
+
+List images in staging registry.
+```
+gcloud container images list --repository gcr.io/k8s-staging-descheduler
+```
+
+List descheduler image tags in the staging registry.
+```
+gcloud container images list-tags gcr.io/k8s-staging-descheduler/descheduler
+```
+
+Pull image from the staging registry.
+```
+docker pull gcr.io/k8s-staging-descheduler/descheduler:v20200206-0.9.0-94-ge2a23f284
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,6 +33,11 @@ List descheduler image tags in the staging registry.
 gcloud container images list-tags gcr.io/k8s-staging-descheduler/descheduler
 ```
 
+Get SHA256 hash for a specific image in the staging registry.
+```
+gcloud container images describe gcr.io/k8s-staging-descheduler/descheduler:v20200206-0.9.0-94-ge2a23f284
+```
+
 Pull image from the staging registry.
 ```
 docker pull gcr.io/k8s-staging-descheduler/descheduler:v20200206-0.9.0-94-ge2a23f284


### PR DESCRIPTION
Add a link to the test grid dashboard for automated container image builds,
and documents useful gcloud commands for woking with the staging registry.

This documentation is useful for project maintainers that are creating
releases and publishing container images. The chance of remembering
these commands and links is slim to none. Therefore documenting this
information will be very useful.