### PR TITLE
Update Release Documentation For Helm Charts

### DIFF
--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: descheduler
-version: 1.0.0
+version: 0.18.0
 appVersion: 0.18.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -1,6 +1,8 @@
 # Release Guide
 
-## Semi-automatic
+## Container Image
+
+### Semi-automatic
 
 1. Make sure your repo is clean by git's standards
 2. Create a release branch `git checkout -b release-1.18` (not required for patch releases)
@@ -11,7 +13,7 @@
 7. Publish release
 8. Email `kubernetes-sig-scheduling@googlegroups.com` to announce the release
 
-## Manual
+### Manual
 
 1. Make sure your repo is clean by git's standards
 2. Create a release branch `git checkout -b release-1.18` (not required for patch releases)
@@ -24,7 +26,7 @@
 9. Publish release
 10. Email `kubernetes-sig-scheduling@googlegroups.com` to announce the release
 
-## Notes
+### Notes
 See [post-descheduler-push-images dashboard](https://testgrid.k8s.io/sig-scheduling#post-descheduler-push-images) for staging registry image build job status.
 
 View the descheduler staging registry using [this URL](https://console.cloud.google.com/gcr/images/k8s-staging-descheduler/GLOBAL/descheduler) in a web browser
@@ -49,3 +51,19 @@ Pull image from the staging registry.
 ```
 docker pull gcr.io/k8s-staging-descheduler/descheduler:v20200206-0.9.0-94-ge2a23f284
 ```
+
+## Helm Chart
+Helm chart releases are managed by a separate set of git tags that are prefixed with `chart-*`. Example git tag name is `chart-0.18.0`. Released versions of the
+helm charts are stored in the `gh-pages` branch of this repo. The [chart-releaser-action GitHub Action](https://github.com/helm/chart-releaser-action) is setup to
+build and push the helm charts to the `gh-pages` branch when a `chart-*` git tag is created.
+
+The major and minor version of the chart matches the descheduler major and minor versions. For example descheduler helm chart version chart-0.18.0 corresponds
+to descheduler version v0.18.0. The patch version of the descheduler helm chart and the patcher version of the descheduler will not necessarily match. The patch
+version of the descheduler helm chart is used to version changes specific to the helm chart.
+
+1. Merge all helm chart changes into the appropriate release branch(i.e. release-1.18)
+   1. Ensure that `appVersion` in file `charts/descheduler/Chart.yaml` matches the descheduler version(no `v` prefix)
+   2. Ensure that `version` in file `charts/descheduler/Chart.yaml` has been incremented. This is the chart version.
+2. Make sure your repo is clean by git's standards
+3. Create the tag and push it `git checkout release-1.18; CHART_VERSION=chart-0.18.0; git tag $CHART_VERSION; git push origin $CHART_VERSION`
+4. Verify the new helm artifact has been successfully pushed to the `gh-pages` branch


### PR DESCRIPTION
The descheduler now has an official helm chart. This change documents the
process to release a new helm chart artifact.