### PR TITLE
HighNodeutilisation strategy

### DIFF
--- a/pkg/descheduler/strategies/highnodeutilization.go
+++ b/pkg/descheduler/strategies/highnodeutilization.go
@@ -19,7 +19,6 @@ package strategies
 import (
 	"context"
 	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -31,11 +30,13 @@ import (
 	"sigs.k8s.io/descheduler/pkg/utils"
 )
 
-// LowNodeUtilization evicts pods from overutilized nodes to underutilized nodes. Note that CPU/Memory requests are used
-// to calculate nodes' utilization and not the actual resource usage.
-func LowNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
-	// todo: move to config validation?
-	// TODO: May be create a struct for the strategy as well, so that we don't have to pass along the all the params?
+
+
+
+// HighNodeUtilization evicts pods from underutilized nodes. 
+// This works with the scheduler policy of MostRequestedPriority where pods will be placed in highly utilized nodes.
+// Note that CPU/Memory requests are used to calculate nodes' utilization and not the actual resource usage.
+func HighNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
 	if strategy.Params == nil || strategy.Params.NodeResourceUtilizationThresholds == nil {
 		klog.V(1).Infof("NodeResourceUtilizationThresholds not set")
 		return
@@ -44,56 +45,56 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 	thresholds := strategy.Params.NodeResourceUtilizationThresholds.Thresholds
 	targetThresholds := strategy.Params.NodeResourceUtilizationThresholds.TargetThresholds
 	if err := validateLowNodeUtilizationStrategyConfig(thresholds, targetThresholds); err != nil {
-		klog.Errorf("LowNodeUtilization config is not valid: %v", err)
+		klog.Errorf("HighNodeUtilization config is not valid: %v", err)
 		return
 	}
 	
 	setMaxValuesForMissingThresholds(thresholds, targetThresholds)
 
 	npm := createNodePodsMap(ctx, client, nodes)
-	desiredNodes, targetNodes := classifyNodesForLowUtilization(npm, thresholds, targetThresholds)
+	desiredNodes, targetNodes := classifyNodesForHighUtilization(npm, thresholds, targetThresholds)
 
-	klog.V(1).Infof("Criteria for a node under utilization: CPU: %v, Mem: %v, Pods: %v",
-		thresholds[v1.ResourceCPU], thresholds[v1.ResourceMemory], thresholds[v1.ResourcePods])
+	// klog.V(1).Infof("Criteria for a node under utilization: CPU: %v, Mem: %v, Pods: %v",
+	// 	thresholds[v1.ResourceCPU], thresholds[v1.ResourceMemory], thresholds[v1.ResourcePods])
 
-	if len(desiredNodes) == 0 {
-		klog.V(1).Infof("No node is underutilized, nothing to do here, you might tune your thresholds further")
-		return
-	}
-	klog.V(1).Infof("Total number of underutilized nodes: %v", len(desiredNodes))
+	// if len(lowNodes) == 0 {
+	// 	klog.V(1).Infof("No node is underutilized, nothing to do here, you might tune your thresholds further")
+	// 	return
+	// }
+	// klog.V(1).Infof("Total number of underutilized nodes: %v", len(lowNodes))
 
-	if len(desiredNodes) < strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes {
-		klog.V(1).Infof("number of nodes underutilized (%v) is less than NumberOfNodes (%v), nothing to do here", len(desiredNodes), strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes)
-		return
-	}
+	// if len(lowNodes) < strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes {
+	// 	klog.V(1).Infof("number of nodes underutilized (%v) is less than NumberOfNodes (%v), nothing to do here", len(lowNodes), strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes)
+	// 	return
+	// }
 
-	if len(desiredNodes) == len(nodes) {
-		klog.V(1).Infof("all nodes are underutilized, nothing to do here")
-		return
-	}
+	// if len(lowNodes) == len(nodes) {
+	// 	klog.V(1).Infof("all nodes are underutilized, nothing to do here")
+	// 	return
+	// }
 
-	if len(targetNodes) == 0 {
-		klog.V(1).Infof("all nodes are under target utilization, nothing to do here")
-		return
-	}
+	// if len(targetNodes) == 0 {
+	// 	klog.V(1).Infof("all nodes are under target utilization, nothing to do here")
+	// 	return
+	// }
 
-	klog.V(1).Infof("Criteria for a node above target utilization: CPU: %v, Mem: %v, Pods: %v",
-		targetThresholds[v1.ResourceCPU], targetThresholds[v1.ResourceMemory], targetThresholds[v1.ResourcePods])
-	klog.V(1).Infof("Total number of nodes above target utilization: %v", len(targetNodes))
+	// klog.V(1).Infof("Criteria for a node above target utilization: CPU: %v, Mem: %v, Pods: %v",
+	// 	targetThresholds[v1.ResourceCPU], targetThresholds[v1.ResourceMemory], targetThresholds[v1.ResourcePods])
+	// klog.V(1).Infof("Total number of nodes above target utilization: %v", len(targetNodes))
 
-	evictPodsFromHighUsageTargetNodes(
+	evictPodsFromLowUsageTargetNodes(
 		ctx,
 		targetNodes,
 		desiredNodes,
-		targetThresholds,
+		thresholds,
 		podEvictor)
 
 	klog.V(1).Infof("Total number of pods evicted: %v", podEvictor.TotalEvicted())
 }
 
-// classifyNodes classifies the nodes into low-utilization or high-utilization nodes. If a node lies between
-// low and high thresholds, it is simply ignored.
-func classifyNodesForLowUtilization(npm NodePodsMap, thresholds api.ResourceThresholds, targetThresholds api.ResourceThresholds) ([]NodeUsageMap, []NodeUsageMap) {
+
+// classifyNodesForHighUtilization classifies the nodes into low-utilization or target nodes. 
+func classifyNodesForHighUtilization(npm NodePodsMap, thresholds api.ResourceThresholds, targetThresholds api.ResourceThresholds) ([]NodeUsageMap, []NodeUsageMap) {
 	desiredNodes, targetNodes := []NodeUsageMap{}, []NodeUsageMap{}
 	for node, pods := range npm {
 		usage := nodeUtilization(node, pods)
@@ -102,41 +103,40 @@ func classifyNodesForLowUtilization(npm NodePodsMap, thresholds api.ResourceThre
 			usage:   usage,
 			allPods: pods,
 		}
-		// Check if node is underutilized and if we can schedule pods on it.
-		if !nodeutil.IsNodeUnschedulable(node) && isNodeBelowThresholdUtilization(usage, thresholds) {
+		if isNodeBelowThresholdUtilization(usage, targetThresholds) {
 			klog.V(2).Infof("Node %#v is under utilized with usage: %#v", node.Name, usage)
-			desiredNodes = append(desiredNodes, nuMap)
-		} else if isNodeAboveThresholdUtilization(usage, targetThresholds) {
-			klog.V(2).Infof("Node %#v is over utilized with usage: %#v", node.Name, usage)
 			targetNodes = append(targetNodes, nuMap)
+		} else if !nodeutil.IsNodeUnschedulable(node) && 
+		!isNodeAboveThresholdUtilization(usage, thresholds) && 
+		!isNodeBelowThresholdUtilization(usage, targetThresholds) {
+			klog.V(2).Infof("Node %#v is utilized with usage: %#v", node.Name, usage)
+			desiredNodes = append(desiredNodes, nuMap)
 		} else {
-			klog.V(2).Infof("Node %#v is appropriately utilized with usage: %#v", node.Name, usage)
+			klog.V(2).Infof("Node %#v is over utilized with usage: %#v", node.Name, usage)
 		}
+		
 	}
 	return desiredNodes, targetNodes
 }
 
 // evictPodsFromTargetNodes evicts pods based on priority, if all the pods on the node have priority, if not
 // evicts them based on QoS as fallback option.
-func evictPodsFromHighUsageTargetNodes(
+func evictPodsFromLowUsageTargetNodes(
 	ctx context.Context,
 	targetNodes, desiredNodes []NodeUsageMap,
-	targetThresholds api.ResourceThresholds,
+	thresholds api.ResourceThresholds,
 	podEvictor *evictions.PodEvictor,
 ) {
 
-	sortNodesByUsage(targetNodes, true)
+	sortNodesByUsage(targetNodes, false)
 
 	// upper bound on total number of pods/cpu/memory to be moved
-	totalPods, totalCPU, totalMem, taintsOfDesiredNodes := computeDesiredNodeResourcesAndTaints(desiredNodes, targetThresholds)
+	totalPods, totalCPU, totalMem, taintsOfDesiredNodes := computeDesiredNodeResourcesAndTaints(desiredNodes, thresholds)
+	
 	klog.V(1).Infof("Total capacity to be moved: CPU:%v, Mem:%v, Pods:%v", totalCPU, totalMem, totalPods)
 	klog.V(1).Infof("********Number of pods evicted from each node:***********")
 
 	for _, node := range targetNodes {
-		nodeCapacity := node.node.Status.Capacity
-		if len(node.node.Status.Allocatable) > 0 {
-			nodeCapacity = node.node.Status.Allocatable
-		}
 		klog.V(3).Infof("evicting pods from node %#v with usage: %#v", node.node.Name, node.usage)
 
 		nonRemovablePods, removablePods := classifyPods(node.allPods, podEvictor)
@@ -150,27 +150,23 @@ func evictPodsFromHighUsageTargetNodes(
 		klog.V(1).Infof("evicting pods based on priority, if they have same priority, they'll be evicted based on QoS tiers")
 		// sort the evictable Pods based on priority. This also sorts them based on QoS. If there are multiple pods with same priority, they are sorted based on QoS tiers.
 		podutil.SortPodsBasedOnPriorityLowToHigh(removablePods)
-		evictPodsFromHighUsageNode(ctx, removablePods, targetThresholds, nodeCapacity, node.usage, &totalPods, &totalCPU, &totalMem, taintsOfDesiredNodes, podEvictor, node.node)
+		evictPodsFromLowUsageNode(ctx, removablePods, &totalPods, &totalCPU, &totalMem, taintsOfDesiredNodes, podEvictor, node.node)
 
 		klog.V(1).Infof("%v pods evicted from node %#v with usage %v", podEvictor.NodeEvicted(node.node), node.node.Name, node.usage)
 	}
 }
 
-func evictPodsFromHighUsageNode(
+func evictPodsFromLowUsageNode(
 	ctx context.Context,
 	inputPods []*v1.Pod,
-	targetThresholds api.ResourceThresholds,
-	nodeCapacity v1.ResourceList,
-	nodeUsage api.ResourceThresholds,
 	totalPods *float64,
 	totalCPU *float64,
 	totalMem *float64,
 	taintsOfDesiredNodes map[string][]v1.Taint,
 	podEvictor *evictions.PodEvictor,
 	node *v1.Node) {
-	// stop if node utilization drops below target threshold or any of required capacity (cpu, memory, pods) is moved
-	if isNodeAboveThresholdUtilization(nodeUsage, targetThresholds) && *totalPods > 0 && *totalCPU > 0 && *totalMem > 0 {
-		onePodPercentage := api.Percentage((float64(1) * 100) / float64(nodeCapacity.Pods().Value()))
+	// stop if any of required capacity (cpu, memory, pods) is moved
+	if *totalPods > 0 && *totalCPU > 0 && *totalMem > 0 {
 		for _, pod := range inputPods {
 			if !utils.PodToleratesTaints(pod, taintsOfDesiredNodes) {
 				klog.V(3).Infof("Skipping eviction for Pod: %#v, doesn't tolerate node taint", pod.Name)
@@ -188,21 +184,13 @@ func evictPodsFromHighUsageNode(
 
 			if success {
 				klog.V(3).Infof("Evicted pod: %#v", pod.Name)
-				// update remaining pods
-				nodeUsage[v1.ResourcePods] -= onePodPercentage
+				// update remaining pods, cpu, memory
 				*totalPods--
-
-				// update remaining cpu
 				*totalCPU -= float64(cUsage)
-				nodeUsage[v1.ResourceCPU] -= api.Percentage((float64(cUsage) * 100) / float64(nodeCapacity.Cpu().MilliValue()))
-
-				// update remaining memory
 				*totalMem -= float64(mUsage)
-				nodeUsage[v1.ResourceMemory] -= api.Percentage(float64(mUsage) / float64(nodeCapacity.Memory().Value()) * 100)
-
-				klog.V(3).Infof("updated node usage: %#v", nodeUsage)
-				// check if node utilization drops below target threshold or any required capacity (cpu, memory, pods) is moved
-				if !isNodeAboveThresholdUtilization(nodeUsage, targetThresholds) || *totalPods <= 0 || *totalCPU <= 0 || *totalMem <= 0 {
+				// check if any required capacity (cpu, memory, pods) is moved
+				if *totalPods <= 0 || *totalCPU <= 0 || *totalMem <= 0 {
+					klog.V(3).Infof("Required threshold scheduled. No more pods can be evicted")
 					break
 				}
 			}
@@ -210,7 +198,8 @@ func evictPodsFromHighUsageNode(
 	}
 }
 
-func validateLowNodeUtilizationStrategyConfig(thresholds, targetThresholds api.ResourceThresholds) error{
+
+func validateHighNodeUtilizationStrategyConfig(thresholds, targetThresholds api.ResourceThresholds) error{
 	if err := validateStrategyConfig(thresholds, targetThresholds); err != nil {
 		return err
 	}
@@ -218,9 +207,11 @@ func validateLowNodeUtilizationStrategyConfig(thresholds, targetThresholds api.R
 	for resourceName, value := range thresholds {
 		if targetValue, ok := targetThresholds[resourceName]; !ok {
 			return fmt.Errorf("thresholds and targetThresholds configured different resources")
-		} else if value > targetValue {
+		} else if value < targetValue {
 			return fmt.Errorf("thresholds' %v percentage is greater than targetThresholds'", resourceName)
 		}
 	}
 	return nil
 }
+
+

--- a/pkg/descheduler/strategies/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/highnodeutilization_test.go
@@ -1,0 +1,537 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategies
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
+	"sigs.k8s.io/descheduler/pkg/utils"
+	"sigs.k8s.io/descheduler/test"
+)
+
+func TestHighNodeUtilization(t *testing.T) {
+	ctx := context.Background()
+	n1NodeName := "n1"
+	n2NodeName := "n2"
+	n3NodeName := "n3"
+
+	testCases := []struct {
+		name                         string
+		thresholds, targetThresholds api.ResourceThresholds
+		nodes                        map[string]*v1.Node
+		pods                         map[string]*v1.PodList
+		// TODO: divide expectedPodsEvicted into two params like other tests
+		// expectedPodsEvicted should be the result num of pods that this testCase expected but now it represents both
+		// MaxNoOfPodsToEvictPerNode and the test's expected result
+		expectedPodsEvicted int
+		evictedPods         []string
+	}{
+		{
+			name: "no eviction - nodes above target thresholds",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  80,
+				v1.ResourcePods: 80,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  20,
+				v1.ResourcePods: 20,
+			},
+			nodes: map[string]*v1.Node{
+				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
+				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
+			},
+			pods: map[string]*v1.PodList{
+				n1NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p1", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p4", 400, 0, n1NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n2NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p9", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p10", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p11", 400, 0, n2NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n3NodeName: {},
+			},
+			expectedPodsEvicted: 0,
+		},
+		{
+			name: "evict only evictable pods",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  80,
+				v1.ResourcePods: 80,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  50,
+				v1.ResourcePods: 50,
+			},
+			nodes: map[string]*v1.Node{
+				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
+				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
+			},
+			pods: map[string]*v1.PodList{
+				n1NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p1", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 0, n1NodeName, test.SetDSOwnerRef),
+						*test.BuildTestPod("p4", 400, 0, n1NodeName, test.SetDSOwnerRef),
+						*test.BuildTestPod("p5", 400, 0, n1NodeName, test.SetDSOwnerRef),
+					},
+				},
+				n2NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p6", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						// This wont be evicted
+						*test.BuildTestPod("p7", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							// A pod with local storage.
+							test.SetNormalOwnerRef(pod)
+							pod.Spec.Volumes = []v1.Volume{
+								{
+									Name: "sample",
+									VolumeSource: v1.VolumeSource{
+										HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
+										EmptyDir: &v1.EmptyDirVolumeSource{
+											SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+									},
+								},
+							}
+							// A Mirror Pod.
+							pod.Annotations = test.GetMirrorPodAnnotation()
+						}),
+						// This wont be evicted
+						*test.BuildTestPod("p8", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							// A Critical Pod.
+							pod.Namespace = "kube-system"
+							priority := utils.SystemCriticalPriority
+							pod.Spec.Priority = &priority
+						}),
+					},
+				},
+				n3NodeName: {},
+			},
+			expectedPodsEvicted: 1,
+			evictedPods:         []string{"p6"},
+		},
+		{
+			name: "without priorities stop when cpu capacity is depleted",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  80,
+				v1.ResourcePods: 80,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  50,
+				v1.ResourcePods: 50,
+			},
+			nodes: map[string]*v1.Node{
+				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
+				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
+			},
+			pods: map[string]*v1.PodList{
+				n1NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p1", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p4", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p5", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p6", 400, 300, n1NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n2NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p7", 400, 300, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p8", 400, 300, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 300, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p10", 400, 300, n2NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n3NodeName: {},
+			},
+			// 4 pods available for eviction based on v1.ResourcePods, only 2 pods can be evicted before cpu is depleted
+			expectedPodsEvicted: 2,
+			evictedPods:         []string{"p7", "p8"},
+		},
+		{
+			name: "without priorities stop when memory capacity is depleted",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  80,
+				v1.ResourcePods: 80,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  50,
+				v1.ResourcePods: 50,
+			},
+			nodes: map[string]*v1.Node{
+				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
+				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
+			},
+			pods: map[string]*v1.PodList{
+				n1NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p1", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p4", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p5", 400, 300, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p6", 400, 300, n1NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n2NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p7", 400, 500, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p8", 400, 300, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 300, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p10", 400, 300, n2NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n3NodeName: {},
+			},
+			// 4 pods available for eviction based on v1.ResourcePods, only 1 pods can be evicted before cpu is depleted
+			expectedPodsEvicted: 1,
+			evictedPods:         []string{"p7"},
+		},
+		{
+			name: "with priorities",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  80,
+				v1.ResourcePods: 80,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  50,
+				v1.ResourcePods: 50,
+			},
+			nodes: map[string]*v1.Node{
+				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
+				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
+			},
+			pods: map[string]*v1.PodList{
+				n1NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p1", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p4", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p5", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p6", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p7", 400, 0, n2NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n2NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p8", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							test.SetRSOwnerRef(pod)
+							test.SetPodPriority(pod, int32(10000))
+						}),
+						*test.BuildTestPod("p9", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							test.SetRSOwnerRef(pod)
+							test.SetPodPriority(pod, int32(0))
+						}),
+						//This wont be evicted
+						*test.BuildTestPod("p10", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							// A pod with local storage.
+							test.SetNormalOwnerRef(pod)
+							test.SetPodPriority(pod, int32(0))
+							pod.Spec.Volumes = []v1.Volume{
+								{
+									Name: "sample",
+									VolumeSource: v1.VolumeSource{
+										HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
+										EmptyDir: &v1.EmptyDirVolumeSource{
+											SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+									},
+								},
+							}
+							// A Mirror Pod.
+							pod.Annotations = test.GetMirrorPodAnnotation()
+						}),
+						//This wont be evicted
+						*test.BuildTestPod("p11", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							// A Critical Pod.
+							pod.Namespace = "kube-system"
+							priority := utils.SystemCriticalPriority
+							pod.Spec.Priority = &priority
+						}),
+					},
+				},
+				n3NodeName: {},
+			},
+			expectedPodsEvicted: 1,
+			evictedPods:         []string{"p9"},
+		},
+		{
+			name: "without priorities evicting best-effort pods only",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  80,
+				v1.ResourcePods: 80,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  50,
+				v1.ResourcePods: 50,
+			},
+			nodes: map[string]*v1.Node{
+				n1NodeName: test.BuildTestNode(n1NodeName, 4000, 3000, 9, nil),
+				n2NodeName: test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+				n3NodeName: test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
+			},
+			// All pods are assumed to be burstable (test.BuildTestNode always sets both cpu/memory resource requests to some value)
+			pods: map[string]*v1.PodList{
+				n1NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p1", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p2", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p3", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p4", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p5", 400, 0, n2NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p6", 400, 0, n2NodeName, test.SetRSOwnerRef),
+					},
+				},
+				n2NodeName: {
+					Items: []v1.Pod{
+						*test.BuildTestPod("p7", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							test.SetRSOwnerRef(pod)
+							test.MakeBestEffortPod(pod)
+						}),
+						*test.BuildTestPod("p8", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							test.SetRSOwnerRef(pod)
+							test.MakeBestEffortPod(pod)
+						}),
+						*test.BuildTestPod("p9", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							test.SetRSOwnerRef(pod)
+							test.MakeBurstablePod(pod)
+						}),
+						//This wont be evicted
+						*test.BuildTestPod("p10", 400, 0, n1NodeName, func(pod *v1.Pod) {
+							// A Critical Pod.
+							pod.Namespace = "kube-system"
+							priority := utils.SystemCriticalPriority
+							pod.Spec.Priority = &priority
+						}),
+					},
+				},
+				n3NodeName: {},
+			},
+			expectedPodsEvicted: 2,
+			evictedPods:         []string{"p7", "p8"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := &fake.Clientset{}
+			fakeClient.Fake.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+				list := action.(core.ListAction)
+				fieldString := list.GetListRestrictions().Fields.String()
+				if strings.Contains(fieldString, n1NodeName) {
+					return true, test.pods[n1NodeName], nil
+				}
+				if strings.Contains(fieldString, n2NodeName) {
+					return true, test.pods[n2NodeName], nil
+				}
+				if strings.Contains(fieldString, n3NodeName) {
+					return true, test.pods[n3NodeName], nil
+				}
+				return true, nil, fmt.Errorf("Failed to list: %v", list)
+			})
+			fakeClient.Fake.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+				getAction := action.(core.GetAction)
+				if node, exists := test.nodes[getAction.GetName()]; exists {
+					return true, node, nil
+				}
+				return true, nil, fmt.Errorf("Wrong node: %v", getAction.GetName())
+			})
+			podsForEviction := make(map[string]struct{})
+			for _, pod := range test.evictedPods {
+				podsForEviction[pod] = struct{}{}
+			}
+
+			evictionFailed := false
+			if len(test.evictedPods) > 0 {
+				fakeClient.Fake.AddReactor("create", "pods", func(action core.Action) (bool, runtime.Object, error) {
+					getAction := action.(core.CreateAction)
+					obj := getAction.GetObject()
+					if eviction, ok := obj.(*v1beta1.Eviction); ok {
+						if _, exists := podsForEviction[eviction.Name]; exists {
+							return true, obj, nil
+						}
+						evictionFailed = true
+						return true, nil, fmt.Errorf("pod %q was unexpectedly evicted", eviction.Name)
+					}
+					return true, obj, nil
+				})
+			}
+
+			var nodes []*v1.Node
+			for _, node := range test.nodes {
+				nodes = append(nodes, node)
+			}
+
+			podEvictor := evictions.NewPodEvictor(
+				fakeClient,
+				"v1",
+				false,
+				test.expectedPodsEvicted,
+				nodes,
+				false,
+			)
+
+			strategy := api.DeschedulerStrategy{
+				Enabled: true,
+				Params: &api.StrategyParameters{
+					NodeResourceUtilizationThresholds: &api.NodeResourceUtilizationThresholds{
+						Thresholds:       test.thresholds,
+						TargetThresholds: test.targetThresholds,
+					},
+				},
+			}
+			HighNodeUtilization(ctx, fakeClient, strategy, nodes, podEvictor)
+
+			podsEvicted := podEvictor.TotalEvicted()
+			if test.expectedPodsEvicted != podsEvicted {
+				t.Errorf("Expected %#v pods to be evicted but %#v got evicted - %s", test.expectedPodsEvicted, podsEvicted, test.name)
+			}
+			if evictionFailed {
+				t.Errorf("Pod evictions failed unexpectedly")
+			}
+		})
+	}
+}
+
+func TestValidateHighNodeUtilizationStrategyConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		thresholds       api.ResourceThresholds
+		targetThresholds api.ResourceThresholds
+		errInfo          error
+		allow            bool
+	}{
+		{
+			name: "passing invalid thresholds",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    20,
+				v1.ResourceMemory: 120,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    80,
+				v1.ResourceMemory: 80,
+			},
+			errInfo: fmt.Errorf("thresholds config is not valid: %v", fmt.Errorf(
+				"%v threshold not in [%v, %v] range", v1.ResourceMemory, MinResourcePercentage, MaxResourcePercentage)),
+		},
+		{
+			name: "passing invalid targetThresholds",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    20,
+				v1.ResourceMemory: 20,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    80,
+				"resourceInvalid": 80,
+			},
+			errInfo: fmt.Errorf("targetThresholds config is not valid: %v",
+				fmt.Errorf("only cpu, memory, or pods thresholds can be specified")),
+		},
+		{
+			name: "thresholds and targetThresholds configured different num of resources",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    20,
+				v1.ResourceMemory: 20,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    80,
+				v1.ResourceMemory: 80,
+				v1.ResourcePods:   80,
+			},
+			errInfo: fmt.Errorf("thresholds and targetThresholds configured different resources"),
+		},
+		{
+			name: "thresholds and targetThresholds configured different resources",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    80,
+				v1.ResourceMemory: 20,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  20,
+				v1.ResourcePods: 80,
+			},
+			errInfo: fmt.Errorf("thresholds and targetThresholds configured different resources"),
+		},
+		{
+			allow: true,
+			name:  "thresholds' CPU config value is lesser than targetThresholds'",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    50,
+				v1.ResourceMemory: 20,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    80,
+				v1.ResourceMemory: 80,
+			},
+			errInfo: fmt.Errorf("thresholds' %v percentage is lesser than targetThresholds'", v1.ResourceCPU),
+		},
+		{
+			name: "passing valid strategy config",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    80,
+				v1.ResourceMemory: 80,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:    20,
+				v1.ResourceMemory: 20,
+			},
+			errInfo: nil,
+		},
+	}
+
+	for _, testCase := range tests {
+		if !testCase.allow {
+			continue
+		}
+		validateErr := validateHighNodeUtilizationStrategyConfig(testCase.thresholds, testCase.targetThresholds)
+
+		if validateErr == nil || testCase.errInfo == nil {
+			if validateErr != testCase.errInfo {
+				t.Errorf("expected validity of strategy config: thresholds %#v targetThresholds %#v\nto be %v but got %v instead",
+					testCase.thresholds, testCase.targetThresholds, testCase.errInfo, validateErr)
+			}
+		} else if validateErr.Error() != testCase.errInfo.Error() {
+			t.Errorf("expected validity of strategy config: thresholds %#v targetThresholds %#v\nto be %v but got %v instead",
+				testCase.thresholds, testCase.targetThresholds, testCase.errInfo, validateErr)
+		}
+	}
+}

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -47,7 +47,7 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		klog.Errorf("LowNodeUtilization config is not valid: %v", err)
 		return
 	}
