### PR TITLE
Allow custom priority threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,9 @@ strategies:
         maxPodLifeTimeSeconds: 86400
 ````
 
-## Namespace filtering
+## Filter Pods
+
+### Namespace filtering
 
 Strategies like `PodLifeTime`, `RemovePodsHavingTooManyRestarts`, `RemovePodsViolatingNodeTaints`,
 `RemovePodsViolatingNodeAffinity` and `RemovePodsViolatingInterPodAntiAffinity` can specify `namespaces`
@@ -275,6 +277,41 @@ strategies:
 The strategy gets executed over all namespaces but `namespace1` and `namespace2`.
 
 It's not allowed to compute `include` with `exclude` field.
+
+### Priority filtering
+
+All strategies are able to configure a priority threshold, only pods under the threshold can be evicted. You can
+specify this threshold by setting `thresholdPriorityClassName`(setting the threshold to the value of the given
+priority class) or `thresholdPriority`(directly setting the threshold) parameters. By default, this threshold
+is set to the value of `system-cluster-critical` priority class.
+E.g.
+
+Setting `thresholdPriority`
+```
+apiVersion: "descheduler/v1alpha1"
+kind: "DeschedulerPolicy"
+strategies:
+  "PodLifeTime":
+     enabled: true
+     params:
+        maxPodLifeTimeSeconds: 86400
+        thresholdPriority: 10000
+```
+
+Setting `thresholdPriorityClassName`
+```
+apiVersion: "descheduler/v1alpha1"
+kind: "DeschedulerPolicy"
+strategies:
+  "PodLifeTime":
+     enabled: true
+     params:
+        maxPodLifeTimeSeconds: 86400
+        thresholdPriorityClassName: "priorityclass1"
+```
+
+Note that you can't configure both `thresholdPriority` and `thresholdPriorityClassName`, if the given priority class
+does not exist, descheduler won't create it and will throw an error.
 
 ## Pod Evictions
 

--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -18,4 +18,7 @@ rules:
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs: ["create"]
+- apiGroups: ["scheduling.k8s.io"]
+  resources: ["priorityclasses"]
+  verbs: ["get", "watch", "list"]
 {{- end -}}

