### PR TITLE
examples: fix typo

### DIFF
--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -21,5 +21,5 @@ strategies:
      enabled: true
      params:
        podsHavingTooManyRestarts:
-         podRestartThresholds: 100
+         podRestartThreshold: 100
          includingInitContainers: true


### PR DESCRIPTION
Fix incorrect example causing following error in runtime:

```
I0628 12:23:46.112073       1 toomanyrestarts.go:36] PodsHavingTooManyRestarts thresholds not set
```
