### PR TITLE
Move sortPodsBasedOnPriority to pod util

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ When the descheduler decides to evict pods from a node, it employs the following
 never evicted because these pods won't be recreated.
 * Pods associated with DaemonSets are never evicted.
 * Pods with local storage are never evicted.
-* Best efforts pods are evicted before burstable and guaranteed pods.
+* In `LowNodeUtilization`, pods are evicted by their priority from low to high, and if they have same priority,
+best effort pods are evicted before burstable and guaranteed pods.
 * All types of pods with the annotation descheduler.alpha.kubernetes.io/evict are evicted. This
   annotation is used to override checks which prevent eviction and users can select which pod is evicted.
   Users should know how and if the pod will be recreated.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ When the descheduler decides to evict pods from a node, it employs the following
 never evicted because these pods won't be recreated.
 * Pods associated with DaemonSets are never evicted.
 * Pods with local storage are never evicted.
-* In `LowNodeUtilization`, pods are evicted by their priority from low to high, and if they have same priority,
+* In `LowNodeUtilization` and `RemovePodsViolatingInterPodAntiAffinity`, pods are evicted by their priority from low to high, and if they have same priority,
 best effort pods are evicted before burstable and guaranteed pods.
 * All types of pods with the annotation descheduler.alpha.kubernetes.io/evict are evicted. This
   annotation is used to override checks which prevent eviction and users can select which pod is evicted.

--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -27,6 +28,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"sigs.k8s.io/descheduler/test"
+)
+
+var (
+	lowPriority  = int32(0)
+	highPriority = int32(10000)
 )
 
 func TestListPodsOnANode(t *testing.T) {
@@ -65,5 +71,45 @@ func TestListPodsOnANode(t *testing.T) {
 		if len(pods) != testCase.expectedPodCount {
 			t.Errorf("expected %v pods on node %v, got %+v", testCase.expectedPodCount, testCase.node.Name, len(pods))
 		}
+	}
+}
+
+func TestSortPodsBasedOnPriorityLowToHigh(t *testing.T) {
+	n1 := test.BuildTestNode("n1", 4000, 3000, 9, nil)
+
+	p1 := test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
+		test.SetPodPriority(pod, lowPriority)
+	})
+
+	// BestEffort
+	p2 := test.BuildTestPod("p2", 400, 0, n1.Name, func(pod *v1.Pod) {
+		test.SetPodPriority(pod, highPriority)
+		test.MakeBestEffortPod(pod)
+	})
+
+	// Burstable
+	p3 := test.BuildTestPod("p3", 400, 0, n1.Name, func(pod *v1.Pod) {
+		test.SetPodPriority(pod, highPriority)
+		test.MakeBurstablePod(pod)
+	})
+
+	// Guaranteed
+	p4 := test.BuildTestPod("p4", 400, 100, n1.Name, func(pod *v1.Pod) {
+		test.SetPodPriority(pod, highPriority)
+		test.MakeGuaranteedPod(pod)
+	})
+
+	// Best effort with nil priorities.
+	p5 := test.BuildTestPod("p5", 400, 100, n1.Name, test.MakeBestEffortPod)
+	p5.Spec.Priority = nil
+
+	p6 := test.BuildTestPod("p6", 400, 100, n1.Name, test.MakeGuaranteedPod)
+	p6.Spec.Priority = nil
+
+	podList := []*v1.Pod{p4, p3, p2, p1, p6, p5}
+
+	SortPodsBasedOnPriorityLowToHigh(podList)
+	if !reflect.DeepEqual(podList[len(podList)-1], p4) {
+		t.Errorf("Expected last pod in sorted list to be %v which of highest priority and guaranteed but got %v", p4, podList[len(podList)-1])
 	}
 }

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -44,30 +44,6 @@ var (
 	lowPriority  = int32(0)
 	highPriority = int32(10000)
 )
