### PR TITLE
Add more verbose logging to IsEvictable checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ never evicted because these pods won't be recreated.
   annotation is used to override checks which prevent eviction and users can select which pod is evicted.
   Users should know how and if the pod will be recreated.
 
+Setting `--v=4` or greater on the Descheduler will log all reasons why any pod is not evictable.
+
 ### Pod Disruption Budget (PDB)
 
 Pods subject to a Pod Disruption Budget(PDB) are not evicted if descheduling violates its PDB. The pods


### PR DESCRIPTION
This makes the `IsEvictable` check more verbose at `logLevel=4`, but breaking each check into its own conditional and logging errors for each one, finally outputting the full list if the pod does not also have the "evictable" annotation.

This gives output like this:
```
I0529 16:14:06.044444       1 pods.go:60] Pod dedicated-nodes-vkr8s in namespace test-ns is not evictable: Pod lacks an eviction annotation and fails the following checks: [pod is critical, pod does not have any ownerrefs]
```