### PR TITLE
Add check for ownerref length in DuplicatePods strategy

### DIFF
--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -69,7 +69,7 @@ func RemoveDuplicatePods(
 		duplicateKeysMap := map[string][][]string{}
 		for _, pod := range pods {
 			ownerRefList := podutil.OwnerRef(pod)
-			if hasExcludedOwnerRefKind(ownerRefList, strategy) {
+			if hasExcludedOwnerRefKind(ownerRefList, strategy) || len(ownerRefList) == 0 {
 				continue
 			}
 			podContainerKeys := make([]string, 0, len(ownerRefList)*len(pod.Spec.Containers))


### PR DESCRIPTION
This fixes a panic that occurs if a pod has no ownerrefs
later on in the strategy. If a pod has no ownerrefs, there's
nothing for us to do with it.

For reference, the panic that occurs looks like this:
```
E0807 13:35:30.950616       1 runtime.go:78] Observed a panic: runtime.boundsError{x:0, y:0, signed:true, code:0x0} (runtime error: index out of range [0] with length 0)
goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x159d940, 0xc000958400)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x159d940, 0xc000958400)
	/opt/rh/go-toolset-1.14/root/usr/lib/go-toolset-1.14-golang/src/runtime/panic.go:969 +0x166
sigs.k8s.io/descheduler/pkg/descheduler/strategies.RemoveDuplicatePods(0x18cf720, 0xc000042068, 0x18fc020, 0xc0003a8c60, 0xc000136001, 0x0, 0x0, 0xc000158000, 0x6, 0x6, ...)
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/strategies/duplicates.go:88 +0xe54
sigs.k8s.io/descheduler/pkg/descheduler.RunDeschedulerStrategies.func1()
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler.go:107 +0x2d0
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0001f3b38)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0006cbb38, 0x1893000, 0xc0000af500, 0x1, 0xc0000d6000)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xa3
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0001f3b38, 0xdf8475800, 0x0, 0x1, 0xc0000d6000)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
sigs.k8s.io/descheduler/pkg/descheduler.RunDeschedulerStrategies(0x18cf720, 0xc000042068, 0xc0003b0080, 0xc0003acc30, 0xc0003546e0, 0xe, 0xc0000d6000, 0xc0001f3cd8, 0x1373c5a)
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler.go:82 +0x468
sigs.k8s.io/descheduler/pkg/descheduler.Run(0xc0003b0080, 0xc0001f3d58, 0xc0001f3d58)
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler.go:60 +0x17d
sigs.k8s.io/descheduler/cmd/descheduler/app.Run(...)
	/go/src/sigs.k8s.io/descheduler/cmd/descheduler/app/server.go:60
sigs.k8s.io/descheduler/cmd/descheduler/app.NewDeschedulerCommand.func1(0xc0002f5b80, 0xc0003ac9f0, 0x0, 0x3)
	/go/src/sigs.k8s.io/descheduler/cmd/descheduler/app/server.go:44 +0x60
github.com/spf13/cobra.(*Command).execute(0xc0002f5b80, 0xc00003c0d0, 0x3, 0x3, 0xc0002f5b80, 0xc00003c0d0)
	/go/src/sigs.k8s.io/descheduler/vendor/github.com/spf13/cobra/command.go:830 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002f5b80, 0x23c1a30, 0x0, 0x0)
	/go/src/sigs.k8s.io/descheduler/vendor/github.com/spf13/cobra/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/sigs.k8s.io/descheduler/vendor/github.com/spf13/cobra/command.go:864
main.main()
	/go/src/sigs.k8s.io/descheduler/cmd/descheduler/descheduler.go:32 +0xba
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x105
panic(0x159d940, 0xc000958400)
	/opt/rh/go-toolset-1.14/root/usr/lib/go-toolset-1.14-golang/src/runtime/panic.go:969 +0x166
sigs.k8s.io/descheduler/pkg/descheduler/strategies.RemoveDuplicatePods(0x18cf720, 0xc000042068, 0x18fc020, 0xc0003a8c60, 0xc000136001, 0x0, 0x0, 0xc000158000, 0x6, 0x6, ...)
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/strategies/duplicates.go:88 +0xe54
sigs.k8s.io/descheduler/pkg/descheduler.RunDeschedulerStrategies.func1()
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler.go:107 +0x2d0
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0001f3b38)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0006cbb38, 0x1893000, 0xc0000af500, 0x1, 0xc0000d6000)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xa3
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0001f3b38, 0xdf8475800, 0x0, 0x1, 0xc0000d6000)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/sigs.k8s.io/descheduler/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
sigs.k8s.io/descheduler/pkg/descheduler.RunDeschedulerStrategies(0x18cf720, 0xc000042068, 0xc0003b0080, 0xc0003acc30, 0xc0003546e0, 0xe, 0xc0000d6000, 0xc0001f3cd8, 0x1373c5a)
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler.go:82 +0x468
sigs.k8s.io/descheduler/pkg/descheduler.Run(0xc0003b0080, 0xc0001f3d58, 0xc0001f3d58)
	/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler.go:60 +0x17d
sigs.k8s.io/descheduler/cmd/descheduler/app.Run(...)
	/go/src/sigs.k8s.io/descheduler/cmd/descheduler/app/server.go:60
sigs.k8s.io/descheduler/cmd/descheduler/app.NewDeschedulerCommand.func1(0xc0002f5b80, 0xc0003ac9f0, 0x0, 0x3)
	/go/src/sigs.k8s.io/descheduler/cmd/descheduler/app/server.go:44 +0x60
github.com/spf13/cobra.(*Command).execute(0xc0002f5b80, 0xc00003c0d0, 0x3, 0x3, 0xc0002f5b80, 0xc00003c0d0)
	/go/src/sigs.k8s.io/descheduler/vendor/github.com/spf13/cobra/command.go:830 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002f5b80, 0x23c1a30, 0x0, 0x0)
	/go/src/sigs.k8s.io/descheduler/vendor/github.com/spf13/cobra/command.go:914 +0x2fb
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/sigs.k8s.io/descheduler/vendor/github.com/spf13/cobra/command.go:864
main.main()
	/go/src/sigs.k8s.io/descheduler/cmd/descheduler/descheduler.go:32 +0xba
```

/kind bug
/priority critical-urgent