### PR TITLE
charts/descheduler: add PodSecurityPolicy support

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -55,5 +55,6 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                                      |
 | `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                              |
 | `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                                                 |
+| `podSecurityPolicy.create`     | If `true`, create PodSecurityPolicy                                                                                   | `true`                                                 |
 | `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                                                 |
 | `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                                  |

--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -21,4 +21,11 @@ rules:
 - apiGroups: ["scheduling.k8s.io"]
   resources: ["priorityclasses"]
   verbs: ["get", "watch", "list"]
+{{- if .Values.podSecurityPolicy.create }}
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "descheduler.fullname" . }}
+{{- end }}
 {{- end -}}

--- a/charts/descheduler/templates/podsecuritypolicy.yaml
+++ b/charts/descheduler/templates/podsecuritypolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "descheduler.fullname" . }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'secret'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: true
+{{- end -}}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -51,6 +51,10 @@ rbac:
   # Specifies whether RBAC resources should be created
   create: true
 
+podSecurityPolicy:
+  # Specifies whether PodSecurityPolicy should be created.
+  create: true
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true


### PR DESCRIPTION
This commit adds restrictive PodSecurityPolicy, which can be
optionally created, so descheduler can be deployed on clusters with
PodSecurityPolicy admission controller, but which do not ship default
policies.

Signed-off-by: Mateusz Gozdek <mgozdekof@gmail.com>