### PR TITLE
Download golangci-lint to _output/bin directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LDFLAG_LOCATION=sigs.k8s.io/descheduler/cmd/descheduler/app
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitCommit=${COMMIT}"
 
 GOLANGCI_VERSION := v1.15.0
-HAS_GOLANGCI := $(shell which golangci-lint)
+HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint)
 
 # REGISTRY is the container registry to push
 # into. The default is to push to the staging
@@ -84,6 +84,6 @@ gen:
 	go mod tidy
 lint:
 ifndef HAS_GOLANGCI
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin ${GOLANGCI_VERSION}
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./_output/bin ${GOLANGCI_VERSION}
 endif
-	golangci-lint run
+	./_output/bin/golangci-lint run


### PR DESCRIPTION
Follow up to https://github.com/kubernetes-sigs/descheduler/pull/307, the `make lint` target fails in CI with `make: golangci-lint: Command not found`. This should fix it

Currently we check if the binary exists in `$PATH`, but we download it directly to GOPATH if not. This could provide different results between local and CI runs (if a different version of the binary exists somewhere else in the path). This standardizes that and downloads it directly to the temporary `_output` directory, so as also not to interfere with any local copies of `golangci-lint` that may exist in developers' GOPATHs