--- a/kubernetes/rbac.yaml
+++ b/kubernetes/rbac.yaml
@@ -17,6 +17,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs: ["create"]
+- apiGroups: ["scheduling.k8s.io"]
+  resources: ["priorityclasses"]
+  verbs: ["get", "watch", "list"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -52,8 +52,8 @@ type Namespaces struct {
 }
 
 // Besides Namespaces only one of its members may be specified
-// TODO(jchaloup): move Namespaces to individual strategies once the policy
-// version is bumped to v1alpha2
+// TODO(jchaloup): move Namespaces ThresholdPriority and ThresholdPriorityClassName to individual strategies
+//  once the policy version is bumped to v1alpha2
 type StrategyParameters struct {
 	NodeResourceUtilizationThresholds *NodeResourceUtilizationThresholds
 	NodeAffinityType                  []string
@@ -61,6 +61,8 @@ type StrategyParameters struct {
 	MaxPodLifeTimeSeconds             *uint
 	RemoveDuplicates                  *RemoveDuplicates
 	Namespaces                        Namespaces
+	ThresholdPriority                 *int32
+	ThresholdPriorityClassName        string
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -51,7 +51,7 @@ type Namespaces struct {
 	Exclude []string `json:"exclude"`
 }
 
-// Besides Namespaces only one of its members may be specified
+// Besides Namespaces ThresholdPriority and ThresholdPriorityClassName only one of its members may be specified
 type StrategyParameters struct {
 	NodeResourceUtilizationThresholds *NodeResourceUtilizationThresholds `json:"nodeResourceUtilizationThresholds,omitempty"`
 	NodeAffinityType                  []string                           `json:"nodeAffinityType,omitempty"`
@@ -59,6 +59,8 @@ type StrategyParameters struct {
 	MaxPodLifeTimeSeconds             *uint                              `json:"maxPodLifeTimeSeconds,omitempty"`
 	RemoveDuplicates                  *RemoveDuplicates                  `json:"removeDuplicates,omitempty"`
 	Namespaces                        Namespaces                         `json:"namespaces"`
+	ThresholdPriority                 *int32                             `json:"thresholdPriority"`
+	ThresholdPriorityClassName        string                             `json:"thresholdPriorityClassName"`
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/v1alpha1/zz_generated.conversion.go
@@ -249,6 +249,8 @@ func autoConvert_v1alpha1_StrategyParameters_To_api_StrategyParameters(in *Strat
 	if err := Convert_v1alpha1_Namespaces_To_api_Namespaces(&in.Namespaces, &out.Namespaces, s); err != nil {
 		return err
 	}
+	out.ThresholdPriority = (*int32)(unsafe.Pointer(in.ThresholdPriority))
+	out.ThresholdPriorityClassName = in.ThresholdPriorityClassName
 	return nil
 }
 
@@ -266,6 +268,8 @@ func autoConvert_api_StrategyParameters_To_v1alpha1_StrategyParameters(in *api.S
 	if err := Convert_api_Namespaces_To_v1alpha1_Namespaces(&in.Namespaces, &out.Namespaces, s); err != nil {
 		return err
 	}
+	out.ThresholdPriority = (*int32)(unsafe.Pointer(in.ThresholdPriority))
+	out.ThresholdPriorityClassName = in.ThresholdPriorityClassName
 	return nil
 }
 

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -243,6 +243,11 @@ func (in *StrategyParameters) DeepCopyInto(out *StrategyParameters) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Namespaces.DeepCopyInto(&out.Namespaces)
+	if in.ThresholdPriority != nil {
+		in, out := &in.ThresholdPriority, &out.ThresholdPriority
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -243,6 +243,11 @@ func (in *StrategyParameters) DeepCopyInto(out *StrategyParameters) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Namespaces.DeepCopyInto(&out.Namespaces)
+	if in.ThresholdPriority != nil {
+		in, out := &in.ThresholdPriority, &out.ThresholdPriority
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -397,7 +397,7 @@ func classifyPods(pods []*v1.Pod, evictor *evictions.PodEvictor) ([]*v1.Pod, []*
 	var nonRemovablePods, removablePods []*v1.Pod
 
 	for _, pod := range pods {
-		if !evictor.IsEvictable(pod) {
+		if !evictor.IsEvictable(pod, utils.SystemCriticalPriority) {
 			nonRemovablePods = append(nonRemovablePods, pod)
 		} else {
 			removablePods = append(removablePods, pod)

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/pkg/utils"
 )
 
 func validatePodsViolatingNodeAffinityParams(params *api.StrategyParameters) error {
@@ -61,7 +62,7 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 					client,
 					node,
 					podutil.WithFilter(func(pod *v1.Pod) bool {
-						return podEvictor.IsEvictable(pod) &&
+						return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority) &&
 							!nodeutil.PodFitsCurrentNode(pod, node) &&
 							nodeutil.PodFitsAnyNode(pod, nodes)
 					}),

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -39,6 +39,9 @@ func validatePodsViolatingNodeAffinityParams(params *api.StrategyParameters) err
 	if len(params.Namespaces.Include) > 0 && len(params.Namespaces.Exclude) > 0 {
 		return fmt.Errorf("only one of Include/Exclude namespaces can be set")
 	}
+	if params.ThresholdPriority != nil && params.ThresholdPriorityClassName != "" {
+		return fmt.Errorf("only one of thresholdPriority and thresholdPriorityClassName can be set")
+	}
 
 	return nil
 }
@@ -49,6 +52,12 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 		klog.V(1).Info(err)
 		return
 	}
+	thresholdPriority, err := utils.GetPriorityFromStrategyParams(ctx, client, strategy.Params)
+	if err != nil {
+		klog.V(1).Infof("failed to get threshold priority from strategy's params: %#v", err)
+		return
+	}
+
 	for _, nodeAffinity := range strategy.Params.NodeAffinityType {
 		klog.V(2).Infof("Executing for nodeAffinityType: %v", nodeAffinity)
 
@@ -62,7 +71,7 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 					client,
 					node,
 					podutil.WithFilter(func(pod *v1.Pod) bool {
-						return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority) &&
+						return podEvictor.IsEvictable(pod, thresholdPriority) &&
 							!nodeutil.PodFitsCurrentNode(pod, node) &&
 							nodeutil.PodFitsAnyNode(pod, nodes)
 					}),

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -60,7 +60,9 @@ func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interfa
 			ctx,
 			client,
 			node,
-			podutil.WithFilter(podEvictor.IsEvictable),
+			podutil.WithFilter(func(pod *v1.Pod) bool {
+				return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority)
+			}),
 			podutil.WithNamespaces(namespaces.Include),
 			podutil.WithoutNamespaces(namespaces.Exclude),
 		)

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -57,7 +57,9 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 			ctx,
 			client,
 			node,
-			podutil.WithFilter(podEvictor.IsEvictable),
+			podutil.WithFilter(func(pod *v1.Pod) bool {
+				return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority)
+			}),
 			podutil.WithNamespaces(namespaces.Include),
 			podutil.WithoutNamespaces(namespaces.Exclude),
 		)

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -40,6 +40,9 @@ func validateRemovePodsViolatingInterPodAntiAffinityParams(params *api.StrategyP
 	if len(params.Namespaces.Include) > 0 && len(params.Namespaces.Exclude) > 0 {
 		return fmt.Errorf("only one of Include/Exclude namespaces can be set")
 	}
+	if params.ThresholdPriority != nil && params.ThresholdPriorityClassName != "" {
+		return fmt.Errorf("only one of thresholdPriority and thresholdPriorityClassName can be set")
+	}
 
 	return nil
 }
@@ -50,6 +53,11 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 	if strategy.Params != nil {
 		namespaces = strategy.Params.Namespaces
 	}
+	thresholdPriority, err := utils.GetPriorityFromStrategyParams(ctx, client, strategy.Params)
+	if err != nil {
+		klog.V(1).Infof("failed to get threshold priority from strategy's params: %#v", err)
+		return
+	}
 
 	for _, node := range nodes {
 		klog.V(1).Infof("Processing node: %#v\n", node.Name)
@@ -58,7 +66,7 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 			client,
 			node,
 			podutil.WithFilter(func(pod *v1.Pod) bool {
-				return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority)
+				return podEvictor.IsEvictable(pod, thresholdPriority)
 			}),
 			podutil.WithNamespaces(namespaces.Include),
 			podutil.WithoutNamespaces(namespaces.Exclude),

--- a/pkg/descheduler/strategies/toomanyrestarts.go
+++ b/pkg/descheduler/strategies/toomanyrestarts.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/pkg/utils"
 )
 
 func validateRemovePodsHavingTooManyRestartsParams(params *api.StrategyParameters) error {
@@ -56,7 +57,9 @@ func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Inter
 			ctx,
 			client,
 			node,
-			podutil.WithFilter(podEvictor.IsEvictable),
+			podutil.WithFilter(func(pod *v1.Pod) bool {
+				return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority)
+			}),
 			podutil.WithNamespaces(strategy.Params.Namespaces.Include),
 			podutil.WithoutNamespaces(strategy.Params.Namespaces.Exclude),
 		)

--- a/pkg/utils/pod.go
+++ b/pkg/utils/pod.go
@@ -104,7 +104,7 @@ func GetPodSource(pod *v1.Pod) (string, error) {
 	return "", fmt.Errorf("cannot get source of pod %q", pod.UID)
 }
 
-// IsCriticalPod returns true if pod's priority is greater than or equal to SystemCriticalPriority.
+// IsCriticalPod returns true if the pod is a static or mirror pod.
 func IsCriticalPod(pod *v1.Pod) bool {
 	if IsStaticPod(pod) {
 		return true
@@ -112,15 +112,7 @@ func IsCriticalPod(pod *v1.Pod) bool {
 	if IsMirrorPod(pod) {
 		return true
 	}
-	if pod.Spec.Priority != nil && IsCriticalPodBasedOnPriority(*pod.Spec.Priority) {
-		return true
-	}
 	return false
-}
-
-// IsCriticalPodBasedOnPriority checks if the given pod is a critical pod based on priority resolved from pod Spec.
-func IsCriticalPodBasedOnPriority(priority int32) bool {
-	return priority >= SystemCriticalPriority
 }
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all

--- a/pkg/utils/priority.go
+++ b/pkg/utils/priority.go
@@ -1,9 +1,15 @@
 package utils
 
 import (
+	"context"
+	"fmt"
+
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/descheduler/pkg/api"
 )
 
 const SystemCriticalPriority = 2 * int32(1000000000)
@@ -32,4 +38,37 @@ func PodMatchesTermsNamespaceAndSelector(pod *v1.Pod, namespaces sets.String, se
 		return false
 	}
 	return true
+}
+
+// GetPriorityFromPriorityClass gets priority from the given priority class.
+// If no priority class is provided, it will return SystemCriticalPriority by default.
+func GetPriorityFromPriorityClass(ctx context.Context, client clientset.Interface, name string) (int32, error) {
+	if name != "" {
+		priorityClass, err := client.SchedulingV1().PriorityClasses().Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return 0, err
+		}
+		return priorityClass.Value, nil
+	}
+	return SystemCriticalPriority, nil
+}
+
+// GetPriorityFromStrategyParams gets priority from the given StrategyParameters.
+// It will return SystemCriticalPriority by default.
+func GetPriorityFromStrategyParams(ctx context.Context, client clientset.Interface, params *api.StrategyParameters) (priority int32, err error) {
+	if params == nil {
+		return SystemCriticalPriority, nil
+	}
+	if params.ThresholdPriority != nil {
+		priority = *params.ThresholdPriority
+	} else {
+		priority, err = GetPriorityFromPriorityClass(ctx, client, params.ThresholdPriorityClassName)
+		if err != nil {
+			return
+		}
+	}
+	if priority > SystemCriticalPriority {
+		return 0, fmt.Errorf("Priority threshold can't be greater than %d", SystemCriticalPriority)
+	}
+	return
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"math"
 	"os"
+	"sigs.k8s.io/descheduler/pkg/utils"
 	"sort"
 	"strings"
 	"testing"
@@ -509,7 +510,10 @@ func evictPods(ctx context.Context, t *testing.T, clientSet clientset.Interface,
 			continue
 		}
 		// List all the pods on the current Node
-		podsOnANode, err := podutil.ListPodsOnANode(ctx, clientSet, node, podutil.WithFilter(podEvictor.IsEvictable))
+		podsOnANode, err := podutil.ListPodsOnANode(ctx, clientSet, node,
+			podutil.WithFilter(func(pod *v1.Pod) bool {
+				return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority)
+			}))
 		if err != nil {
 			t.Errorf("Error listing pods on a node %v", err)
 		}
@@ -521,7 +525,10 @@ func evictPods(ctx context.Context, t *testing.T, clientSet clientset.Interface,
 	}
 	t.Log("Eviction of pods starting")
 	startEndToEndForLowNodeUtilization(ctx, clientSet, nodeInformer, podEvictor)
-	podsOnleastUtilizedNode, err := podutil.ListPodsOnANode(ctx, clientSet, leastLoadedNode, podutil.WithFilter(podEvictor.IsEvictable))
+	podsOnleastUtilizedNode, err := podutil.ListPodsOnANode(ctx, clientSet, leastLoadedNode,
+		podutil.WithFilter(func(pod *v1.Pod) bool {
+			return podEvictor.IsEvictable(pod, utils.SystemCriticalPriority)
+		}))
 	if err != nil {
 		t.Errorf("Error listing pods on a node %v", err)
 	}


### PR DESCRIPTION
Fixes #329 
Introduce a new configuration for each strategies which allows users to define a PriorityClass which is used by PodEvictor to check if a pod is evictable.

TODO:
- [x] Add PriorityClass to `StrategyParameters` and read and set it to PodEvictor
- [x] e2e tests for priority class
- [x] README
- [x] e2e tests for priority