### PR TITLE
Add damemi to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - aveshagarwal
 - k82cn
 - ravisantoshgudimetla
+- damemi
 reviewers:
 - aveshagarwal
 - k82cn


### PR DESCRIPTION
I have been a reviewer for some time now and plan to remain active in the descheduler (and the rest of the scheduling sig). 

I am invested in this project as part of my day job and obviously a genuine interest in seeing it grow. I believe my active status in the rest of sig-scheduling also benefits this project.

I look forward to continuing to improve the descheduler as an active maintainer and assisting and encouraging others to contribute as well.

