### PR TITLE
Fix 'make gen' target outside of GOPATH

### DIFF
--- a/hack/lib/init.sh
+++ b/hack/lib/init.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set -o errexit
-set -o nounset
 set -o pipefail
 
 
@@ -37,11 +36,37 @@ function os::util::absolute_path() {
 }
 readonly -f os::util::absolute_path
 
+# os::util::project_within_gopath checks if the OS_ROOT exists within a GOPATH
+function os::util::project_within_gopath() {
+	local within_gopath=false
+
+	if [[ ! -z "$GOPATH" ]]; then
+		for p in $GOPATH; do
+			# As OS_ROOT is an absolute path, we can simply check
+			# to see if it begins with any of the GOPATH paths.
+			if [[ $1 == $p* ]]; then
+				within_gopath=true
+				break
+			fi
+		done
+	fi
+
+	echo $within_gopath
+}
+readonly -f os::util::project_within_gopath
+
 # find the absolute path to the root of the Origin source tree
 init_source="$( dirname "${BASH_SOURCE}" )/../.."
 OS_ROOT="$( os::util::absolute_path "${init_source}" )"
 export OS_ROOT
 cd "${OS_ROOT}"
 
-PRJ_PREFIX="sigs.k8s.io/descheduler"
+WITHIN_GOPATH="$( os::util::project_within_gopath "${OS_ROOT}" )"
+
+if [ "$WITHIN_GOPATH" = true ]; then
+	PRJ_PREFIX="sigs.k8s.io/descheduler"
+else
+	PRJ_PREFIX="."
+fi
+
 OS_OUTPUT_BINPATH="${OS_ROOT}/_output/bin"

--- a/hack/update-generated-conversions.sh
+++ b/hack/update-generated-conversions.sh
@@ -6,4 +6,5 @@ go build -o "${OS_OUTPUT_BINPATH}/conversion-gen" "k8s.io/code-generator/cmd/con
 ${OS_OUTPUT_BINPATH}/conversion-gen \
 		--go-header-file "hack/boilerplate/boilerplate.go.txt" \
 		--input-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api/v1alpha1" \
+		--output-base "${OS_ROOT}" \
 		--output-file-base zz_generated.conversion

--- a/hack/update-generated-deep-copies.sh
+++ b/hack/update-generated-deep-copies.sh
@@ -6,5 +6,6 @@ go build -o "${OS_OUTPUT_BINPATH}/deepcopy-gen" "k8s.io/code-generator/cmd/deepc
 ${OS_OUTPUT_BINPATH}/deepcopy-gen \
                 --go-header-file "hack/boilerplate/boilerplate.go.txt" \
                 --input-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig,${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api,${PRJ_PREFIX}/pkg/api/v1alpha1" \
+		--output-base "${OS_ROOT}" \
                 --output-file-base zz_generated.deepcopy
 

--- a/hack/update-generated-defaulters.sh
+++ b/hack/update-generated-defaulters.sh
@@ -7,4 +7,5 @@ ${OS_OUTPUT_BINPATH}/defaulter-gen \
                 --go-header-file "hack/boilerplate/boilerplate.go.txt" \
                 --input-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api/v1alpha1" \
 		--extra-peer-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api/v1alpha1" \
+		--output-base "${OS_ROOT}" \
                 --output-file-base zz_generated.defaults


### PR DESCRIPTION
When running 'make gen' outside of a GOPATH, it fails to update the
generated files in-place, and further gets confused, as it's unable
to locate the working descheduler directory.

The update tools further cannot handle an absolute path for the
package imports, so this must be relative to the OS_ROOT. Output
files must further be written in place, which doesn't work if
one has both an active GOPATH and is working on descheduler outside
of it. This is addressed by specifying the output base, which maps
properly for both the in-GOPATH and out-of-GOPATH cases.

This resolves #313.