### PR TITLE
Remove redundant eviction log message and add "Reason" param to EvictPod

### DIFF
--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -101,7 +101,7 @@ func RemoveDuplicatePods(
 		}
 
 		for _, pod := range duplicatePods {
-			if _, err := podEvictor.EvictPod(ctx, pod, node); err != nil {
+			if _, err := podEvictor.EvictPod(ctx, pod, node, "RemoveDuplicatePods"); err != nil {
 				klog.Errorf("Error evicting pod: (%#v)", err)
 				break
 			}

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -289,7 +289,7 @@ func evictPods(
 			cUsage := utils.GetResourceRequest(pod, v1.ResourceCPU)
 			mUsage := utils.GetResourceRequest(pod, v1.ResourceMemory)
 
-			success, err := podEvictor.EvictPod(ctx, pod, node)
+			success, err := podEvictor.EvictPod(ctx, pod, node, "LowNodeUtilization")
 			if err != nil {
 				klog.Errorf("Error evicting pod: (%#v)", err)
 				break

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -55,7 +55,7 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 				for _, pod := range pods {
 					if pod.Spec.Affinity != nil && pod.Spec.Affinity.NodeAffinity != nil && pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 						klog.V(1).Infof("Evicting pod: %v", pod.Name)
-						if _, err := podEvictor.EvictPod(ctx, pod, node); err != nil {
+						if _, err := podEvictor.EvictPod(ctx, pod, node, "NodeAffinity"); err != nil {
 							klog.Errorf("Error evicting pod: (%#v)", err)
 							break
 						}

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -46,7 +46,7 @@ func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interfa
 				func(taint *v1.Taint) bool { return taint.Effect == v1.TaintEffectNoSchedule },
 			) {
 				klog.V(2).Infof("Not all taints with NoSchedule effect are tolerated after update for pod %v on node %v", pods[i].Name, node.Name)
-				if _, err := podEvictor.EvictPod(ctx, pods[i], node); err != nil {
+				if _, err := podEvictor.EvictPod(ctx, pods[i], node, "NodeTaint"); err != nil {
 					klog.Errorf("Error evicting pod: (%#v)", err)
 					break
 				}

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -40,7 +40,7 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 		totalPods := len(pods)
 		for i := 0; i < totalPods; i++ {
 			if checkPodsWithAntiAffinityExist(pods[i], pods) {
-				success, err := podEvictor.EvictPod(ctx, pods[i], node)
+				success, err := podEvictor.EvictPod(ctx, pods[i], node, "InterPodAntiAffinity")
 				if err != nil {
 					klog.Errorf("Error evicting pod: (%#v)", err)
 					break

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -47,7 +47,6 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 				}
 
 				if success {
-					klog.V(1).Infof("Evicted pod: %#v\n because of existing anti-affinity", pods[i].Name)
 					// Since the current pod is evicted all other pods which have anti-affinity with this
 					// pod need not be evicted.
 					// Update pods.

--- a/pkg/descheduler/strategies/pod_lifetime.go
+++ b/pkg/descheduler/strategies/pod_lifetime.go
@@ -40,7 +40,7 @@ func PodLifeTime(ctx context.Context, client clientset.Interface, strategy api.D
 		klog.V(1).Infof("Processing node: %#v", node.Name)
 		pods := listOldPodsOnNode(ctx, client, node, *strategy.Params.MaxPodLifeTimeSeconds, podEvictor)
 		for _, pod := range pods {
-			success, err := podEvictor.EvictPod(ctx, pod, node)
+			success, err := podEvictor.EvictPod(ctx, pod, node, "PodLifeTime")
 			if success {
 				klog.V(1).Infof("Evicted pod: %#v because it was created more than %v seconds ago", pod.Name, *strategy.Params.MaxPodLifeTimeSeconds)
 			}

--- a/pkg/descheduler/strategies/toomanyrestarts.go
+++ b/pkg/descheduler/strategies/toomanyrestarts.go
@@ -53,7 +53,7 @@ func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Inter
 			} else if restarts < strategy.Params.PodsHavingTooManyRestarts.PodRestartThreshold {
 				continue
 			}
-			if _, err := podEvictor.EvictPod(ctx, pods[i], node); err != nil {
+			if _, err := podEvictor.EvictPod(ctx, pods[i], node, "TooManyRestarts"); err != nil {
 				klog.Errorf("Error evicting pod: (%#v)", err)
 				break
 			}


### PR DESCRIPTION
Related to the changes in https://github.com/kubernetes-sigs/descheduler/pull/287, because the PodEvictor logs when a pod is successfully evicted (either in dry-run or normal mode) this message becomes redundant and confusing when in dry run. For example, it currently looks like:

```
I0528 09:23:48.664691       1 evictions.go:100] Evicted pod in dry run mode: "hello1-54d7977cd-l8wx7" in namespace "test"
I0528 09:23:48.664700       1 pod_antiaffinity.go:50] Evicted pod: "hello1-54d7977cd-l8wx7" because of existing anti-affinity
```

This extra message doesn't provide much information, though it may be reasonable to add an extra "reason" parameter to `podEvictor.EvictPod` to give context on what strategy specifically caused the eviction (since all eviction logs now just originate from `evictions.go`). This includes that change and the log output looks like:

```
evictions.go:148] Evicted pod: "dedicated-nodes-zf7kh" in namespace "mdame-test" (RemoveDuplicatePods)
```