### PR TITLE
Move IsEvictable check in PodAntiAffinity

### DIFF
--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -74,7 +74,6 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 			ctx,
 			client,
 			node,
-			podutil.WithFilter(evictable.IsEvictable),
 			podutil.WithNamespaces(includedNamespaces),
 			podutil.WithoutNamespaces(excludedNamespaces),
 		)
@@ -85,7 +84,7 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 		podutil.SortPodsBasedOnPriorityLowToHigh(pods)
 		totalPods := len(pods)
 		for i := 0; i < totalPods; i++ {
-			if checkPodsWithAntiAffinityExist(pods[i], pods) {
+			if checkPodsWithAntiAffinityExist(pods[i], pods) && evictable.IsEvictable(pods[i]) {
 				success, err := podEvictor.EvictPod(ctx, pods[i], node, "InterPodAntiAffinity")
 				if err != nil {
 					klog.ErrorS(err, "Error evicting pod")


### PR DESCRIPTION
While non-evictable pods should never be evicted, they should still be
considered when calculating PodAntiAffinity violations. For example, you
may have an evictable pod that should not be running next to a system-critical
static pod. We currently filter IsEvictable before checking for Affinity violations,
so this case would not be caught.

/kind bug