### PR TITLE
Add parent make verify target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ before_script:
 script:
 - mkdir -p ~/gopath/src/sigs.k8s.io/
 - mv ~/gopath/src/github.com/kubernetes-sigs/descheduler ~/gopath/src/sigs.k8s.io/.
-- make verify-gofmt
-- make verify-vendor
-- make lint
+- make verify
 - make build
 - make test-unit
 - make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ push: push-container-to-gcloud
 clean:
 	rm -rf _output
 
+verify: verify-gofmt verify-vendor lint
+
 verify-gofmt:
 	./hack/verify-gofmt.sh
 


### PR DESCRIPTION
This adds a `make verify` target which will run all of the other `*-verify` targets. This would simplify our CI and make future changes to it easier as well