### PR TITLE
Update To Go 1.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.14.4
+FROM golang:1.15.0
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ LDFLAG_LOCATION=sigs.k8s.io/descheduler/cmd/descheduler/app
 
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitCommit=${COMMIT}"
 
-GOLANGCI_VERSION := v1.15.0
+GOLANGCI_VERSION := v1.30.0
 HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint)
 
 # REGISTRY is the container registry to push

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -3,7 +3,7 @@
 ## Required Tools
 
 - [Git](https://git-scm.com/downloads)
-- [Go 1.14+](https://golang.org/dl/)
+- [Go 1.15+](https://golang.org/dl/)
 - [Docker](https://docs.docker.com/install/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 - [kind](https://kind.sigs.k8s.io/)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/descheduler
 
-go 1.14
+go 1.15
 
 require (
 	github.com/spf13/cobra v0.0.5

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -23,7 +23,7 @@ DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3|go1.4|go1.5|go1.6|go1.7|go1.8|go1.9|go1.10|go1.11|go1.12|go1.13|go1.14') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.13|go1.14|go1.15') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -23,7 +23,7 @@ DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.2|go1.3|go1.4|go1.5|go1.6|go1.7|go1.8|go1.9|go1.10|go1.11|go1.12|go1.13|go1.14') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.13|go1.14|go1.15') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -69,7 +69,7 @@ func TestReadyNodesWithNodeSelector(t *testing.T) {
 	sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
 	nodeInformer := sharedInformerFactory.Core().V1().Nodes()
 
-	stopChannel := make(chan struct{}, 0)
+	stopChannel := make(chan struct{})
 	sharedInformerFactory.Start(stopChannel)
 	sharedInformerFactory.WaitForCacheSync(stopChannel)
 	defer close(stopChannel)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -144,7 +144,7 @@ func initializeClient(t *testing.T) (clientset.Interface, coreinformers.NodeInfo
 		t.Errorf("Error during client creation with %v", err)
 	}
 
-	stopChannel := make(chan struct{}, 0)
+	stopChannel := make(chan struct{})
 
 	sharedInformerFactory := informers.NewSharedInformerFactory(clientSet, 0)
 	sharedInformerFactory.Start(stopChannel)


### PR DESCRIPTION
As part of the k8s 1.19 release cycle the Go version is being bumped to
1.15.0. Updating the descheduler to use Go 1.15 prior to the descheduler
v0.19.0 release.

See below issues for reference:
* https://github.com/kubernetes/release/issues/1421
* https://github.com/kubernetes/kubernetes/issues/93484