### PR TITLE
Tolerations tains code cleanup

### DIFF
--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -102,18 +102,11 @@ func allTaintsTolerated(taints []v1.Taint, tolerations []v1.Toleration) bool {
 	if len(taints) == 0 {
 		return true
 	}
-	if len(tolerations) == 0 && len(taints) > 0 {
+	if len(tolerations) == 0 {
 		return false
 	}
 	for i := range taints {
-		tolerated := false
-		for j := range tolerations {
-			if tolerations[j].ToleratesTaint(&taints[i]) {
-				tolerated = true
-				break
-			}
-		}
-		if !tolerated {
+		if !utils.TolerationsTolerateTaint(tolerations, &taints[i]) {
 			return false
 		}
 	}

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -97,24 +97,6 @@ func getNoScheduleTaints(taints []v1.Taint) []v1.Taint {
 	return result
 }
 
-//toleratesTaint returns true if a toleration tolerates a taint, or false otherwise
-func toleratesTaint(toleration *v1.Toleration, taint *v1.Taint) bool {
-
-	if (len(toleration.Key) > 0 && toleration.Key != taint.Key) ||
-		(len(toleration.Effect) > 0 && toleration.Effect != taint.Effect) {
-		return false
-	}
-	switch toleration.Operator {
-	// empty operator means Equal
-	case "", TolerationOpEqual:
-		return toleration.Value == taint.Value
-	case TolerationOpExists:
-		return true
-	default:
-		return false
-	}
-}
-
 // allTaintsTolerated returns true if all are tolerated, or false otherwise.
 func allTaintsTolerated(taints []v1.Taint, tolerations []v1.Toleration) bool {
 	if len(taints) == 0 {
@@ -126,7 +108,7 @@ func allTaintsTolerated(taints []v1.Taint, tolerations []v1.Toleration) bool {
 	for i := range taints {
 		tolerated := false
 		for j := range tolerations {
-			if toleratesTaint(&tolerations[j], &taints[i]) {
+			if tolerations[j].ToleratesTaint(&taints[i]) {
 				tolerated = true
 				break
 			}

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -188,7 +188,7 @@ func TestToleratesTaint(t *testing.T) {
 			description: "toleration and taint have the same key and effect, and operator is Exists, and taint has no value, expect tolerated",
 			toleration: v1.Toleration{
 				Key:      "foo",
-				Operator: TolerationOpExists,
+				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,
 			},
 			taint: v1.Taint{
@@ -201,7 +201,7 @@ func TestToleratesTaint(t *testing.T) {
 			description: "toleration and taint have the same key and effect, and operator is Exists, and taint has some value, expect tolerated",
 			toleration: v1.Toleration{
 				Key:      "foo",
-				Operator: TolerationOpExists,
+				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,
 			},
 			taint: v1.Taint{
@@ -215,7 +215,7 @@ func TestToleratesTaint(t *testing.T) {
 			description: "toleration and taint have the same effect, toleration has empty key and operator is Exists, means match all taints, expect tolerated",
 			toleration: v1.Toleration{
 				Key:      "",
-				Operator: TolerationOpExists,
+				Operator: v1.TolerationOpExists,
 				Effect:   v1.TaintEffectNoSchedule,
 			},
 			taint: v1.Taint{
@@ -229,7 +229,7 @@ func TestToleratesTaint(t *testing.T) {
 			description: "toleration and taint have the same key, effect and value, and operator is Equal, expect tolerated",
 			toleration: v1.Toleration{
 				Key:      "foo",
-				Operator: TolerationOpEqual,
+				Operator: v1.TolerationOpEqual,
 				Value:    "bar",
 				Effect:   v1.TaintEffectNoSchedule,
 			},
@@ -244,7 +244,7 @@ func TestToleratesTaint(t *testing.T) {
 			description: "toleration and taint have the same key and effect, but different values, and operator is Equal, expect not tolerated",
 			toleration: v1.Toleration{
 				Key:      "foo",
-				Operator: TolerationOpEqual,
+				Operator: v1.TolerationOpEqual,
 				Value:    "value1",
 				Effect:   v1.TaintEffectNoSchedule,
 			},
@@ -259,7 +259,7 @@ func TestToleratesTaint(t *testing.T) {
 			description: "toleration and taint have the same key and value, but different effects, and operator is Equal, expect not tolerated",
 			toleration: v1.Toleration{
 				Key:      "foo",
-				Operator: TolerationOpEqual,
+				Operator: v1.TolerationOpEqual,
 				Value:    "bar",
 				Effect:   v1.TaintEffectNoSchedule,
 			},

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -277,22 +277,3 @@ func TestToleratesTaint(t *testing.T) {
 		}
 	}
 }
-
-func TestFilterNoExecuteTaints(t *testing.T) {
-	taints := []v1.Taint{
-		{
-			Key:    "one",
-			Value:  "one",
-			Effect: v1.TaintEffectNoExecute,
-		},
-		{
-			Key:    "two",
-			Value:  "two",
-			Effect: v1.TaintEffectNoSchedule,
-		},
-	}
-	taints = getNoScheduleTaints(taints)
-	if len(taints) != 1 || taints[0].Key != "two" {
-		t.Errorf("Filtering doesn't work. Got %v", taints)
-	}
-}

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -272,7 +272,7 @@ func TestToleratesTaint(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		if tolerated := toleratesTaint(&tc.toleration, &tc.taint); tc.expectTolerated != tolerated {
+		if tolerated := tc.toleration.ToleratesTaint(&tc.taint); tc.expectTolerated != tolerated {
 			t.Errorf("[%s] expect %v, got %v: toleration %+v, taint %s", tc.description, tc.expectTolerated, tolerated, tc.toleration, tc.taint.ToString())
 		}
 	}


### PR DESCRIPTION
Re opening https://github.com/kubernetes-sigs/descheduler/pull/265

Removing duplicated code. Broken down the changes into smaller steps for easier review.

@damemi @seanmalloy PTAL