### PR TITLE
Update Maintainer Details In Helm Chart

### DIFF
--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -12,5 +12,5 @@ icon: https://kubernetes.io/images/favicon.png
 sources:
 - https://github.com/kubernetes-sigs/descheduler
 maintainers:
-- name: stevehipwell
-  email: steve.hipwell@github.com
+- name: Kubernetes SIG Scheduling
+  email: kubernetes-sig-scheduling@googlegroups.com


### PR DESCRIPTION
Changing the maintainer for the helm chart to SIG scheduling instead of
an individual person.