### PR TITLE
Update version parsing to exclude helm-chart tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 .PHONY: test
 
 # VERSION is currently based on the last commit
-VERSION?=$(shell git describe --tags)
+VERSION?=$(shell git describe --tags --match "v*")
 COMMIT=$(shell git rev-parse HEAD)
 BUILD=$(shell date +%FT%T%z)
 LDFLAG_LOCATION=sigs.k8s.io/descheduler/cmd/descheduler/app


### PR DESCRIPTION
With the new Helm chart releaser action, `descheduler-helm-chart` tags are getting parsed as the most recent tag and pushed to our [staging repo](https://console.cloud.google.com/gcr/images/k8s-staging-descheduler/GLOBAL/descheduler?gcrImageListsize=30) on automated builds. You can see this by running `make image` locally:

```
$ make image
docker build -t descheduler:descheduler-helm-chart-0.18.1-11-g5bb038953 .
...
```

This update makes it so the latest *image* version is only considered if it's prefixed with `v`. New output:
```
$ make image
docker build -t descheduler:v0.18.0-79-g597089902 .
```

Because [Helm chart releases are separate from Descheduler releases](https://github.com/kubernetes-sigs/descheduler/pull/298#issuecomment-648683361) I think it's important that our image building only refers to *Descheduler* tags, as those correlate to descheduler releases. We also aren't building any images for the Helm chart so there shouldn't be any need to use those tags.