### PR TITLE
Add Helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release Charts
+
+on:
+  push:
+    tags:
+      - chart-*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0-rc.2
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,8 @@ IMAGE_GCLOUD:=$(REGISTRY)/descheduler:$(VERSION)
 # In the future binaries can be uploaded to
 # GCS bucket gs://k8s-staging-descheduler.
 
+HAS_HELM := $(shell which helm)
+
 all: build
 
 build:
@@ -62,7 +64,7 @@ push: push-container-to-gcloud
 clean:
 	rm -rf _output
 
-verify: verify-gofmt verify-vendor lint
+verify: verify-gofmt verify-vendor lint lint-chart
 
 verify-gofmt:
 	./hack/verify-gofmt.sh
@@ -86,3 +88,9 @@ ifndef HAS_GOLANGCI
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./_output/bin ${GOLANGCI_VERSION}
 endif
 	./_output/bin/golangci-lint run
+
+lint-chart:
+ifndef HAS_HELM
+	curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && chmod 700 ./get_helm.sh && ./get_helm.sh
+endif
+	helm lint ./charts/descheduler

--- a/charts/descheduler/.helmignore
+++ b/charts/descheduler/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+name: descheduler
+version: 1.0.0
+appVersion: 0.18.0
+description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
+keywords:
+- kubernetes
+- descheduler
+- kube-scheduler
+home: https://github.com/kubernetes-sigs/descheduler
+icon: https://kubernetes.io/images/favicon.png
+sources:
+- https://github.com/kubernetes-sigs/descheduler
+maintainers:
+- name: stevehipwell
+  email: steve.hipwell@github.com

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -1,0 +1,59 @@
+# Descheduler for Kubernetes
+
+[Descheduler](https://github.com/kubernetes-sigs/descheduler/) for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
+
+## TL;DR:
+
+```shell
+helm repo add descheduler https://kubernetes-sigs.github.io/descheduler/
+$ helm install descheduler/descheduler --name my-release
+```
+
+## Introduction
+
+This chart bootstraps a [desheduler](https://github.com/kubernetes-sigs/descheduler/) cron job on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.14+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```shell
+helm install --name my-release descheduler/descheduler
+```
+
+The command deploys _descheduler_ on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```shell
+helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the _descheduler_ chart and their default values.
+
+| Parameter                      | Description                                                                                                           | Default                                                |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `image.repository`             | Docker repository to use                                                                                              | `us.gcr.io/k8s-artifacts-prod/descheduler/descheduler` |
+| `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                                              |
+| `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                                         |
+| `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                                   |
+| `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                                   |
+| `schedule`                     | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                                        |
+| `cmdOptions`                   | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                                      |
+| `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                                      |
+| `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                              |
+| `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                                                 |
+| `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                                                 |
+| `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                                  |

--- a/charts/descheduler/templates/NOTES.txt
+++ b/charts/descheduler/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Descheduler installed as a cron job.

--- a/charts/descheduler/templates/_helpers.tpl
+++ b/charts/descheduler/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "descheduler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "descheduler.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "descheduler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "descheduler.labels" -}}
+app.kubernetes.io/name: {{ include "descheduler.name" . }}
+helm.sh/chart: {{ include "descheduler.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "descheduler.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "descheduler.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "descheduler.fullname" . }}
+  labels:
+    {{- include "descheduler.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list", "delete"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]
+{{- end -}}

--- a/charts/descheduler/templates/clusterrolebinding.yaml
+++ b/charts/descheduler/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "descheduler.fullname" . }}
+  labels:
+    {{- include "descheduler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "descheduler.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "descheduler.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/descheduler/templates/configmap.yaml
+++ b/charts/descheduler/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "descheduler.fullname" . }}
+  labels:
+    {{- include "descheduler.labels" . | nindent 4 }}
+data:
+  policy.yaml: |
+    apiVersion: "descheduler/v1alpha1"
+    kind: "DeschedulerPolicy"
+{{ toYaml .Values.deschedulerPolicy | trim | indent 4 }}

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ template "descheduler.fullname" . }}
+  labels:
+    {{- include "descheduler.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: {{ template "descheduler.fullname" . }}
+          annotations:
+            checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+            {{- if .Values.podAnnotations }}
+            {{- .Values.podAnnotations | toYaml | nindent 12 }}
+            {{- end }}
+          labels:
+            app.kubernetes.io/name: {{ include "descheduler.name" . }}
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            {{- if .Values.podLabels }}
+            {{- .Values.podLabels | toYaml | nindent 12 }}
+            {{- end }}
+        spec:
+          {{- if .Values.priorityClassName }}
+          priorityClassName: {{ .Values.priorityClassName }}
+          {{- end }}
+          serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
+          restartPolicy: "Never"
+          containers:
+            - name: {{ .Chart.Name }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - "/bin/descheduler"
+              args:
+                - "--policy-config-file"
+                - "/policy-dir/policy.yaml"
+                {{- range $key, $value := .Values.cmdOptions }}
+                - {{ printf "--%s" $key | quote }}
+                {{- if $value }}
+                - {{ $value | quote }}
+                {{- end }}
+                {{- end }}
+              volumeMounts:
+                - mountPath: /policy-dir
+                  name: policy-volume
+          volumes:
+          - name: policy-volume
+            configMap:
+              name: {{ template "descheduler.fullname" . }}

--- a/charts/descheduler/templates/serviceaccount.yaml
+++ b/charts/descheduler/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "descheduler.serviceAccountName" . }}
+  labels:
+    {{- include "descheduler.labels" . | nindent 4 }}
+{{- end -}}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -1,0 +1,59 @@
+# Default values for descheduler.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: us.gcr.io/k8s-artifacts-prod/descheduler/descheduler
+  # Overrides the image tag whose default is the chart version
+  tag: ""
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+schedule: "*/2 * * * *"
+
+cmdOptions:
+  v: 3
+  # evict-local-storage-pods:
+  # max-pods-to-evict-per-node: 10
+  # node-selector: "key1=value1,key2=value2"
+
+deschedulerPolicy:
+  strategies:
+    RemoveDuplicates:
+      enabled: true
+    RemovePodsViolatingNodeTaints:
+      enabled: true
+    RemovePodsViolatingNodeAffinity:
+      enabled: true
+      params:
+         nodeAffinityType:
+         - requiredDuringSchedulingIgnoredDuringExecution
+    RemovePodsViolatingInterPodAntiAffinity:
+      enabled: true
+    LowNodeUtilization:
+      enabled: true
+      params:
+        nodeResourceUtilizationThresholds:
+          thresholds:
+            cpu: 20
+            memory: 20
+            pods: 20
+          targetThresholds:
+            cpu: 50
+            memory: 50
+            pods: 50
+
+priorityClassName: system-cluster-critical
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:


### PR DESCRIPTION
This PR adds a native _Helm_ chart to this repository at `charts/descheduler` and uses [GitHub Actions](https://github.com/features/actions), specifically the [Helm actions](https://github.com/helm?q=action&type=&language=), to validate and release the chart (see the following rules).

- PRs with changes to `charts/**` will trigger the _lint-test_ action
- Tags with the pattern `chart-*` will trigger the _release_ action

**IMPORTANT** - For this PR to work the `helm/chart-releaser-action` [pre-requisites](https://github.com/helm/chart-releaser-action#pre-requisites) need to be completed.