### PR TITLE
Add verify-gofmt make target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ before_script:
 script:
 - mkdir -p ~/gopath/src/sigs.k8s.io/
 - mv ~/gopath/src/github.com/kubernetes-sigs/descheduler ~/gopath/src/sigs.k8s.io/.
-- hack/verify-gofmt.sh
-- hack/verify-vendor.sh
+- make verify-gofmt
+- make verify-vendor
 - make lint
 - make build
 - make test-unit

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,12 @@ push: push-container-to-gcloud
 clean:
 	rm -rf _output
 
+verify-gofmt:
+	./hack/verify-gofmt.sh
+
+verify-vendor:
+	./hack/verify-vendor.sh
+
 test-unit:
 	./test/run-unit-tests.sh
 


### PR DESCRIPTION
So CI can run 'make verify-gofmt' instead of ./hack/verify-gofmt in case the script location changes.