### PR TITLE
Refactor strategy options for future extensibility

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -19,6 +19,7 @@ package descheduler
 import (
 	"context"
 	"fmt"
+	strategyopts "sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 
 	"k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -60,7 +61,7 @@ func Run(rs *options.DeschedulerServer) error {
 	return RunDeschedulerStrategies(ctx, rs, deschedulerPolicy, evictionPolicyGroupVersion, stopChannel)
 }
 
-type strategyFunction func(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts strategies.Options, podEvictor *evictions.PodEvictor)
+type strategyFunction func(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts strategyopts.Options, podEvictor *evictions.PodEvictor)
 
 func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer, deschedulerPolicy *api.DeschedulerPolicy, evictionPolicyGroupVersion string, stopChannel chan struct{}) error {
 	sharedInformerFactory := informers.NewSharedInformerFactory(rs.Client, 0)
@@ -101,7 +102,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 			nodes,
 		)
 
-		opts := strategies.Options{
+		opts := strategyopts.Options{
 			EvictLocalStoragePods: rs.EvictLocalStoragePods,
 		}
 

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"sigs.k8s.io/descheduler/pkg/utils"
 )
 
@@ -64,14 +65,14 @@ func IsEvictable(pod *v1.Pod, evictLocalStoragePods bool) bool {
 }
 
 // ListEvictablePodsOnNode returns the list of evictable pods on node.
