### PR TITLE
Add missing address of api.StrategyParameters

### DIFF
--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -418,7 +418,7 @@ func TestLowNodeUtilization(t *testing.T) {
 
 			strategy := api.DeschedulerStrategy{
 				Enabled: true,
-				Params: api.StrategyParameters{
+				Params: &api.StrategyParameters{
 					NodeResourceUtilizationThresholds: &api.NodeResourceUtilizationThresholds{
 						Thresholds:       test.thresholds,
 						TargetThresholds: test.targetThresholds,


### PR DESCRIPTION
https://github.com/kubernetes-sigs/descheduler/pull/285 got merged before re-running the unit tests.