### PR TITLE
Update Travis CI build matrix with latest k8s point releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: go
 go:
   - 1.13.x
 env:
-  - K8S_VERSION=v1.17.0
-  - K8S_VERSION=v1.16.4
-  - K8S_VERSION=v1.15.7
+  - K8S_VERSION=v1.17.5
+  - K8S_VERSION=v1.16.9
+  - K8S_VERSION=v1.15.11
 services:
   - docker
 before_script:


### PR DESCRIPTION
Cherry pick commit 4941f6a16becfa611ec31685632e4308633fc384 to the `release-1.17` branch.