### PR TITLE
Update e2e tests to use kind v0.9.0

### DIFF
--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -6,7 +6,7 @@
 - [Go 1.15+](https://golang.org/dl/)
 - [Docker](https://docs.docker.com/install/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
-- [kind](https://kind.sigs.k8s.io/)
+- [kind v0.9.0+](https://kind.sigs.k8s.io/)
 
 ## Build and Run
 

--- a/hack/kind_config.yaml
+++ b/hack/kind_config.yaml
@@ -1,5 +1,5 @@
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
 - role: worker

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -18,7 +18,7 @@
 if [ -n "$KIND_E2E" ]; then
     K8S_VERSION=${KUBERNETES_VERSION:-v1.18.2}
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-    wget https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64
+    wget https://github.com/kubernetes-sigs/kind/releases/download/v0.9.0/kind-linux-amd64
     chmod +x kind-linux-amd64
     mv kind-linux-amd64 kind
     export PATH=$PATH:$PWD


### PR DESCRIPTION
This is a cherry-pick of https://github.com/kubernetes-sigs/descheduler/pull/401 for the `release-1.19` branch.