-func ListEvictablePodsOnNode(ctx context.Context, client clientset.Interface, node *v1.Node, evictLocalStoragePods bool) ([]*v1.Pod, error) {
+func ListEvictablePodsOnNode(ctx context.Context, client clientset.Interface, node *v1.Node, opts options.Options) ([]*v1.Pod, error) {
 	pods, err := ListPodsOnANode(ctx, client, node)
 	if err != nil {
 		return []*v1.Pod{}, err
 	}
 	evictablePods := make([]*v1.Pod, 0)
 	for _, pod := range pods {
-		if !IsEvictable(pod, evictLocalStoragePods) {
+		if !IsEvictable(pod, opts.EvictLocalStoragePods) {
 			continue
 		} else {
 			evictablePods = append(evictablePods, pod)

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -42,12 +42,12 @@ func RemoveDuplicatePods(
 	client clientset.Interface,
 	strategy api.DeschedulerStrategy,
 	nodes []*v1.Node,
-	evictLocalStoragePods bool,
+	opts Options,
 	podEvictor *evictions.PodEvictor,
 ) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v", node.Name)
-		duplicatePods := listDuplicatePodsOnANode(ctx, client, node, strategy, evictLocalStoragePods)
+		duplicatePods := listDuplicatePodsOnANode(ctx, client, node, strategy, opts.EvictLocalStoragePods)
 		for _, pod := range duplicatePods {
 			if _, err := podEvictor.EvictPod(ctx, pod, node); err != nil {
 				klog.Errorf("Error evicting pod: (%#v)", err)

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -201,7 +202,7 @@ func TestFindDuplicatePods(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		opts := Options{
+		opts := options.Options{
 			EvictLocalStoragePods: false,
 		}
 

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -201,7 +201,11 @@ func TestFindDuplicatePods(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, []*v1.Node{node}, false, podEvictor)
+		opts := Options{
+			EvictLocalStoragePods: false,
+		}
+
+		RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, []*v1.Node{node}, opts, podEvictor)
 		podsEvicted := podEvictor.TotalEvicted()
 		if podsEvicted != testCase.expectedEvictedPodCount {
 			t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -19,6 +19,7 @@ package strategies
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
@@ -46,7 +47,7 @@ const (
 	MaxResourcePercentage = 100
 )
 
-func LowNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
+func LowNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts options.Options, podEvictor *evictions.PodEvictor) {
 	// todo: move to config validation?
 	// TODO: May be create a struct for the strategy as well, so that we don't have to pass along the all the params?
 	if strategy.Params == nil || strategy.Params.NodeResourceUtilizationThresholds == nil {

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -46,7 +46,7 @@ const (
 	MaxResourcePercentage = 100
 )
 
-func LowNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+func LowNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
 	// todo: move to config validation?
 	// TODO: May be create a struct for the strategy as well, so that we don't have to pass along the all the params?
 	if strategy.Params == nil || strategy.Params.NodeResourceUtilizationThresholds == nil {
@@ -75,7 +75,7 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 	}
 
 	npm := createNodePodsMap(ctx, client, nodes)
-	lowNodes, targetNodes := classifyNodes(npm, thresholds, targetThresholds, evictLocalStoragePods)
+	lowNodes, targetNodes := classifyNodes(npm, thresholds, targetThresholds, opts.EvictLocalStoragePods)
 
 	klog.V(1).Infof("Criteria for a node under utilization: CPU: %v, Mem: %v, Pods: %v",
 		thresholds[v1.ResourceCPU], thresholds[v1.ResourceMemory], thresholds[v1.ResourcePods])
@@ -110,7 +110,7 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		targetNodes,
 		lowNodes,
 		targetThresholds,
-		evictLocalStoragePods,
+		opts.EvictLocalStoragePods,
 		podEvictor)
 
 	klog.V(1).Infof("Total number of pods evicted: %v", podEvictor.TotalEvicted())

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -19,6 +19,7 @@ package strategies
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"strings"
 	"testing"
 
@@ -426,7 +427,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 			}
 
-			opts := Options{
+			opts := options.Options{
 				EvictLocalStoragePods: false,
 			}
 
@@ -830,7 +831,7 @@ func TestWithTaints(t *testing.T) {
 				item.nodes,
 			)
 
-			opts := Options{
+			opts := options.Options{
 				EvictLocalStoragePods: false,
 			}
 

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -425,7 +425,12 @@ func TestLowNodeUtilization(t *testing.T) {
 					},
 				},
 			}
-			LowNodeUtilization(ctx, fakeClient, strategy, nodes, false, podEvictor)
+
+			opts := Options{
+				EvictLocalStoragePods: false,
+			}
+
+			LowNodeUtilization(ctx, fakeClient, strategy, nodes, opts, podEvictor)
 
 			podsEvicted := podEvictor.TotalEvicted()
 			if test.expectedPodsEvicted != podsEvicted {
@@ -825,7 +830,11 @@ func TestWithTaints(t *testing.T) {
 				item.nodes,
 			)
 
-			LowNodeUtilization(ctx, &fake.Clientset{Fake: *fakePtr}, strategy, item.nodes, false, podEvictor)
+			opts := Options{
+				EvictLocalStoragePods: false,
+			}
+
+			LowNodeUtilization(ctx, &fake.Clientset{Fake: *fakePtr}, strategy, item.nodes, opts, podEvictor)
 
 			if item.evictionsExpected != evictionCounter {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, evictionCounter)

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -29,7 +29,7 @@ import (
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 )
 
-func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
 	if strategy.Params == nil {
 		klog.V(1).Infof("NodeAffinityType not set")
 		return
@@ -42,7 +42,7 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 			for _, node := range nodes {
 				klog.V(1).Infof("Processing node: %#v\n", node.Name)
 
-				pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, evictLocalStoragePods)
+				pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
 				if err != nil {
 					klog.Errorf("failed to get pods from %v: %v", node.Name, err)
 				}

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -29,7 +30,7 @@ import (
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 )
 
-func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts options.Options, podEvictor *evictions.PodEvictor) {
 	if strategy.Params == nil {
 		klog.V(1).Infof("NodeAffinityType not set")
 		return
@@ -42,7 +43,7 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 			for _, node := range nodes {
 				klog.V(1).Infof("Processing node: %#v\n", node.Name)
 
-				pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
+				pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts)
 				if err != nil {
 					klog.Errorf("failed to get pods from %v: %v", node.Name, err)
 				}

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -159,7 +159,11 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			tc.nodes,
 		)
 
-		RemovePodsViolatingNodeAffinity(ctx, fakeClient, tc.strategy, tc.nodes, false, podEvictor)
+		opts := Options{
+			EvictLocalStoragePods: false,
+		}
+
+		RemovePodsViolatingNodeAffinity(ctx, fakeClient, tc.strategy, tc.nodes, opts, podEvictor)
 		actualEvictedPodCount := podEvictor.TotalEvicted()
 		if actualEvictedPodCount != tc.expectedEvictedPodCount {
 			t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -159,7 +160,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			tc.nodes,
 		)
 
-		opts := Options{
+		opts := options.Options{
 			EvictLocalStoragePods: false,
 		}
 

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -30,10 +30,10 @@ import (
 )
 
 // RemovePodsViolatingNodeTaints evicts pods on the node which violate NoSchedule Taints on nodes
-func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v\n", node.Name)
-		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, evictLocalStoragePods)
+		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
 		if err != nil {
 			//no pods evicted as error encountered retrieving evictable Pods
 			return

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -30,10 +31,10 @@ import (
 )
 
 // RemovePodsViolatingNodeTaints evicts pods on the node which violate NoSchedule Taints on nodes
-func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts options.Options, podEvictor *evictions.PodEvictor) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v\n", node.Name)
-		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
+		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts)
 		if err != nil {
 			//no pods evicted as error encountered retrieving evictable Pods
 			return

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -172,7 +172,11 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			tc.nodes,
 		)
 
-		RemovePodsViolatingNodeTaints(ctx, fakeClient, api.DeschedulerStrategy{}, tc.nodes, tc.evictLocalStoragePods, podEvictor)
+		opts := Options{
+			EvictLocalStoragePods: tc.evictLocalStoragePods,
+		}
+
+		RemovePodsViolatingNodeTaints(ctx, fakeClient, api.DeschedulerStrategy{}, tc.nodes, opts, podEvictor)
 		actualEvictedPodCount := podEvictor.TotalEvicted()
 		if actualEvictedPodCount != tc.expectedEvictedPodCount {
 			t.Errorf("Test %#v failed, Unexpected no of pods evicted: pods evicted: %d, expected: %d", tc.description, actualEvictedPodCount, tc.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -3,6 +3,7 @@ package strategies
 import (
 	"context"
 	"fmt"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -172,7 +173,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			tc.nodes,
 		)
 
-		opts := Options{
+		opts := options.Options{
 			EvictLocalStoragePods: tc.evictLocalStoragePods,
 		}
 

--- a/pkg/descheduler/strategies/options.go
+++ b/pkg/descheduler/strategies/options.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategies
+
+// Generic options for use across all strategies
+type Options struct {
+	EvictLocalStoragePods bool
+}

--- a/pkg/descheduler/strategies/options/options.go
+++ b/pkg/descheduler/strategies/options/options.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package strategies
+package options
 
 // Generic options for use across all strategies
 type Options struct {

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"sigs.k8s.io/descheduler/pkg/utils"
 
 	"k8s.io/api/core/v1"
@@ -30,10 +31,10 @@ import (
 )
 
 // RemovePodsViolatingInterPodAntiAffinity evicts pods on the node which are having a pod affinity rules.
-func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts options.Options, podEvictor *evictions.PodEvictor) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v\n", node.Name)
-		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
+		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts)
 		if err != nil {
 			return
 		}

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -30,10 +30,10 @@ import (
 )
 
 // RemovePodsViolatingInterPodAntiAffinity evicts pods on the node which are having a pod affinity rules.
-func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v\n", node.Name)
-		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, evictLocalStoragePods)
+		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
 		if err != nil {
 			return
 		}

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -86,7 +87,7 @@ func TestPodAntiAffinity(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		opts := Options{
+		opts := options.Options{
 			EvictLocalStoragePods: false,
 		}
 

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -86,7 +86,11 @@ func TestPodAntiAffinity(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		RemovePodsViolatingInterPodAntiAffinity(ctx, fakeClient, api.DeschedulerStrategy{}, []*v1.Node{node}, false, podEvictor)
+		opts := Options{
+			EvictLocalStoragePods: false,
+		}
+
+		RemovePodsViolatingInterPodAntiAffinity(ctx, fakeClient, api.DeschedulerStrategy{}, []*v1.Node{node}, opts, podEvictor)
 		podsEvicted := podEvictor.TotalEvicted()
 		if podsEvicted != test.expectedEvictedPodCount {
 			t.Errorf("Unexpected no of pods evicted: pods evicted: %d, expected: %d", podsEvicted, test.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/pod_lifetime.go
+++ b/pkg/descheduler/strategies/pod_lifetime.go
@@ -18,7 +18,6 @@ package strategies
 
 import (
 	"context"
-
 	v1 "k8s.io/api/core/v1"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -30,7 +29,7 @@ import (
 )
 
 // PodLifeTime evicts pods on nodes that were created more than strategy.Params.MaxPodLifeTimeSeconds seconds ago.
-func PodLifeTime(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+func PodLifeTime(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
 	if strategy.Params == nil || strategy.Params.MaxPodLifeTimeSeconds == nil {
 		klog.V(1).Infof("MaxPodLifeTimeSeconds not set")
 		return
@@ -38,7 +37,7 @@ func PodLifeTime(ctx context.Context, client clientset.Interface, strategy api.D
 
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v", node.Name)
-		pods := listOldPodsOnNode(ctx, client, node, *strategy.Params.MaxPodLifeTimeSeconds, evictLocalStoragePods)
+		pods := listOldPodsOnNode(ctx, client, node, *strategy.Params.MaxPodLifeTimeSeconds, opts.EvictLocalStoragePods)
 		for _, pod := range pods {
 			success, err := podEvictor.EvictPod(ctx, pod, node)
 			if success {

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -159,7 +159,11 @@ func TestPodLifeTime(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		PodLifeTime(ctx, fakeClient, tc.strategy, []*v1.Node{node}, false, podEvictor)
+		opts := Options{
+			EvictLocalStoragePods: false,
+		}
+
+		PodLifeTime(ctx, fakeClient, tc.strategy, []*v1.Node{node}, opts, podEvictor)
 		podsEvicted := podEvictor.TotalEvicted()
 		if podsEvicted != tc.expectedEvictedPodCount {
 			t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.description, tc.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"testing"
 	"time"
 
@@ -159,7 +160,7 @@ func TestPodLifeTime(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		opts := Options{
+		opts := options.Options{
 			EvictLocalStoragePods: false,
 		}
 

--- a/pkg/descheduler/strategies/toomanyrestarts.go
+++ b/pkg/descheduler/strategies/toomanyrestarts.go
@@ -31,14 +31,14 @@ import (
 // RemovePodsHavingTooManyRestarts removes the pods that have too many restarts on node.
 // There are too many cases leading this issue: Volume mount failed, app error due to nodes' different settings.
 // As of now, this strategy won't evict daemonsets, mirror pods, critical pods and pods with local storages.
-func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, evictLocalStoragePods bool, podEvictor *evictions.PodEvictor) {
+func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
 	if strategy.Params == nil || strategy.Params.PodsHavingTooManyRestarts == nil || strategy.Params.PodsHavingTooManyRestarts.PodRestartThreshold < 1 {
 		klog.V(1).Infof("PodsHavingTooManyRestarts thresholds not set")
 		return
 	}
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %s", node.Name)
-		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, evictLocalStoragePods)
+		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
 		if err != nil {
 			klog.Errorf("Error when list pods at node %s", node.Name)
 			continue

--- a/pkg/descheduler/strategies/toomanyrestarts.go
+++ b/pkg/descheduler/strategies/toomanyrestarts.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -31,14 +32,14 @@ import (
 // RemovePodsHavingTooManyRestarts removes the pods that have too many restarts on node.
 // There are too many cases leading this issue: Volume mount failed, app error due to nodes' different settings.
 // As of now, this strategy won't evict daemonsets, mirror pods, critical pods and pods with local storages.
-func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts Options, podEvictor *evictions.PodEvictor) {
+func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, opts options.Options, podEvictor *evictions.PodEvictor) {
 	if strategy.Params == nil || strategy.Params.PodsHavingTooManyRestarts == nil || strategy.Params.PodsHavingTooManyRestarts.PodRestartThreshold < 1 {
 		klog.V(1).Infof("PodsHavingTooManyRestarts thresholds not set")
 		return
 	}
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %s", node.Name)
-		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts.EvictLocalStoragePods)
+		pods, err := podutil.ListEvictablePodsOnNode(ctx, client, node, opts)
 		if err != nil {
 			klog.Errorf("Error when list pods at node %s", node.Name)
 			continue

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -18,6 +18,7 @@ package strategies
 
 import (
 	"context"
+	"sigs.k8s.io/descheduler/pkg/descheduler/strategies/options"
 	"testing"
 
 	"fmt"
@@ -173,7 +174,7 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		opts := Options{
+		opts := options.Options{
 			EvictLocalStoragePods: false,
 		}
 

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -173,7 +173,11 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 			[]*v1.Node{node},
 		)
 
-		RemovePodsHavingTooManyRestarts(ctx, fakeClient, tc.strategy, []*v1.Node{node}, false, podEvictor)
+		opts := Options{
+			EvictLocalStoragePods: false,
+		}
+
+		RemovePodsHavingTooManyRestarts(ctx, fakeClient, tc.strategy, []*v1.Node{node}, opts, podEvictor)
 		actualEvictedPodCount := podEvictor.TotalEvicted()
 		if actualEvictedPodCount != tc.expectedEvictedPodCount {
 			t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -134,7 +134,11 @@ func startEndToEndForLowNodeUtilization(ctx context.Context, clientset clientset
 		nodes,
 	)
 
-	strategies.LowNodeUtilization(ctx, clientset, lowNodeUtilizationStrategy, nodes, false, podEvictor)
+	opts := strategies.Options{
+		EvictLocalStoragePods: false,
+	}
+
+	strategies.LowNodeUtilization(ctx, clientset, lowNodeUtilizationStrategy, nodes, opts, podEvictor)
 	time.Sleep(10 * time.Second)
 }
 


### PR DESCRIPTION
At present each strategy function codies a list of flags that are passed
in, we generalize this instead by switching to an Options struct which
can be easily extended for future flags without needing to modify the
function prototype.