### PR TITLE
Adding replica check when evicting managed pods from node

### DIFF
--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -100,7 +100,7 @@ func TestIsEvictable(t *testing.T) {
 		}, {
 			pod: test.BuildTestPod("p3", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
-				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList("replicaset-1")
 			},
 			evictLocalStoragePods: false,
 			result:                true,
@@ -108,7 +108,7 @@ func TestIsEvictable(t *testing.T) {
 			pod: test.BuildTestPod("p4", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList("replicaset-1")
 			},
 			evictLocalStoragePods: false,
 			result:                true,
@@ -267,7 +267,7 @@ func TestPodTypes(t *testing.T) {
 	p3 := test.BuildTestPod("p3", 400, 0, n1.Name, nil)
 	p4 := test.BuildTestPod("p4", 400, 0, n1.Name, nil)
 
-	p1.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+	p1.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList("replicaset-1")
 	// The following 4 pods won't get evicted.
 	// A daemonset.
 	//p2.Annotations = test.GetDaemonSetAnnotation()

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -45,7 +45,7 @@ func TestPodLifeTime(t *testing.T) {
 	p2.Namespace = "dev"
 	p2.ObjectMeta.CreationTimestamp = olderPodCreationTime
 
-	ownerRef1 := test.GetReplicaSetOwnerRefList()
+	ownerRef1 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p1.ObjectMeta.OwnerReferences = ownerRef1
 	p2.ObjectMeta.OwnerReferences = ownerRef1
 
@@ -57,7 +57,7 @@ func TestPodLifeTime(t *testing.T) {
 	p4.Namespace = "dev"
 	p4.ObjectMeta.CreationTimestamp = newerPodCreationTime
 
-	ownerRef2 := test.GetReplicaSetOwnerRefList()
+	ownerRef2 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p3.ObjectMeta.OwnerReferences = ownerRef2
 	p4.ObjectMeta.OwnerReferences = ownerRef2
 
@@ -69,7 +69,7 @@ func TestPodLifeTime(t *testing.T) {
 	p6.Namespace = "dev"
 	p6.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 605))
 
-	ownerRef3 := test.GetReplicaSetOwnerRefList()
+	ownerRef3 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p5.ObjectMeta.OwnerReferences = ownerRef3
 	p6.ObjectMeta.OwnerReferences = ownerRef3
 
@@ -81,7 +81,7 @@ func TestPodLifeTime(t *testing.T) {
 	p8.Namespace = "dev"
 	p8.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 595))
 
-	ownerRef4 := test.GetReplicaSetOwnerRefList()
+	ownerRef4 := test.GetReplicaSetOwnerRefList("replicaset-1")
 	p5.ObjectMeta.OwnerReferences = ownerRef4
 	p6.ObjectMeta.OwnerReferences = ownerRef4
 

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -19,6 +19,7 @@ package test
 import (
 	"fmt"
 
+	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,10 +73,52 @@ func GetNormalPodOwnerRefList() []metav1.OwnerReference {
 	return ownerRefList
 }
 
+// BuildTestReplicaController creates a test replication controller
+func BuildTestReplicaController(name string, replicas int) *v1.ReplicationController {
+	rc := &v1.ReplicationController{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Status: v1.ReplicationControllerStatus{
+			Replicas: int32(replicas),
+		},
+	}
+	return rc
+}
+
+// BuildTestReplicaSet creates a test replica set
+func BuildTestReplicaSet(name string, replicas int) *apps.ReplicaSet {
+	rs := &apps.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+		Status: apps.ReplicaSetStatus{
+			Replicas: int32(replicas),
+		},
+	}
+	return rs
+}
+
 // GetReplicaSetOwnerRefList returns the ownerRef needed for replicaset pod.
-func GetReplicaSetOwnerRefList() []metav1.OwnerReference {
+func GetReplicaSetOwnerRefList(rsName string) []metav1.OwnerReference {
 	ownerRefList := make([]metav1.OwnerReference, 0)
-	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicaSet", APIVersion: "v1", Name: "replicaset-1"})
+	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicaSet", APIVersion: "v1", Name: rsName})
+	return ownerRefList
+}
+
+// GetReplicationControllerOwnerRefList returns the ownerRef needed for replicationcontroller pod.
+func GetReplicationControllerOwnerRefList() []metav1.OwnerReference {
+	ownerRefList := make([]metav1.OwnerReference, 0)
+	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicationController", APIVersion: "v1", Name: "replicationcontroller-1"})
+	return ownerRefList
+}
+
+// GetReplicationControllerOwnerRefList returns the ownerRef needed for replicationcontroller pod.
+func GetReplicationControllerOwnerRefList() []metav1.OwnerReference {
+	ownerRefList := make([]metav1.OwnerReference, 0)
+	ownerRefList = append(ownerRefList, metav1.OwnerReference{Kind: "ReplicationController", APIVersion: "v1", Name: "replicationcontroller-1"})
 	return ownerRefList
 }
 
@@ -139,7 +182,7 @@ func MakeGuaranteedPod(pod *v1.Pod) {
 
 // SetRSOwnerRef sets the given pod's owner to ReplicaSet
 func SetRSOwnerRef(pod *v1.Pod) {
-	pod.ObjectMeta.OwnerReferences = GetReplicaSetOwnerRefList()
+	pod.ObjectMeta.OwnerReferences = GetReplicaSetOwnerRefList("replicaset-1")
 }
 
 // SetDSOwnerRef sets the given pod's owner to DaemonSet


### PR DESCRIPTION
Overriding PR #334 

> When pods managed by deployment/replicaset/replicationcontroller have replica count greater than available nodes, even after descheduler evicting these pods, they will end up in the same node.
> This would just run in a loop and is ineffective.
> 
> This PR checks for the owners replication factor and decides whether to consider the pod as duplicate or not.
> 
> Fixes #263