### PR TITLE
Critical pod annotation scheduler.alpha.kubernetes.io/critical-pod has been drop, no need to set it anymore in the tests

### DIFF
--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package pod
 
 import (
-	"sigs.k8s.io/descheduler/pkg/utils"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/descheduler/pkg/utils"
 	"sigs.k8s.io/descheduler/test"
 )
 
@@ -150,15 +150,19 @@ func TestIsEvictable(t *testing.T) {
 		}, {
 			pod: test.BuildTestPod("p12", 400, 0, n1.Name),
 			runBefore: func(pod *v1.Pod) {
-				pod.Annotations = test.GetCriticalPodAnnotation()
+				priority := utils.SystemCriticalPriority
+				pod.Spec.Priority = &priority
 			},
 			evictLocalStoragePods: false,
 			result:                false,
 		}, {
 			pod: test.BuildTestPod("p13", 400, 0, n1.Name),
 			runBefore: func(pod *v1.Pod) {
-				pod.Annotations = test.GetCriticalPodAnnotation()
-				pod.Annotations["descheduler.alpha.kubernetes.io/evict"] = "true"
+				priority := utils.SystemCriticalPriority
+				pod.Spec.Priority = &priority
+				pod.Annotations = map[string]string{
+					"descheduler.alpha.kubernetes.io/evict": "true",
+				}
 			},
 			evictLocalStoragePods: false,
 			result:                true,
@@ -208,7 +212,8 @@ func TestPodTypes(t *testing.T) {
 	p4.Annotations = test.GetMirrorPodAnnotation()
 	// A Critical Pod.
 	p5.Namespace = "kube-system"
-	p5.Annotations = test.GetCriticalPodAnnotation()
+	priority := utils.SystemCriticalPriority
+	p5.Spec.Priority = &priority
 	systemCriticalPriority := utils.SystemCriticalPriority
 	p5.Spec.Priority = &systemCriticalPriority
 	if !IsMirrorPod(p4) {

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -85,7 +85,8 @@ func TestFindDuplicatePods(t *testing.T) {
 	p6.Annotations = test.GetMirrorPodAnnotation()
 
 	// A Critical Pod.
-	p7.Annotations = test.GetCriticalPodAnnotation()
+	priority := utils.SystemCriticalPriority
+	p7.Spec.Priority = &priority
 
 	testCases := []struct {
 		description             string

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -21,12 +21,13 @@ import (
 	"strings"
 	"testing"
 
+	"reflect"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	"reflect"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/utils"
 	"sigs.k8s.io/descheduler/test"
@@ -81,7 +82,8 @@ func TestLowNodeUtilizationWithoutPriority(t *testing.T) {
 	p7.Annotations = test.GetMirrorPodAnnotation()
 	// A Critical Pod.
 	p8.Namespace = "kube-system"
-	p8.Annotations = test.GetCriticalPodAnnotation()
+	priority := utils.SystemCriticalPriority
+	p8.Spec.Priority = &priority
 	p9 := test.BuildTestPod("p9", 400, 0, n1.Name)
 	p9.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
 	fakeClient := &fake.Clientset{}
@@ -186,7 +188,8 @@ func TestLowNodeUtilizationWithPriorities(t *testing.T) {
 	p7.Annotations = test.GetMirrorPodAnnotation()
 	// A Critical Pod.
 	p8.Namespace = "kube-system"
-	p8.Annotations = test.GetCriticalPodAnnotation()
+	priority := utils.SystemCriticalPriority
+	p8.Spec.Priority = &priority
 	p9 := test.BuildTestPod("p9", 400, 0, n1.Name)
 	p9.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
 	fakeClient := &fake.Clientset{}

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -70,7 +70,8 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 	// The following 4 pods won't get evicted.
 	// A Critical Pod.
 	p7.Namespace = "kube-system"
-	p7.Annotations = test.GetCriticalPodAnnotation()
+	priority := utils.SystemCriticalPriority
+	p7.Spec.Priority = &priority
 
 	// A daemonset.
 	p8.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList()

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -84,14 +84,6 @@ func GetDaemonSetOwnerRefList() []metav1.OwnerReference {
 	return ownerRefList
 }
 
-// GetCriticalPodAnnotation returns the annotation needed for critical pod.
-func GetCriticalPodAnnotation() map[string]string {
-	return map[string]string{
-		"kubernetes.io/created-by":                   "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"Pod\"}}",
-		"scheduler.alpha.kubernetes.io/critical-pod": "",
-	}
-}
-
 // BuildTestNode creates a node with specified capacity.
 func BuildTestNode(name string, millicpu int64, mem int64, pods int64) *v1.Node {
 	node := &v1.Node{


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/descheduler/issues/228