### PR TITLE
Add NPD+CA autohealing use case to user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -88,3 +88,12 @@ strategies:
     params:
       maxPodLifeTimeSeconds: 604800 # pods run for a maximum of 7 days
 ```
+
+### Autoheal Node Problems
+Descheduler's `RemovePodsViolatingNodeTaints` strategy can be combined with 
+[Node Problem Detector](https://github.com/kubernetes/node-problem-detector/) and
+[Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to automatically remove
+Nodes which have problems. Node Problem Detector can detect specific Node problems and taint any Nodes which have those
+problems. The Descheduler will then deschedule workloads from those Nodes. Finally, if the descheduled Node's resource 
+allocation falls below the Cluster Autoscaler's scale down threshold, the Node will become a scale down candidate
+and can be removed by Cluster Autoscaler. These three components form an autohealing cycle for Node problems.


### PR DESCRIPTION
Add documentation on combining descheduler, NPD and CA to autoheal Node problems. This is a real-world use case in production at my organization. We have even written some custom NPD plugins specific to our internal infrastructure and observed those problems be autohealed with this setup.