### PR TITLE
Bump Helm chart to version 0.18.1

### DIFF
--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: descheduler
-version: 0.18.0
+version: 0.18.1
 appVersion: 0.18.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:


### PR DESCRIPTION
This still represents Descheduler v0.18.0, but this is to make a small change
in order to try triggering the Helm chart-releaser action.