### PR TITLE
Fix GCR Image Location In Job and CronJob YAML

### DIFF
--- a/kubernetes/cronjob.yaml
+++ b/kubernetes/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
-            image: us.gcr.io/k8s-artifacts-prod/descheduler:v0.10.0
+            image: us.gcr.io/k8s-artifacts-prod/descheduler/descheduler:v0.10.0
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume

--- a/kubernetes/job.yaml
+++ b/kubernetes/job.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
-          image: us.gcr.io/k8s-artifacts-prod/descheduler:v0.10.0
+          image: us.gcr.io/k8s-artifacts-prod/descheduler/descheduler:v0.10.0
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume


### PR DESCRIPTION
The correct location for the official descheduler container image is
us.gcr.io/k8s-artifacts-prod/descheduler/descheduler:TAG_NAME.