-
-func setRSOwnerRef(pod *v1.Pod)          { pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList() }
-func setDSOwnerRef(pod *v1.Pod)          { pod.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList() }
-func setNormalOwnerRef(pod *v1.Pod)      { pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList() }
-func setHighPriority(pod *v1.Pod)        { pod.Spec.Priority = &highPriority }
-func setLowPriority(pod *v1.Pod)         { pod.Spec.Priority = &lowPriority }
-func setNodeUnschedulable(node *v1.Node) { node.Spec.Unschedulable = true }
-
-func makeBestEffortPod(pod *v1.Pod) {
-	pod.Spec.Containers[0].Resources.Requests = nil
-	pod.Spec.Containers[0].Resources.Requests = nil
-	pod.Spec.Containers[0].Resources.Limits = nil
-	pod.Spec.Containers[0].Resources.Limits = nil
-}
-
-func makeBurstablePod(pod *v1.Pod) {
-	pod.Spec.Containers[0].Resources.Limits = nil
-	pod.Spec.Containers[0].Resources.Limits = nil
-}
-
-func makeGuaranteedPod(pod *v1.Pod) {
-	pod.Spec.Containers[0].Resources.Limits[v1.ResourceCPU] = pod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU]
-	pod.Spec.Containers[0].Resources.Limits[v1.ResourceMemory] = pod.Spec.Containers[0].Resources.Requests[v1.ResourceMemory]
-}
 
 func TestLowNodeUtilization(t *testing.T) {
 	ctx := context.Background()
@@ -99,19 +75,19 @@ func TestLowNodeUtilization(t *testing.T) {
 			nodes: map[string]*v1.Node{
 				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
 				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
-				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, setNodeUnschedulable),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
 			},
 			pods: map[string]*v1.PodList{
 				n1NodeName: {
 					Items: []v1.Pod{
 						// These won't be evicted.
-						*test.BuildTestPod("p1", 400, 0, n1NodeName, setDSOwnerRef),
-						*test.BuildTestPod("p2", 400, 0, n1NodeName, setDSOwnerRef),
-						*test.BuildTestPod("p3", 400, 0, n1NodeName, setDSOwnerRef),
-						*test.BuildTestPod("p4", 400, 0, n1NodeName, setDSOwnerRef),
+						*test.BuildTestPod("p1", 400, 0, n1NodeName, test.SetDSOwnerRef),
+						*test.BuildTestPod("p2", 400, 0, n1NodeName, test.SetDSOwnerRef),
+						*test.BuildTestPod("p3", 400, 0, n1NodeName, test.SetDSOwnerRef),
+						*test.BuildTestPod("p4", 400, 0, n1NodeName, test.SetDSOwnerRef),
 						*test.BuildTestPod("p5", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							// A pod with local storage.
-							setNormalOwnerRef(pod)
+							test.SetNormalOwnerRef(pod)
 							pod.Spec.Volumes = []v1.Volume{
 								{
 									Name: "sample",
@@ -135,7 +111,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, setRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -155,21 +131,21 @@ func TestLowNodeUtilization(t *testing.T) {
 			nodes: map[string]*v1.Node{
 				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
 				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
-				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, setNodeUnschedulable),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
 			},
 			pods: map[string]*v1.PodList{
 				n1NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p1", 400, 0, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p2", 400, 0, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p3", 400, 0, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p4", 400, 0, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p5", 400, 0, n1NodeName, setRSOwnerRef),
+						*test.BuildTestPod("p1", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p4", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p5", 400, 0, n1NodeName, test.SetRSOwnerRef),
 						// These won't be evicted.
-						*test.BuildTestPod("p6", 400, 0, n1NodeName, setDSOwnerRef),
+						*test.BuildTestPod("p6", 400, 0, n1NodeName, test.SetDSOwnerRef),
 						*test.BuildTestPod("p7", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							// A pod with local storage.
-							setNormalOwnerRef(pod)
+							test.SetNormalOwnerRef(pod)
 							pod.Spec.Volumes = []v1.Volume{
 								{
 									Name: "sample",
@@ -193,7 +169,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, setRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -213,21 +189,21 @@ func TestLowNodeUtilization(t *testing.T) {
 			nodes: map[string]*v1.Node{
 				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
 				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
-				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, setNodeUnschedulable),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
 			},
 			pods: map[string]*v1.PodList{
 				n1NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p1", 400, 300, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p2", 400, 300, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p3", 400, 300, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p4", 400, 300, n1NodeName, setRSOwnerRef),
-						*test.BuildTestPod("p5", 400, 300, n1NodeName, setRSOwnerRef),
+						*test.BuildTestPod("p1", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p4", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p5", 400, 300, n1NodeName, test.SetRSOwnerRef),
 						// These won't be evicted.
-						*test.BuildTestPod("p6", 400, 300, n1NodeName, setDSOwnerRef),
+						*test.BuildTestPod("p6", 400, 300, n1NodeName, test.SetDSOwnerRef),
 						*test.BuildTestPod("p7", 400, 300, n1NodeName, func(pod *v1.Pod) {
 							// A pod with local storage.
-							setNormalOwnerRef(pod)
+							test.SetNormalOwnerRef(pod)
 							pod.Spec.Volumes = []v1.Volume{
 								{
 									Name: "sample",
@@ -251,7 +227,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 2100, n1NodeName, setRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 2100, n1NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -272,40 +248,40 @@ func TestLowNodeUtilization(t *testing.T) {
 			nodes: map[string]*v1.Node{
 				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
 				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
-				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, setNodeUnschedulable),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
 			},
 			pods: map[string]*v1.PodList{
 				n1NodeName: {
 					Items: []v1.Pod{
 						*test.BuildTestPod("p1", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							setHighPriority(pod)
+							test.SetRSOwnerRef(pod)
+							test.SetPodPriority(pod, highPriority)
 						}),
 						*test.BuildTestPod("p2", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							setHighPriority(pod)
+							test.SetRSOwnerRef(pod)
+							test.SetPodPriority(pod, highPriority)
 						}),
 						*test.BuildTestPod("p3", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							setHighPriority(pod)
+							test.SetRSOwnerRef(pod)
+							test.SetPodPriority(pod, highPriority)
 						}),
 						*test.BuildTestPod("p4", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							setHighPriority(pod)
+							test.SetRSOwnerRef(pod)
+							test.SetPodPriority(pod, highPriority)
 						}),
 						*test.BuildTestPod("p5", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							setLowPriority(pod)
+							test.SetRSOwnerRef(pod)
+							test.SetPodPriority(pod, lowPriority)
 						}),
 						// These won't be evicted.
 						*test.BuildTestPod("p6", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setDSOwnerRef(pod)
-							setHighPriority(pod)
+							test.SetDSOwnerRef(pod)
+							test.SetPodPriority(pod, highPriority)
 						}),
 						*test.BuildTestPod("p7", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							// A pod with local storage.
-							setNormalOwnerRef(pod)
-							setLowPriority(pod)
+							test.SetNormalOwnerRef(pod)
+							test.SetPodPriority(pod, lowPriority)
 							pod.Spec.Volumes = []v1.Volume{
 								{
 									Name: "sample",
@@ -329,7 +305,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, setRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -349,38 +325,38 @@ func TestLowNodeUtilization(t *testing.T) {
 			nodes: map[string]*v1.Node{
 				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
 				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
-				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, setNodeUnschedulable),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
 			},
 			// All pods are assumed to be burstable (test.BuildTestNode always sets both cpu/memory resource requests to some value)
 			pods: map[string]*v1.PodList{
 				n1NodeName: {
 					Items: []v1.Pod{
 						*test.BuildTestPod("p1", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							makeBestEffortPod(pod)
+							test.SetRSOwnerRef(pod)
+							test.MakeBestEffortPod(pod)
 						}),
 						*test.BuildTestPod("p2", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							makeBestEffortPod(pod)
+							test.SetRSOwnerRef(pod)
+							test.MakeBestEffortPod(pod)
 						}),
 						*test.BuildTestPod("p3", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
+							test.SetRSOwnerRef(pod)
 						}),
 						*test.BuildTestPod("p4", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							makeBestEffortPod(pod)
+							test.SetRSOwnerRef(pod)
+							test.MakeBestEffortPod(pod)
 						}),
 						*test.BuildTestPod("p5", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setRSOwnerRef(pod)
-							makeBestEffortPod(pod)
+							test.SetRSOwnerRef(pod)
+							test.MakeBestEffortPod(pod)
 						}),
 						// These won't be evicted.
 						*test.BuildTestPod("p6", 400, 0, n1NodeName, func(pod *v1.Pod) {
-							setDSOwnerRef(pod)
+							test.SetDSOwnerRef(pod)
 						}),
 						*test.BuildTestPod("p7", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							// A pod with local storage.
-							setNormalOwnerRef(pod)
+							test.SetNormalOwnerRef(pod)
 							pod.Spec.Volumes = []v1.Volume{
 								{
 									Name: "sample",
@@ -404,7 +380,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, setRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -498,31 +474,33 @@ func TestLowNodeUtilization(t *testing.T) {
 func TestSortPodsByPriority(t *testing.T) {
 	n1 := test.BuildTestNode("n1", 4000, 3000, 9, nil)
 
-	p1 := test.BuildTestPod("p1", 400, 0, n1.Name, setLowPriority)
+	p1 := test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
+		test.SetPodPriority(pod, lowPriority)
+	})
 
 	// BestEffort
 	p2 := test.BuildTestPod("p2", 400, 0, n1.Name, func(pod *v1.Pod) {
-		setHighPriority(pod)
-		makeBestEffortPod(pod)
+		test.SetPodPriority(pod, highPriority)
+		test.MakeBestEffortPod(pod)
 	})
 
 	// Burstable
 	p3 := test.BuildTestPod("p3", 400, 0, n1.Name, func(pod *v1.Pod) {
-		setHighPriority(pod)
-		makeBurstablePod(pod)
+		test.SetPodPriority(pod, highPriority)
+		test.MakeBurstablePod(pod)
 	})
 
 	// Guaranteed
 	p4 := test.BuildTestPod("p4", 400, 100, n1.Name, func(pod *v1.Pod) {
-		setHighPriority(pod)
-		makeGuaranteedPod(pod)
+		test.SetPodPriority(pod, highPriority)
+		test.MakeGuaranteedPod(pod)
 	})
 
 	// Best effort with nil priorities.
-	p5 := test.BuildTestPod("p5", 400, 100, n1.Name, makeBestEffortPod)
+	p5 := test.BuildTestPod("p5", 400, 100, n1.Name, test.MakeBestEffortPod)
 	p5.Spec.Priority = nil
 
-	p6 := test.BuildTestPod("p6", 400, 100, n1.Name, makeGuaranteedPod)
+	p6 := test.BuildTestPod("p6", 400, 100, n1.Name, test.MakeGuaranteedPod)
 	p6.Spec.Priority = nil
 
 	podList := []*v1.Pod{p4, p3, p2, p1, p6, p5}
@@ -783,7 +761,7 @@ func TestWithTaints(t *testing.T) {
 		},
 	}
 
-	podThatToleratesTaint := test.BuildTestPod("tolerate_pod", 200, 0, n1.Name, setRSOwnerRef)
+	podThatToleratesTaint := test.BuildTestPod("tolerate_pod", 200, 0, n1.Name, test.SetRSOwnerRef)
 	podThatToleratesTaint.Spec.Tolerations = []v1.Toleration{
 		{
 			Key:   "key",
@@ -802,16 +780,16 @@ func TestWithTaints(t *testing.T) {
 			nodes: []*v1.Node{n1, n2, n3},
 			pods: []*v1.Pod{
 				//Node 1 pods
-				test.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_2_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_3_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_4_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_5_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_6_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_7_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_8_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_2_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_3_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_4_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_5_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_6_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_7_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_8_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
 				// Node 2 pods
-				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n2.Name), 200, 0, n2.Name, setRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n2.Name), 200, 0, n2.Name, test.SetRSOwnerRef),
 			},
 			evictionsExpected: 1,
 		},
@@ -820,16 +798,16 @@ func TestWithTaints(t *testing.T) {
 			nodes: []*v1.Node{n1, n3withTaints},
 			pods: []*v1.Pod{
 				//Node 1 pods
-				test.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_2_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_3_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_4_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_5_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_6_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_7_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_8_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_2_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_3_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_4_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_5_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_6_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_7_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_8_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
 				// Node 3 pods
-				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n3withTaints.Name), 200, 0, n3withTaints.Name, setRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n3withTaints.Name), 200, 0, n3withTaints.Name, test.SetRSOwnerRef),
 			},
 			evictionsExpected: 0,
 		},
@@ -838,16 +816,16 @@ func TestWithTaints(t *testing.T) {
 			nodes: []*v1.Node{n1, n3withTaints},
 			pods: []*v1.Pod{
 				//Node 1 pods
-				test.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_2_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_3_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_4_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_5_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_6_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
-				test.BuildTestPod(fmt.Sprintf("pod_7_%s", n1.Name), 200, 0, n1.Name, setRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_2_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_3_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_4_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_5_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_6_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_7_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
 				podThatToleratesTaint,
 				// Node 3 pods
-				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n3withTaints.Name), 200, 0, n3withTaints.Name, setRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n3withTaints.Name), 200, 0, n3withTaints.Name, test.SetRSOwnerRef),
 			},
 			evictionsExpected: 1,
 		},

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"reflect"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -468,46 +466,6 @@ func TestLowNodeUtilization(t *testing.T) {
 				t.Errorf("Pod evictions failed unexpectedly")
 			}
 		})
-	}
-}
-
-func TestSortPodsByPriority(t *testing.T) {
-	n1 := test.BuildTestNode("n1", 4000, 3000, 9, nil)
-
-	p1 := test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
-		test.SetPodPriority(pod, lowPriority)
-	})
-
-	// BestEffort
-	p2 := test.BuildTestPod("p2", 400, 0, n1.Name, func(pod *v1.Pod) {
-		test.SetPodPriority(pod, highPriority)
-		test.MakeBestEffortPod(pod)
-	})
-
-	// Burstable
-	p3 := test.BuildTestPod("p3", 400, 0, n1.Name, func(pod *v1.Pod) {
-		test.SetPodPriority(pod, highPriority)
-		test.MakeBurstablePod(pod)
-	})
-
-	// Guaranteed
-	p4 := test.BuildTestPod("p4", 400, 100, n1.Name, func(pod *v1.Pod) {
-		test.SetPodPriority(pod, highPriority)
-		test.MakeGuaranteedPod(pod)
-	})
-
-	// Best effort with nil priorities.
-	p5 := test.BuildTestPod("p5", 400, 100, n1.Name, test.MakeBestEffortPod)
-	p5.Spec.Priority = nil
-
-	p6 := test.BuildTestPod("p6", 400, 100, n1.Name, test.MakeGuaranteedPod)
-	p6.Spec.Priority = nil
-
-	podList := []*v1.Pod{p4, p3, p2, p1, p6, p5}
-
-	sortPodsBasedOnPriority(podList)
-	if !reflect.DeepEqual(podList[len(podList)-1], p4) {
-		t.Errorf("Expected last pod in sorted list to be %v which of highest priority and guaranteed but got %v", p4, podList[len(podList)-1])
 	}
 }
 

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -37,6 +37,8 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 		if err != nil {
 			return
 		}
+		// sort the evictable Pods based on priority, if there are multiple pods with same priority, they are sorted based on QoS tiers.
+		podutil.SortPodsBasedOnPriorityLowToHigh(pods)
 		totalPods := len(pods)
 		for i := 0; i < totalPods; i++ {
 			if checkPodsWithAntiAffinityExist(pods[i], pods) {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -116,3 +116,48 @@ func BuildTestNode(name string, millicpu int64, mem int64, pods int64, apply fun
 	}
 	return node
 }
+
+// MakeBestEffortPod makes the given pod a BestEffort pod
+func MakeBestEffortPod(pod *v1.Pod) {
+	pod.Spec.Containers[0].Resources.Requests = nil
+	pod.Spec.Containers[0].Resources.Requests = nil
+	pod.Spec.Containers[0].Resources.Limits = nil
+	pod.Spec.Containers[0].Resources.Limits = nil
+}
+
+// MakeBurstablePod makes the given pod a Burstable pod
+func MakeBurstablePod(pod *v1.Pod) {
+	pod.Spec.Containers[0].Resources.Limits = nil
+	pod.Spec.Containers[0].Resources.Limits = nil
+}
+
+// MakeGuaranteedPod makes the given pod an Guaranteed pod
+func MakeGuaranteedPod(pod *v1.Pod) {
+	pod.Spec.Containers[0].Resources.Limits[v1.ResourceCPU] = pod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU]
+	pod.Spec.Containers[0].Resources.Limits[v1.ResourceMemory] = pod.Spec.Containers[0].Resources.Requests[v1.ResourceMemory]
+}
+
+// SetRSOwnerRef sets the given pod's owner to ReplicaSet
+func SetRSOwnerRef(pod *v1.Pod) {
+	pod.ObjectMeta.OwnerReferences = GetReplicaSetOwnerRefList()
+}
+
+// SetDSOwnerRef sets the given pod's owner to DaemonSet
+func SetDSOwnerRef(pod *v1.Pod) {
+	pod.ObjectMeta.OwnerReferences = GetDaemonSetOwnerRefList()
+}
+
+// SetNormalOwnerRef sets the given pod's owner to Pod
+func SetNormalOwnerRef(pod *v1.Pod) {
+	pod.ObjectMeta.OwnerReferences = GetNormalPodOwnerRefList()
+}
+
+// SetPodPriority sets the given pod's priority
+func SetPodPriority(pod *v1.Pod, priority int32) {
+	pod.Spec.Priority = &priority
+}
+
+// SetNodeUnschedulable sets the given node unschedulable
+func SetNodeUnschedulable(node *v1.Node) {
+	node.Spec.Unschedulable = true
+}


### PR DESCRIPTION
As #294  mentioned, we may need to sort pods in other strategies, so I moved this func to pod util.