### PR TITLE
Move kind setup to e2e script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ push: push-container-to-gcloud
 clean:
 	rm -rf _output
 
+verify: verify-gofmt verify-vendor lint
+
+verify-gofmt:
+	./hack/verify-gofmt.sh
+
+verify-vendor:
+	./hack/verify-vendor.sh
+
 test-unit:
 	./test/run-unit-tests.sh
 
@@ -76,6 +84,6 @@ gen:
 	go mod tidy
 lint:
 ifndef HAS_GOLANGCI
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin ${GOLANGCI_VERSION}
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ./_output/bin ${GOLANGCI_VERSION}
 endif
-	golangci-lint run
+	./_output/bin/golangci-lint run

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -15,5 +15,22 @@
 #!/bin/bash
 
 # This just run e2e tests.
+if [ -n "$KIND_E2E" ]; then
+    K8S_VERSION=${KUBERNETES_VERSION:-v1.18.2}
+    curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+    wget https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64
+    chmod +x kind-linux-amd64
+    mv kind-linux-amd64 kind
+    export PATH=$PATH:$PWD
+    kind create cluster --image kindest/node:${K8S_VERSION} --config=./hack/kind_config.yaml
+    export KUBECONFIG="$(kind get kubeconfig-path)"
+    docker pull kubernetes/pause
+    kind load docker-image kubernetes/pause
+    kind get kubeconfig > /tmp/admin.conf
+    export KUBECONFIG="/tmp/admin.conf"
+    mkdir -p ~/gopath/src/sigs.k8s.io/
+    mv ~/gopath/src/github.com/kubernetes-sigs/descheduler ~/gopath/src/sigs.k8s.io/.
+fi
+
 PRJ_PREFIX="sigs.k8s.io/descheduler"
 go test ${PRJ_PREFIX}/test/e2e/ -v


### PR DESCRIPTION
This moves the kind setup (previously used by Travis) to the e2e runner script
to accomodate the switch to Prow. This provides a KIND_E2E env var to specify
whether to run the tests in kind, or (by default) to run locally).

Backporting https://github.com/kubernetes-sigs/descheduler/pull/340