### PR TITLE
Adding replica check when evicting managed pods from node

### DIFF
--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -97,7 +97,7 @@ func TestIsEvictable(t *testing.T) {
 		}, {
 			pod: test.BuildTestPod("p3", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
-				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList("replicaset-1")
 			},
 			evictLocalStoragePods: false,
 			result:                true,
@@ -105,7 +105,7 @@ func TestIsEvictable(t *testing.T) {
 			pod: test.BuildTestPod("p4", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList("replicaset-1")
 			},
 			evictLocalStoragePods: false,
 			result:                true,
@@ -238,7 +238,7 @@ func TestPodTypes(t *testing.T) {
 
 	p6.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 
-	p1.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+	p1.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList("replicaset-1")
 	// The following 4 pods won't get evicted.
 	// A daemonset.
 	//p2.Annotations = test.GetDaemonSetAnnotation()

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -18,13 +18,14 @@ package pod
 
 import (
 	"context"
-	"fmt"
+	"sort"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/pkg/utils"
-	"sort"
 )
 
 // ListPodsOnANode lists all of the pods on a node
@@ -70,7 +71,9 @@ func GetPodOwnerReplicationCount(ctx context.Context, client clientset.Interface
 		}
 		return int(owner.Status.Replicas), nil
 	default:
-		return 0, fmt.Errorf("pod owned by owner %s kind %s non managed", ownerRef.Name, ownerRef.Kind)
+		klog.Infof("pod is non managed by RS or RC - owner name %s kind %s", ownerRef.Name, ownerRef.Kind)
+		// Returning default value as 1 as its a single pod non managed by a rc or rs
+		return 1, nil
 	}
 }
 

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"context"
+	"fmt"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -53,7 +54,7 @@ func ListPodsOnANode(ctx context.Context, client clientset.Interface, node *v1.N
 	return pods, nil
 }
 
-// GetPodOwnerReplicationCount returns the owner's replica count of the pod based on the owner reference
+// GetPodOwnerReplicationCount returns the pod owner's replica count
 func GetPodOwnerReplicationCount(ctx context.Context, client clientset.Interface, ownerRef metav1.OwnerReference) (int, error) {
 	switch ownerRef.Kind {
 	case "ReplicaSet":

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -70,7 +70,7 @@ func GetPodOwnerReplicationCount(ctx context.Context, client clientset.Interface
 		}
 		return int(owner.Status.Replicas), nil
 	default:
-		klog.Infof("pod is non managed by RS or RC - owner name %s kind %s", ownerRef.Name, ownerRef.Kind)
+		klog.V(4).Infof("pod is non managed by RS or RC - owner name %s kind %s", ownerRef.Name, ownerRef.Kind)
 		// Returning default value as 1 as its a single pod non managed by a rc or rs
 		return 1, nil
 	}

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -18,14 +18,13 @@ package pod
 
 import (
 	"context"
-	"sort"
-
+	"fmt"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/pkg/utils"
+	"sort"
 )
 
 // ListPodsOnANode lists all of the pods on a node
@@ -71,9 +70,7 @@ func GetPodOwnerReplicationCount(ctx context.Context, client clientset.Interface
 		}
 		return int(owner.Status.Replicas), nil
 	default:
-		klog.Infof("pod is non managed by RS or RC - owner name %s kind %s", ownerRef.Name, ownerRef.Kind)
-		// Returning default value as 1 as its a single pod non managed by a rc or rs
-		return 1, nil
+		return 0, fmt.Errorf("pod owned by owner %s kind %s non managed", ownerRef.Name, ownerRef.Kind)
 	}
 }
 

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -18,11 +18,11 @@ package pod
 
 import (
 	"context"
-	"fmt"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/pkg/utils"
 	"sort"
 )
@@ -70,7 +70,9 @@ func GetPodOwnerReplicationCount(ctx context.Context, client clientset.Interface
 		}
 		return int(owner.Status.Replicas), nil
 	default:
