### PR TITLE
Update to Go 1.13.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.13.8
+FROM golang:1.13.9
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .


### PR DESCRIPTION
Kubernetes releases 1.16 through 1.19 have been updated
to Go 1.13.9, so it's time to update the descheduler too.