### PR TITLE
Drop descheduler server from strategies

### DIFF
--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -23,35 +23,24 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 
-	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 )
 
-//type creator string
-type DuplicatePodsMap map[string][]*v1.Pod
-
 // RemoveDuplicatePods removes the duplicate pods on node. This strategy evicts all duplicate pods on node.
 // A pod is said to be a duplicate of other if both of them are from same creator, kind and are within the same
 // namespace. As of now, this strategy won't evict daemonsets, mirror pods, critical pods and pods with local storages.
-func RemoveDuplicatePods(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
-	if !strategy.Enabled {
-		return
-	}
-	deleteDuplicatePods(ds.Client, nodes, ds.EvictLocalStoragePods, podEvictor)
-}
-
-// deleteDuplicatePods evicts the pod from node and returns the count of evicted pods.
-func deleteDuplicatePods(
+func RemoveDuplicatePods(
 	client clientset.Interface,
+	strategy api.DeschedulerStrategy,
 	nodes []*v1.Node,
 	evictLocalStoragePods bool,
 	podEvictor *evictions.PodEvictor,
 ) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v", node.Name)
-		dpm := ListDuplicatePodsOnANode(client, node, evictLocalStoragePods)
+		dpm := listDuplicatePodsOnANode(client, node, evictLocalStoragePods)
 		for creator, pods := range dpm {
 			if len(pods) > 1 {
 				klog.V(1).Infof("%#v", creator)
@@ -66,18 +55,17 @@ func deleteDuplicatePods(
 	}
 }
 
-// ListDuplicatePodsOnANode lists duplicate pods on a given node.
-func ListDuplicatePodsOnANode(client clientset.Interface, node *v1.Node, evictLocalStoragePods bool) DuplicatePodsMap {
+//type creator string
+type duplicatePodsMap map[string][]*v1.Pod
+
+// listDuplicatePodsOnANode lists duplicate pods on a given node.
+func listDuplicatePodsOnANode(client clientset.Interface, node *v1.Node, evictLocalStoragePods bool) duplicatePodsMap {
 	pods, err := podutil.ListEvictablePodsOnNode(client, node, evictLocalStoragePods)
 	if err != nil {
 		return nil
 	}
-	return FindDuplicatePods(pods)
-}
 
-// FindDuplicatePods takes a list of pods and returns a duplicatePodsMap.
-func FindDuplicatePods(pods []*v1.Pod) DuplicatePodsMap {
-	dpm := DuplicatePodsMap{}
+	dpm := duplicatePodsMap{}
 	// Ignoring the error here as in the ListDuplicatePodsOnNode function we call ListEvictablePodsOnNode which checks for error.
 	for _, pod := range pods {
 		ownerRefList := podutil.OwnerRef(pod)

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	"sigs.k8s.io/descheduler/pkg/utils"
 	"sigs.k8s.io/descheduler/test"
@@ -143,7 +144,7 @@ func TestFindDuplicatePods(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		deleteDuplicatePods(fakeClient, []*v1.Node{node}, false, podEvictor)
+		RemoveDuplicatePods(fakeClient, api.DeschedulerStrategy{}, []*v1.Node{node}, false, podEvictor)
 		podsEvicted := podEvictor.TotalEvicted()
 		if podsEvicted != testCase.expectedEvictedPodCount {
 			t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -33,9 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/api"
-	"sigs.k8s.io/descheduler/pkg/apis/componentconfig"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	"sigs.k8s.io/descheduler/pkg/utils"
 	"sigs.k8s.io/descheduler/test"
@@ -623,22 +621,15 @@ func TestWithTaints(t *testing.T) {
 				return true, nil, nil
 			})
 
-			ds := &options.DeschedulerServer{
-				Client: &fake.Clientset{Fake: *fakePtr},
-				DeschedulerConfiguration: componentconfig.DeschedulerConfiguration{
-					EvictLocalStoragePods: false,
-				},
-			}
-
 			podEvictor := evictions.NewPodEvictor(
 				&fake.Clientset{Fake: *fakePtr},
 				"policy/v1",
-				ds.DryRun,
+				false,
 				item.evictionsExpected,
 				item.nodes,
 			)
 
-			LowNodeUtilization(ds, strategy, item.nodes, podEvictor)
+			LowNodeUtilization(&fake.Clientset{Fake: *fakePtr}, strategy, item.nodes, false, podEvictor)
 
 			if item.evictionsExpected != evictionCounter {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, evictionCounter)

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -17,7 +17,6 @@ limitations under the License.
 package strategies
 
 import (
-	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
@@ -28,16 +27,8 @@ import (
 	"k8s.io/klog"
 )
 
-// RemovePodsViolatingNodeTaints with elimination strategy
-func RemovePodsViolatingNodeTaints(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
-	if !strategy.Enabled {
-		return
-	}
-	deletePodsViolatingNodeTaints(ds.Client, nodes, ds.EvictLocalStoragePods, podEvictor)
-}
-
-// deletePodsViolatingNodeTaints evicts pods on the node which violate NoSchedule Taints on nodes
-func deletePodsViolatingNodeTaints(client clientset.Interface, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+// RemovePodsViolatingNodeTaints evicts pods on the node which violate NoSchedule Taints on nodes
+func RemovePodsViolatingNodeTaints(client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v\n", node.Name)
 		pods, err := podutil.ListEvictablePodsOnNode(client, node, evictLocalStoragePods)

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	"sigs.k8s.io/descheduler/pkg/utils"
 	"sigs.k8s.io/descheduler/test"
@@ -170,7 +171,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			tc.nodes,
 		)
 
-		deletePodsViolatingNodeTaints(fakeClient, tc.nodes, tc.evictLocalStoragePods, podEvictor)
+		RemovePodsViolatingNodeTaints(fakeClient, api.DeschedulerStrategy{}, tc.nodes, tc.evictLocalStoragePods, podEvictor)
 		actualEvictedPodCount := podEvictor.TotalEvicted()
 		if actualEvictedPodCount != tc.expectedEvictedPodCount {
 			t.Errorf("Test %#v failed, Unexpected no of pods evicted: pods evicted: %d, expected: %d", tc.description, actualEvictedPodCount, tc.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -17,7 +17,6 @@ limitations under the License.
 package strategies
 
 import (
-	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
@@ -29,16 +28,8 @@ import (
 	"k8s.io/klog"
 )
 
-// RemovePodsViolatingInterPodAntiAffinity with elimination strategy
-func RemovePodsViolatingInterPodAntiAffinity(ds *options.DeschedulerServer, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
-	if !strategy.Enabled {
-		return
-	}
-	removePodsWithAffinityRules(ds.Client, nodes, ds.EvictLocalStoragePods, podEvictor)
-}
-
-// removePodsWithAffinityRules evicts pods on the node which are having a pod affinity rules.
-func removePodsWithAffinityRules(client clientset.Interface, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+// RemovePodsViolatingInterPodAntiAffinity evicts pods on the node which are having a pod affinity rules.
+func RemovePodsViolatingInterPodAntiAffinity(client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v\n", node.Name)
 		pods, err := podutil.ListEvictablePodsOnNode(client, node, evictLocalStoragePods)

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	"sigs.k8s.io/descheduler/test"
 )
@@ -83,7 +84,7 @@ func TestPodAntiAffinity(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		removePodsWithAffinityRules(fakeClient, []*v1.Node{node}, false, podEvictor)
+		RemovePodsViolatingInterPodAntiAffinity(fakeClient, api.DeschedulerStrategy{}, []*v1.Node{node}, false, podEvictor)
 		podsEvicted := podEvictor.TotalEvicted()
 		if podsEvicted != test.expectedEvictedPodCount {
 			t.Errorf("Unexpected no of pods evicted: pods evicted: %d, expected: %d", podsEvicted, test.expectedEvictedPodCount)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -125,17 +125,15 @@ func startEndToEndForLowNodeUtilization(clientset clientset.Interface, nodeInfor
 		},
 	}
 
-	ds := &options.DeschedulerServer{Client: clientset}
-
 	podEvictor := evictions.NewPodEvictor(
-		ds.Client,
+		clientset,
 		evictionPolicyGroupVersion,
-		ds.DryRun,
-		ds.MaxNoOfPodsToEvictPerNode,
+		false,
+		0,
 		nodes,
 	)
 
-	strategies.LowNodeUtilization(ds, lowNodeUtilizationStrategy, nodes, podEvictor)
+	strategies.LowNodeUtilization(clientset, lowNodeUtilizationStrategy, nodes, false, podEvictor)
 	time.Sleep(10 * time.Second)
 }
 


### PR DESCRIPTION
Removing `sigs.k8s.io/descheduler/cmd/descheduler/app/options` dependency from all strategies so they can be run independently of `options.DeschedulerServer`.

Building on top of https://github.com/kubernetes-sigs/descheduler/pull/266