-		return 0, fmt.Errorf("pod owned by owner %s kind %s non managed", ownerRef.Name, ownerRef.Kind)
+		klog.Infof("pod is non managed by RS or RC - owner name %s kind %s", ownerRef.Name, ownerRef.Kind)
+		// Returning default value as 1 as its a single pod non managed by a rc or rs
+		return 1, nil
 	}
 }
 

--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -80,7 +80,7 @@ func TestGetPodOwnerReplicaSetReplicaCount(t *testing.T) {
 	expectedReplicaCount := 3
 
 	rs := test.BuildTestReplicaSet(replicasetName, 3)
-	ownerRef1 := test.GetReplicaSetOwnerRefList()
+	ownerRef1 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	pod.ObjectMeta.OwnerReferences = ownerRef1
 
 	fakeClient := &fake.Clientset{}

--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -75,12 +75,11 @@ func TestListPodsOnANode(t *testing.T) {
 }
 
 func TestGetPodOwnerReplicaSetReplicaCount(t *testing.T) {
-	t.SkipNow()
 	pod := test.BuildTestPod("pod1", 100, 0, "n1", nil)
 	replicasetName := "replicaset-1"
 	expectedReplicaCount := 3
 
-	test.BuildTestReplicaSet(replicasetName, 3)
+	rs := test.BuildTestReplicaSet(replicasetName, 3)
 	ownerRef1 := test.GetReplicaSetOwnerRefList()
 	pod.ObjectMeta.OwnerReferences = ownerRef1
 
@@ -89,8 +88,7 @@ func TestGetPodOwnerReplicaSetReplicaCount(t *testing.T) {
 		name := action.(core.GetAction)
 		fieldString := name.GetName()
 		if strings.Contains(fieldString, replicasetName) {
-			// how to return RC as runtime.Object ? pod.DeepCopy is just a placeholder
-			return true, pod.DeepCopy(), nil
+			return true, rs.DeepCopy(), nil
 		}
 		return true, nil, fmt.Errorf("Failed to get replicaset: %v", replicasetName)
 	})
@@ -101,12 +99,11 @@ func TestGetPodOwnerReplicaSetReplicaCount(t *testing.T) {
 }
 
 func TestGetPodOwnerReplicationControllerReplicaCount(t *testing.T) {
-	t.SkipNow()
 	pod := test.BuildTestPod("pod1", 100, 0, "n1", nil)
 	rcOwnerName := "replicationcontroller-1"
 	expectedReplicaCount := 3
 
-	test.BuildTestReplicaSet(rcOwnerName, 3)
+	rc := test.BuildTestReplicaController(rcOwnerName, 3)
 	ownerRef1 := test.GetReplicationControllerOwnerRefList()
 	pod.ObjectMeta.OwnerReferences = ownerRef1
 
@@ -115,8 +112,7 @@ func TestGetPodOwnerReplicationControllerReplicaCount(t *testing.T) {
 		name := action.(core.GetAction)
 		fieldString := name.GetName()
 		if strings.Contains(fieldString, rcOwnerName) {
-			// how to return RC as runtime.Object ? pod.DeepCopy is just a placeholder
-			return true, pod.DeepCopy(), nil
+			return true, rc.DeepCopy(), nil
 		}
 		return true, nil, fmt.Errorf("Failed to get replication controller: %v", rcOwnerName)
 	})

--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -74,6 +74,58 @@ func TestListPodsOnANode(t *testing.T) {
 	}
 }
 
