### PR TITLE
Switch PodsHavingTooManyRestarts params to pointer

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -48,7 +48,7 @@ type DeschedulerStrategy struct {
 type StrategyParameters struct {
 	NodeResourceUtilizationThresholds *NodeResourceUtilizationThresholds
 	NodeAffinityType                  []string
-	PodsHavingTooManyRestarts         PodsHavingTooManyRestarts
+	PodsHavingTooManyRestarts         *PodsHavingTooManyRestarts
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -48,7 +48,7 @@ type DeschedulerStrategy struct {
 type StrategyParameters struct {
 	NodeResourceUtilizationThresholds *NodeResourceUtilizationThresholds `json:"nodeResourceUtilizationThresholds,omitempty"`
 	NodeAffinityType                  []string                           `json:"nodeAffinityType,omitempty"`
-	PodsHavingTooManyRestarts         PodsHavingTooManyRestarts          `json:"podsHavingTooManyRestarts,omitempty"`
+	PodsHavingTooManyRestarts         *PodsHavingTooManyRestarts         `json:"podsHavingTooManyRestarts,omitempty"`
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/v1alpha1/zz_generated.conversion.go
@@ -185,9 +185,7 @@ func Convert_api_PodsHavingTooManyRestarts_To_v1alpha1_PodsHavingTooManyRestarts
 func autoConvert_v1alpha1_StrategyParameters_To_api_StrategyParameters(in *StrategyParameters, out *api.StrategyParameters, s conversion.Scope) error {
 	out.NodeResourceUtilizationThresholds = (*api.NodeResourceUtilizationThresholds)(unsafe.Pointer(in.NodeResourceUtilizationThresholds))
 	out.NodeAffinityType = *(*[]string)(unsafe.Pointer(&in.NodeAffinityType))
-	if err := Convert_v1alpha1_PodsHavingTooManyRestarts_To_api_PodsHavingTooManyRestarts(&in.PodsHavingTooManyRestarts, &out.PodsHavingTooManyRestarts, s); err != nil {
-		return err
-	}
+	out.PodsHavingTooManyRestarts = (*api.PodsHavingTooManyRestarts)(unsafe.Pointer(in.PodsHavingTooManyRestarts))
 	return nil
 }
 
@@ -199,9 +197,7 @@ func Convert_v1alpha1_StrategyParameters_To_api_StrategyParameters(in *StrategyP
 func autoConvert_api_StrategyParameters_To_v1alpha1_StrategyParameters(in *api.StrategyParameters, out *StrategyParameters, s conversion.Scope) error {
 	out.NodeResourceUtilizationThresholds = (*NodeResourceUtilizationThresholds)(unsafe.Pointer(in.NodeResourceUtilizationThresholds))
 	out.NodeAffinityType = *(*[]string)(unsafe.Pointer(&in.NodeAffinityType))
-	if err := Convert_api_PodsHavingTooManyRestarts_To_v1alpha1_PodsHavingTooManyRestarts(&in.PodsHavingTooManyRestarts, &out.PodsHavingTooManyRestarts, s); err != nil {
-		return err
-	}
+	out.PodsHavingTooManyRestarts = (*PodsHavingTooManyRestarts)(unsafe.Pointer(in.PodsHavingTooManyRestarts))
 	return nil
 }
 

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -176,7 +176,11 @@ func (in *StrategyParameters) DeepCopyInto(out *StrategyParameters) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.PodsHavingTooManyRestarts = in.PodsHavingTooManyRestarts
+	if in.PodsHavingTooManyRestarts != nil {
+		in, out := &in.PodsHavingTooManyRestarts, &out.PodsHavingTooManyRestarts
+		*out = new(PodsHavingTooManyRestarts)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -176,7 +176,11 @@ func (in *StrategyParameters) DeepCopyInto(out *StrategyParameters) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.PodsHavingTooManyRestarts = in.PodsHavingTooManyRestarts
+	if in.PodsHavingTooManyRestarts != nil {
+		in, out := &in.PodsHavingTooManyRestarts, &out.PodsHavingTooManyRestarts
+		*out = new(PodsHavingTooManyRestarts)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/descheduler/strategies/toomanyrestarts.go
+++ b/pkg/descheduler/strategies/toomanyrestarts.go
@@ -30,7 +30,8 @@ import (
 // There are too many cases leading this issue: Volume mount failed, app error due to nodes' different settings.
 // As of now, this strategy won't evict daemonsets, mirror pods, critical pods and pods with local storages.
 func RemovePodsHavingTooManyRestarts(client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
-	if strategy.Params.PodsHavingTooManyRestarts.PodRestartThreshold < 1 {
+	if strategy.Params.PodsHavingTooManyRestarts == nil || strategy.Params.PodsHavingTooManyRestarts.PodRestartThreshold < 1 {
+		klog.V(1).Infof("PodsHavingTooManyRestarts thresholds not set")
 		return
 	}
 	for _, node := range nodes {

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -83,7 +83,7 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 		return api.DeschedulerStrategy{
 			Enabled: enabled,
 			Params: api.StrategyParameters{
-				PodsHavingTooManyRestarts: api.PodsHavingTooManyRestarts{
+				PodsHavingTooManyRestarts: &api.PodsHavingTooManyRestarts{
 					PodRestartThreshold:     restartThresholds,
 					IncludingInitContainers: includingInitContainers,
 				},


### PR DESCRIPTION
Similar to https://github.com/kubernetes-sigs/descheduler/pull/240

This changes the PodsHavingTooManyRestarts params to be a pointer field, in order to prevent empty fields being serialized into JSON for unrelated strategies