-	
+
 	setMaxValuesForMissingThresholds(thresholds, targetThresholds)
 
 	npm := createNodePodsMap(ctx, client, nodes)
@@ -118,7 +118,7 @@ func classifyNodesForLowUtilization(npm NodePodsMap, thresholds api.ResourceThre
 
 // evictPodsFromTargetNodes evicts pods based on priority, if all the pods on the node have priority, if not
 // evicts them based on QoS as fallback option.
-func evictPodsFromHighUsageTargetNodes(
+func evictPodsFromLowUsageTargetNodes(
 	ctx context.Context,
 	targetNodes, desiredNodes []NodeUsageMap,
 	targetThresholds api.ResourceThresholds,
@@ -150,13 +150,13 @@ func evictPodsFromHighUsageTargetNodes(
 		klog.V(1).Infof("evicting pods based on priority, if they have same priority, they'll be evicted based on QoS tiers")
 		// sort the evictable Pods based on priority. This also sorts them based on QoS. If there are multiple pods with same priority, they are sorted based on QoS tiers.
 		podutil.SortPodsBasedOnPriorityLowToHigh(removablePods)
-		evictPodsFromHighUsageNode(ctx, removablePods, targetThresholds, nodeCapacity, node.usage, &totalPods, &totalCPU, &totalMem, taintsOfDesiredNodes, podEvictor, node.node)
+		evictPodsFromLowUsageNode(ctx, removablePods, targetThresholds, nodeCapacity, node.usage, &totalPods, &totalCPU, &totalMem, taintsOfDesiredNodes, podEvictor, node.node)
 
 		klog.V(1).Infof("%v pods evicted from node %#v with usage %v", podEvictor.NodeEvicted(node.node), node.node.Name, node.usage)
 	}
 }
 
-func evictPodsFromHighUsageNode(
+func evictPodsFromLowUsageNode(
 	ctx context.Context,
 	inputPods []*v1.Pod,
 	targetThresholds api.ResourceThresholds,
@@ -210,7 +210,7 @@ func evictPodsFromHighUsageNode(
 	}
 }
 
-func validateLowNodeUtilizationStrategyConfig(thresholds, targetThresholds api.ResourceThresholds) error{
+func validateLowNodeUtilizationStrategyConfig(thresholds, targetThresholds api.ResourceThresholds) error {
 	if err := validateStrategyConfig(thresholds, targetThresholds); err != nil {
 		return err
 	}

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -38,11 +38,6 @@ import (
 	"sigs.k8s.io/descheduler/test"
 )
 
-var (
-	lowPriority  = int32(0)
-	highPriority = int32(10000)
-)
-
 func TestLowNodeUtilization(t *testing.T) {
 	ctx := context.Background()
 	n1NodeName := "n1"
@@ -253,33 +248,33 @@ func TestLowNodeUtilization(t *testing.T) {
 					Items: []v1.Pod{
 						*test.BuildTestPod("p1", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							test.SetRSOwnerRef(pod)
-							test.SetPodPriority(pod, highPriority)
+							test.SetPodPriority(pod, int32(10000))
 						}),
 						*test.BuildTestPod("p2", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							test.SetRSOwnerRef(pod)
-							test.SetPodPriority(pod, highPriority)
+							test.SetPodPriority(pod, int32(10000))
 						}),
 						*test.BuildTestPod("p3", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							test.SetRSOwnerRef(pod)
-							test.SetPodPriority(pod, highPriority)
+							test.SetPodPriority(pod, int32(10000))
 						}),
 						*test.BuildTestPod("p4", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							test.SetRSOwnerRef(pod)
-							test.SetPodPriority(pod, highPriority)
+							test.SetPodPriority(pod, int32(10000))
 						}),
 						*test.BuildTestPod("p5", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							test.SetRSOwnerRef(pod)
-							test.SetPodPriority(pod, lowPriority)
+							test.SetPodPriority(pod, int32(0))
 						}),
 						// These won't be evicted.
 						*test.BuildTestPod("p6", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							test.SetDSOwnerRef(pod)
-							test.SetPodPriority(pod, highPriority)
+							test.SetPodPriority(pod, int32(10000))
 						}),
 						*test.BuildTestPod("p7", 400, 0, n1NodeName, func(pod *v1.Pod) {
 							// A pod with local storage.
 							test.SetNormalOwnerRef(pod)
-							test.SetPodPriority(pod, lowPriority)
+							test.SetPodPriority(pod, int32(0))
 							pod.Spec.Volumes = []v1.Volume{
 								{
 									Name: "sample",
@@ -469,7 +464,7 @@ func TestLowNodeUtilization(t *testing.T) {
 	}
 }
 
-func TestValidateStrategyConfig(t *testing.T) {
+func TestLowNodeUtilizationValidateStrategyConfig(t *testing.T) {
 	tests := []struct {
 		name             string
 		thresholds       api.ResourceThresholds

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -109,7 +109,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n2NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -167,7 +167,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n2NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -225,7 +225,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 2100, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 2100, n2NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -303,7 +303,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n2NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -378,7 +378,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				},
 				n2NodeName: {
 					Items: []v1.Pod{
-						*test.BuildTestPod("p9", 400, 0, n1NodeName, test.SetRSOwnerRef),
+						*test.BuildTestPod("p9", 400, 0, n2NodeName, test.SetRSOwnerRef),
 					},
 				},
 				n3NodeName: {},
@@ -554,7 +554,7 @@ func TestValidateStrategyConfig(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		validateErr := validateStrategyConfig(testCase.thresholds, testCase.targetThresholds)
+		validateErr := validateLowNodeUtilizationStrategyConfig(testCase.thresholds, testCase.targetThresholds)
 
 		if validateErr == nil || testCase.errInfo == nil {
 			if validateErr != testCase.errInfo {

--- a/pkg/descheduler/strategies/nodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategies
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
+	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/pkg/utils"
+)
+
+// NodePodsMap is a set of (node, pods) pairs
+type NodePodsMap map[*v1.Node][]*v1.Pod
+
+// NodeUsageMap stores a node's info, pods on it and its resource usage
+type NodeUsageMap struct {
+	node    *v1.Node
+	usage   api.ResourceThresholds
+	allPods []*v1.Pod
+}
+
+const (
+	// MinResourcePercentage is the minimum value of a resource's percentage
+	MinResourcePercentage = 0
+	// MaxResourcePercentage is the maximum value of a resource's percentage
+	MaxResourcePercentage = 100
+)
+
+func validateStrategyConfig(thresholds, targetThresholds api.ResourceThresholds) error {
+	// validate thresholds and targetThresholds config
+	if err := validateThresholds(thresholds); err != nil {
+		return fmt.Errorf("thresholds config is not valid: %v", err)
+	}
+	if err := validateThresholds(targetThresholds); err != nil {
+		return fmt.Errorf("targetThresholds config is not valid: %v", err)
+	}
+
+	// validate if thresholds and targetThresholds have same resources configured
+	if len(thresholds) != len(targetThresholds) {
+		return fmt.Errorf("thresholds and targetThresholds configured different resources")
+	}
+	
+	return nil
+}
+
+// validateThresholds checks if thresholds have valid resource name and resource percentage configured
+func validateThresholds(thresholds api.ResourceThresholds) error {
+	if thresholds == nil || len(thresholds) == 0 {
+		return fmt.Errorf("no resource threshold is configured")
+	}
+	for name, percent := range thresholds {
+		switch name {
+		case v1.ResourceCPU, v1.ResourceMemory, v1.ResourcePods:
+			if percent < MinResourcePercentage || percent > MaxResourcePercentage {
+				return fmt.Errorf("%v threshold not in [%v, %v] range", name, MinResourcePercentage, MaxResourcePercentage)
+			}
+		default:
+			return fmt.Errorf("only cpu, memory, or pods thresholds can be specified")
+		}
+	}
+	return nil
+}
+
+// setMaxValuesForMissingThreshold check if Pods/CPU/Mem are set, if not, set them to 100
+func setMaxValuesForMissingThresholds(thresholds, targetThresholds api.ResourceThresholds) {
+	if _, ok := thresholds[v1.ResourcePods]; !ok {
+		thresholds[v1.ResourcePods] = MaxResourcePercentage
+		targetThresholds[v1.ResourcePods] = MaxResourcePercentage
+	}
+	if _, ok := thresholds[v1.ResourceCPU]; !ok {
+		thresholds[v1.ResourceCPU] = MaxResourcePercentage
+		targetThresholds[v1.ResourceCPU] = MaxResourcePercentage
+	}
+	if _, ok := thresholds[v1.ResourceMemory]; !ok {
+		thresholds[v1.ResourceMemory] = MaxResourcePercentage
+		targetThresholds[v1.ResourceMemory] = MaxResourcePercentage
+	}
+}
+
+// createNodePodsMap returns nodepodsmap with evictable pods on node.
+func createNodePodsMap(ctx context.Context, client clientset.Interface, nodes []*v1.Node) NodePodsMap {
+	npm := NodePodsMap{}
+	for _, node := range nodes {
+		pods, err := podutil.ListPodsOnANode(ctx, client, node, nil)
+		if err != nil {
+			klog.Warningf("node %s will not be processed, error in accessing its pods (%#v)", node.Name, err)
+		} else {
+			npm[node] = pods
+		}
+	}
+	return npm
+}
+
+// isNodeBelowThresholdUtilization checks if a node is underutilized based on threshold
+func isNodeBelowThresholdUtilization(nodeThresholds api.ResourceThresholds, thresholds api.ResourceThresholds) bool {
+	for name, nodeValue := range nodeThresholds {
+		if name == v1.ResourceCPU || name == v1.ResourceMemory || name == v1.ResourcePods {
+			if value, ok := thresholds[name]; !ok {
+				continue
+			} else if nodeValue > value {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// isNodeAboveThresholdUtilization checks if a node is overutilized based on threshold
+func isNodeAboveThresholdUtilization(nodeThresholds api.ResourceThresholds, thresholds api.ResourceThresholds) bool {
+	for name, nodeValue := range nodeThresholds {
+		if name == v1.ResourceCPU || name == v1.ResourceMemory || name == v1.ResourcePods {
+			if value, ok := thresholds[name]; !ok {
+				continue
+			} else if nodeValue > value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func classifyPods(pods []*v1.Pod, evictor *evictions.PodEvictor) ([]*v1.Pod, []*v1.Pod) {
+	var nonRemovablePods, removablePods []*v1.Pod
+
+	for _, pod := range pods {
+		if !evictor.IsEvictable(pod) {
+			nonRemovablePods = append(nonRemovablePods, pod)
+		} else {
+			removablePods = append(removablePods, pod)
+		}
+	}
+
+	return nonRemovablePods, removablePods
+}
+
+// sortNodesByUsage sorts nodes based on usage in descending order
+func sortNodesByUsage(nodes []NodeUsageMap, descending bool) {
+	sort.Slice(nodes, func(i, j int) bool {
+		var ti, tj api.Percentage
+		for name, value := range nodes[i].usage {
+			if name == v1.ResourceCPU || name == v1.ResourceMemory || name == v1.ResourcePods {
+				ti += value
+			}
+		}
+		for name, value := range nodes[j].usage {
+			if name == v1.ResourceCPU || name == v1.ResourceMemory || name == v1.ResourcePods {
+				tj += value
+			}
+		}
+		if descending {
+			return ti > tj
+		} 
+		return ti < tj
+	})
+}
+
+func computeDesiredNodeResourcesAndTaints(desiredNodes []NodeUsageMap,
+	thresholds api.ResourceThresholds) (float64,float64,float64, map[string][]v1.Taint){
+	var totalPods, totalCPU, totalMem float64
+	var taintsOfDesiredNodes = make(map[string][]v1.Taint, len(desiredNodes))
+	for _, node := range desiredNodes {
+		taintsOfDesiredNodes[node.node.Name] = node.node.Spec.Taints
+		nodeCapacity := node.node.Status.Capacity
+		if len(node.node.Status.Allocatable) > 0 {
+			nodeCapacity = node.node.Status.Allocatable
+		}
+		// totalPods to be moved
+		podsPercentage := thresholds[v1.ResourcePods] - node.usage[v1.ResourcePods]
+		totalPods += ((float64(podsPercentage) * float64(nodeCapacity.Pods().Value())) / 100)
+
+		// totalCPU capacity to be moved
+		cpuPercentage := thresholds[v1.ResourceCPU] - node.usage[v1.ResourceCPU]
+		totalCPU += ((float64(cpuPercentage) * float64(nodeCapacity.Cpu().MilliValue())) / 100)
+
+		// totalMem capacity to be moved
+		memPercentage := thresholds[v1.ResourceMemory] - node.usage[v1.ResourceMemory]
+		totalMem += ((float64(memPercentage) * float64(nodeCapacity.Memory().Value())) / 100)
+	}
+	return totalPods, totalCPU, totalMem, taintsOfDesiredNodes
+}
+
+func nodeUtilization(node *v1.Node, pods []*v1.Pod) api.ResourceThresholds {
+	totalReqs := map[v1.ResourceName]*resource.Quantity{
+		v1.ResourceCPU:    {},
+		v1.ResourceMemory: {},
+	}
+	for _, pod := range pods {
+		req, _ := utils.PodRequestsAndLimits(pod)
+		for name, quantity := range req {
+			if name == v1.ResourceCPU || name == v1.ResourceMemory {
+				// As Quantity.Add says: Add adds the provided y quantity to the current value. If the current value is zero,
+				// the format of the quantity will be updated to the format of y.
+				totalReqs[name].Add(quantity)
+			}
+		}
+	}
+
+	nodeCapacity := node.Status.Capacity
+	if len(node.Status.Allocatable) > 0 {
+		nodeCapacity = node.Status.Allocatable
+	}
+
+	totalPods := len(pods)
+	return api.ResourceThresholds{
+		v1.ResourceCPU:    api.Percentage((float64(totalReqs[v1.ResourceCPU].MilliValue()) * 100) / float64(nodeCapacity.Cpu().MilliValue())),
+		v1.ResourceMemory: api.Percentage(float64(totalReqs[v1.ResourceMemory].Value()) / float64(nodeCapacity.Memory().Value()) * 100),
+		v1.ResourcePods:   api.Percentage((float64(totalPods) * 100) / float64(nodeCapacity.Pods().Value())),
+	}
+}

--- a/pkg/descheduler/strategies/nodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization.go
@@ -62,7 +62,7 @@ func validateStrategyConfig(thresholds, targetThresholds api.ResourceThresholds)
 	if len(thresholds) != len(targetThresholds) {
 		return fmt.Errorf("thresholds and targetThresholds configured different resources")
 	}
-	
+
 	return nil
 }
 
@@ -172,13 +172,13 @@ func sortNodesByUsage(nodes []NodeUsageMap, descending bool) {
 		}
 		if descending {
 			return ti > tj
-		} 
+		}
 		return ti < tj
 	})
 }
 
 func computeDesiredNodeResourcesAndTaints(desiredNodes []NodeUsageMap,
-	thresholds api.ResourceThresholds) (float64,float64,float64, map[string][]v1.Taint){
+	thresholds api.ResourceThresholds) (float64, float64, float64, map[string][]v1.Taint) {
 	var totalPods, totalCPU, totalMem float64
 	var taintsOfDesiredNodes = make(map[string][]v1.Taint, len(desiredNodes))
 	for _, node := range desiredNodes {


### PR DESCRIPTION
Adding HighNodeutilisation strategy. Accepts `threshold` and `targetThreshold` as parameter configs.
Eliminate pods from nodes under `targetThreshold` and places them in nodes between `threshold` and `targetThreshold`. 
This works in tandem in scheduler config of `MostRequestedPriority` such that pods are placed in nodes with high utilization.

Functions common to High and LowNode Utilization strategies have been extracted to a seperate file.


Pending
1. E2E tests
2. Docs update
3. Config updates

Fixes #196 