+func TestGetPodOwnerReplicaSetReplicaCount(t *testing.T) {
+	t.SkipNow()
+	pod := test.BuildTestPod("pod1", 100, 0, "n1", nil)
+	replicasetName := "replicaset-1"
+	expectedReplicaCount := 3
+
+	test.BuildTestReplicaSet(replicasetName, 3)
+	ownerRef1 := test.GetReplicaSetOwnerRefList()
+	pod.ObjectMeta.OwnerReferences = ownerRef1
+
+	fakeClient := &fake.Clientset{}
+	fakeClient.Fake.AddReactor("get", "replicasets", func(action core.Action) (bool, runtime.Object, error) {
+		name := action.(core.GetAction)
+		fieldString := name.GetName()
+		if strings.Contains(fieldString, replicasetName) {
+			// how to return RC as runtime.Object ? pod.DeepCopy is just a placeholder
+			return true, pod.DeepCopy(), nil
+		}
+		return true, nil, fmt.Errorf("Failed to get replicaset: %v", replicasetName)
+	})
+	actualReplicas, _ := GetPodOwnerReplicationCount(context.TODO(), fakeClient, pod.OwnerReferences[0])
+	if actualReplicas != expectedReplicaCount {
+		t.Errorf("expected %v replicas for pod owner %v, got %+v", expectedReplicaCount, replicasetName, actualReplicas)
+	}
+}
+
+func TestGetPodOwnerReplicationControllerReplicaCount(t *testing.T) {
+	t.SkipNow()
+	pod := test.BuildTestPod("pod1", 100, 0, "n1", nil)
+	rcOwnerName := "replicationcontroller-1"
+	expectedReplicaCount := 3
+
+	test.BuildTestReplicaSet(rcOwnerName, 3)
+	ownerRef1 := test.GetReplicationControllerOwnerRefList()
+	pod.ObjectMeta.OwnerReferences = ownerRef1
+
+	fakeClient := &fake.Clientset{}
+	fakeClient.Fake.AddReactor("get", "replicationcontrollers", func(action core.Action) (bool, runtime.Object, error) {
+		name := action.(core.GetAction)
+		fieldString := name.GetName()
+		if strings.Contains(fieldString, rcOwnerName) {
+			// how to return RC as runtime.Object ? pod.DeepCopy is just a placeholder
+			return true, pod.DeepCopy(), nil
+		}
+		return true, nil, fmt.Errorf("Failed to get replication controller: %v", rcOwnerName)
+	})
+	actualReplicas, _ := GetPodOwnerReplicationCount(context.TODO(), fakeClient, pod.OwnerReferences[0])
+	if actualReplicas != expectedReplicaCount {
+		t.Errorf("expected %v replicas for pod owner %v, got %+v", expectedReplicaCount, rcOwnerName, actualReplicas)
+	}
+}
+
 func TestSortPodsBasedOnPriorityLowToHigh(t *testing.T) {
 	n1 := test.BuildTestNode("n1", 4000, 3000, 9, nil)
 

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -75,7 +75,9 @@ func RemoveDuplicatePods(
 			if hasExcludedOwnerRefKind(ownerRefList, strategy) {
 				continue
 			}
-			for _, ownerRef := range pod.OwnerReferences {
+
+			podContainerKeys := make([]string, 0, len(ownerRefList)*len(pod.Spec.Containers))
+			for _, ownerRef := range ownerRefList {
 				var err error
 				replicaCount, ok := ownerReplicationCounter[ownerRef.Name]
 				if !ok {
@@ -91,10 +93,6 @@ func RemoveDuplicatePods(
 				if replicaCount > totalNodes {
 					continue PodLoop
 				}
-			}
-
-			podContainerKeys := make([]string, 0, len(ownerRefList)*len(pod.Spec.Containers))
-			for _, ownerRef := range ownerRefList {
 				for _, container := range pod.Spec.Containers {
 					// Namespace/Kind/Name should be unique for the cluster.
 					// We also consider the image, as 2 pods could have the same owner but serve different purposes

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -83,7 +83,7 @@ func RemoveDuplicatePods(
 				if !ok {
 					replicaCount, err = podutil.GetPodOwnerReplicationCount(ctx, client, ownerRef)
 					if err != nil {
-						klog.Errorf("Error retreiving owner replica count %s", ownerRef.Name)
+						klog.Errorf("Error retreiving replica count for owner %s of %s pod in %s namespace", ownerRef.Name, pod.Name, pod.Namespace)
 						continue
 					}
 					ownerReplicationCounter[ownerRef.Name] = replicaCount
@@ -91,6 +91,7 @@ func RemoveDuplicatePods(
 				// If required replicas of the managing owner is greater than available nodes, pods will be duplicated
 				// and shouldnt not be considered for eviction
 				if replicaCount > totalNodes {
+					klog.V(4).Infof("Replication factor of %s pod's owner in namespace %s greater than available nodes. Pod won't be evicted", pod.Name, pod.Namespace)
 					continue PodLoop
 				}
 				for _, container := range pod.Spec.Containers {

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -69,28 +69,13 @@ func RemoveDuplicatePods(
 		// If any of the existing lists for that first key matches the current pod's list, the current pod is a duplicate.
 		// If not, then we add this pod's list to the list of lists for that key.
 		duplicateKeysMap := map[string][][]string{}
-	PodLoop:
 		for _, pod := range pods {
 			ownerRefList := podutil.OwnerRef(pod)
 			if hasExcludedOwnerRefKind(ownerRefList, strategy) {
 				continue
 			}
-			for _, ownerRef := range pod.OwnerReferences {
-				var err error
-				replicaCount, ok := ownerReplicationCounter[ownerRef.Name]
-				if !ok {
-					replicaCount, err = podutil.GetPodOwnerReplicationCount(ctx, client, ownerRef)
-					if err != nil {
-						klog.Errorf("Error retreiving owner replica count %s", ownerRef.Name)
-						continue
-					}
-					ownerReplicationCounter[ownerRef.Name] = replicaCount
-				}
-				// If required replicas of the managing owner is greater than available nodes, pods will be duplicated
-				// and shouldnt not be considered for eviction
-				if replicaCount > totalNodes {
-					continue PodLoop
-				}
+			if isOwnerReplMoreThanNodes(ownerRefList, ownerReplicationCounter, ctx, client, totalNodes) {
+				continue
 			}
 
 			podContainerKeys := make([]string, 0, len(ownerRefList)*len(pod.Spec.Containers))
@@ -128,6 +113,31 @@ func RemoveDuplicatePods(
 			}
 		}
 	}
+}
+
+func isOwnerReplMoreThanNodes(ownerRefs []metav1.OwnerReference,
+	ownerReplicationCounter map[string]int,
+	ctx context.Context,
+	client clientset.Interface,
+	totalNodes int) bool {
+	for _, ownerRef := range ownerRefs {
+		var err error
+		replicaCount, ok := ownerReplicationCounter[ownerRef.Name]
+		if !ok {
+			replicaCount, err = podutil.GetPodOwnerReplicationCount(ctx, client, ownerRef)
+			if err != nil {
+				klog.Errorf("Error retrieving owner replica count %s", ownerRef.Name)
+				continue
+			}
+			ownerReplicationCounter[ownerRef.Name] = replicaCount
+		}
+		// If required replicas of the managing owner is greater than available nodes, pods will be duplicated
+		// and should not be considered for eviction
+		if replicaCount > totalNodes {
+			return true
+		}
+	}
+	return false
 }
 
 func hasExcludedOwnerRefKind(ownerRefs []metav1.OwnerReference, strategy api.DeschedulerStrategy) bool {

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -45,7 +45,7 @@ func TestPodLifeTime(t *testing.T) {
 	p2.Namespace = "dev"
 	p2.ObjectMeta.CreationTimestamp = olderPodCreationTime
 
-	ownerRef1 := test.GetReplicaSetOwnerRefList()
+	ownerRef1 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p1.ObjectMeta.OwnerReferences = ownerRef1
 	p2.ObjectMeta.OwnerReferences = ownerRef1
 
@@ -57,7 +57,7 @@ func TestPodLifeTime(t *testing.T) {
 	p4.Namespace = "dev"
 	p4.ObjectMeta.CreationTimestamp = newerPodCreationTime
 
-	ownerRef2 := test.GetReplicaSetOwnerRefList()
+	ownerRef2 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p3.ObjectMeta.OwnerReferences = ownerRef2
 	p4.ObjectMeta.OwnerReferences = ownerRef2
 
@@ -69,7 +69,7 @@ func TestPodLifeTime(t *testing.T) {
 	p6.Namespace = "dev"
 	p6.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 605))
 
-	ownerRef3 := test.GetReplicaSetOwnerRefList()
+	ownerRef3 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p5.ObjectMeta.OwnerReferences = ownerRef3
 	p6.ObjectMeta.OwnerReferences = ownerRef3
 
@@ -81,7 +81,7 @@ func TestPodLifeTime(t *testing.T) {
 	p8.Namespace = "dev"
 	p8.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 595))
 
-	ownerRef4 := test.GetReplicaSetOwnerRefList()
+	ownerRef4 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p5.ObjectMeta.OwnerReferences = ownerRef4
 	p6.ObjectMeta.OwnerReferences = ownerRef4
 

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -19,6 +19,7 @@ package test
 import (
 	"fmt"
 
+	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,10 +73,45 @@ func GetNormalPodOwnerRefList() []metav1.OwnerReference {
 	return ownerRefList
 }
 
+// BuildTestReplicaController creates a test replication controller
+func BuildTestReplicaController(name string, replicas int) *v1.ReplicationController {
+	rc := &v1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Status: v1.ReplicationControllerStatus{
+			Replicas: int32(replicas),
+		},
+	}
+	return rc
+}
+
+// BuildTestReplicaSet creates a test replica set
+func BuildTestReplicaSet(name string, replicas int) *apps.ReplicaSet {
+	rs := &apps.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Status: apps.ReplicaSetStatus{
+			Replicas: int32(replicas),
+		},
+	}
+	return rs
+}
+
 // GetReplicaSetOwnerRefList returns the ownerRef needed for replicaset pod.
 func GetReplicaSetOwnerRefList() []metav1.OwnerReference {
 	ownerRefList := make([]metav1.OwnerReference, 0)
 	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicaSet", APIVersion: "v1", Name: "replicaset-1"})
+	return ownerRefList
+}
+
+// GetReplicationControllerOwnerRefList returns the ownerRef needed for replicationcontroller pod.
+func GetReplicationControllerOwnerRefList() []metav1.OwnerReference {
+	ownerRefList := make([]metav1.OwnerReference, 0)
+	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicationController", APIVersion: "v1", Name: "replicationcontroller-1"})
 	return ownerRefList
 }
 

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -102,9 +102,9 @@ func BuildTestReplicaSet(name string, replicas int) *apps.ReplicaSet {
 }
 
 // GetReplicaSetOwnerRefList returns the ownerRef needed for replicaset pod.
-func GetReplicaSetOwnerRefList() []metav1.OwnerReference {
+func GetReplicaSetOwnerRefList(rsName string) []metav1.OwnerReference {
 	ownerRefList := make([]metav1.OwnerReference, 0)
-	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicaSet", APIVersion: "v1", Name: "replicaset-1"})
+	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicaSet", APIVersion: "v1", Name: rsName})
 	return ownerRefList
 }
 
@@ -175,7 +175,7 @@ func MakeGuaranteedPod(pod *v1.Pod) {
 
 // SetRSOwnerRef sets the given pod's owner to ReplicaSet
 func SetRSOwnerRef(pod *v1.Pod) {
-	pod.ObjectMeta.OwnerReferences = GetReplicaSetOwnerRefList()
+	pod.ObjectMeta.OwnerReferences = GetReplicaSetOwnerRefList("replicaset-1")
 }
 
 // SetDSOwnerRef sets the given pod's owner to DaemonSet


### PR DESCRIPTION
When pods managed by `deployment/replicaset/replicationcontroller` have replica count greater than available nodes, even after descheduler evicting these pods, they will end up in the same node.
This would just run in a loop and is ineffective.

This PR checks for the owners replication factor and decides whether to consider the pod as duplicate or not.

Fixes #263 