### PR TITLE
Standardize node affinity strategy logs

### DIFF
--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -130,10 +130,10 @@ func PodFitsCurrentNode(pod *v1.Pod, node *v1.Node) bool {
 	}
 
 	if !ok {
-		klog.V(1).Infof("Pod %v does not fit on node %v", pod.Name, node.Name)
+		klog.V(2).Infof("Pod %v does not fit on node %v", pod.Name, node.Name)
 		return false
 	}
 
-	klog.V(3).Infof("Pod %v fits on node %v", pod.Name, node.Name)
+	klog.V(2).Infof("Pod %v fits on node %v", pod.Name, node.Name)
 	return true
 }


### PR DESCRIPTION
These helpers are called in the node affinity strategy:
https://github.com/kubernetes-sigs/descheduler/blob/d7e93058d49f36afce55ae7a3cd9ff8ff624d53e/pkg/descheduler/strategies/node_affinity.go#L47

However at their current loglevels this leads to confusing logs, because if a pod doesn't fit on the current node that message is always logged. But if it doesn't fit on any node, that may not be logged unless log level is >=2 (see https://github.com/kubernetes-sigs/descheduler/blob/d7e93058d49f36afce55ae7a3cd9ff8ff624d53e/pkg/descheduler/node/node.go#L115). This leads to the confusing implication that eviction was intended, but not possible for some other reason.

Since these are used in the same check, they should have the same log levels for their relevant messages.