### PR TITLE
Fix early return from PodFitsAnyNode check

### DIFF
--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -110,12 +110,9 @@ func PodFitsAnyNode(pod *v1.Pod, nodes []*v1.Node) bool {
 		if err != nil || !ok {
 			continue
 		}
-		if ok {
-			if !IsNodeUnschedulable(node) {
-				klog.V(2).Infof("Pod %v can possibly be scheduled on %v", pod.Name, node.Name)
-				return true
-			}
-			return false
+		if !IsNodeUnschedulable(node) {
+			klog.V(2).Infof("Pod %v can possibly be scheduled on %v", pod.Name, node.Name)
+			return true
 		}
 	}
 	return false

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -253,6 +253,49 @@ func TestPodFitsAnyNode(t *testing.T) {
 			success: true,
 		},
 		{
+			description: "Pod expected to fit one of the nodes (error node first)",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      nodeLabelKey,
+												Operator: "In",
+												Values: []string{
+													nodeLabelValue,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							nodeLabelKey: "no",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							nodeLabelKey: nodeLabelValue,
+						},
+					},
+				},
+			},
+			success: true,
+		},
+		{
 			description: "Pod expected to fit none of the nodes",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{


### PR DESCRIPTION
The `PodFitsAnyNode` function returned `false` early if it hit any node with matched the selectors but was also unschedulable (before finding a suitable node).

This PR also includes vendor updates that weren't committed earlier, in order to compile.