### PR TITLE
Update ClusterRole To Allow Creating Events

### DIFF
--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: kube-system
 rules:
 - apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+- apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create"]
+  verbs: ["create", "update"]
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "watch", "list"]


### PR DESCRIPTION
The descheduler creates a k8s event for each pod that it evicts. When
the code to create events was added the RBAC ClusterRole was not updated
to allow creating events. Users would see the below error in the
descheduler log when it tried to create an event.

"system:serviceaccount:kube-system:descheduler-sa" cannot create resource
"events" in API group "" in the namespace "xxxx-production"' (will not retry!)'

This change fixes this error by updating the ClusterRole to allow
creation of k8s events.

Fixes #229 