### PR TITLE
Add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 # Descheduler for Kubernetes
 
-## Introduction
-
 Scheduling in Kubernetes is the process of binding pending pods to nodes, and is performed by
 a component of Kubernetes called kube-scheduler. The scheduler's decisions, whether or where a
 pod can or can not be scheduled, are guided by its configurable policy which comprises of set of
@@ -23,6 +21,33 @@ Consequently, there might be several pods scheduled on less desired nodes in a c
 Descheduler, based on its policy, finds pods that can be moved and evicts them. Please
 note, in current implementation, descheduler does not schedule replacement of evicted pods
 but relies on the default scheduler for that.
+
+Table of Contents
+=================
+
+  * [Quick Start](#quick-start)
+     * [Run As A Job](#run-as-a-job)
+     * [Run As A CronJob](#run-as-a-cronjob)
+     * [Install Using Helm](#install-using-helm)
+  * [User Guide](#user-guide)
+  * [Policy and Strategies](#policy-and-strategies)
+     * [RemoveDuplicates](#removeduplicates)
+     * [LowNodeUtilization](#lownodeutilization)
+     * [RemovePodsViolatingInterPodAntiAffinity](#removepodsviolatinginterpodantiaffinity)
+     * [RemovePodsViolatingNodeAffinity](#removepodsviolatingnodeaffinity)
+     * [RemovePodsViolatingNodeTaints](#removepodsviolatingnodetaints)
+     * [RemovePodsHavingTooManyRestarts](#removepodshavingtoomanyrestarts)
+     * [PodLifeTime](#podlifetime)
+  * [Filter Pods](#filter-pods)
+     * [Namespace filtering](#namespace-filtering)
+     * [Priority filtering](#priority-filtering)
+  * [Pod Evictions](#pod-evictions)
+     * [Pod Disruption Budget (PDB)](#pod-disruption-budget-pdb)
+  * [Compatibility Matrix](#compatibility-matrix)
+  * [Getting Involved and Contributing](#getting-involved-and-contributing)
+     * [Communicating With Contributors](#communicating-with-contributors)
+  * [Roadmap](#roadmap)
+     * [Code of conduct](#code-of-conduct)
 
 ## Quick Start
 


### PR DESCRIPTION
This removes the redundant "Introduction" header and adds a table of contents. See https://github.com/damemi/descheduler/tree/readme-toc#table-of-contents

Got tired of always trying to find whatever strategy's docs I was looking for 😄 