### PR TITLE
Exclude names in RemoveDuplicates strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ if some nodes went down due to whatever reasons, and pods on them were moved to 
 more than one pod associated with a RS or RC, for example, running on the same node. Once the failed nodes
 are ready again, this strategy could be enabled to evict those duplicate pods.
 
-It provides one optional parameter, `ExcludeOwnerKinds`, which is a list of OwnerRef `Kind`s. If a pod
-has any of these `Kind`s listed as an `OwnerRef`, that pod will not be considered for eviction.
+It provides optional parameters: `ExcludeOwnerKinds`, and `ExcludeOwnerNames` which is a list of OwnerRef `Kind`s and `Name`s. If a pod
+has any of these `Kind`s or `Name`s listed as an `OwnerRef`, that pod will not be considered for eviction.
 
 ```
 apiVersion: "descheduler/v1alpha1"

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -90,4 +90,5 @@ type PodsHavingTooManyRestarts struct {
 
 type RemoveDuplicates struct {
 	ExcludeOwnerKinds []string
+	ExcludeOwnerNames []string
 }

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -97,6 +97,9 @@ func RemoveDuplicatePods(
 			if hasExcludedOwnerRefKind(ownerRefList, strategy) || len(ownerRefList) == 0 {
 				continue
 			}
+			if hasExcludedOwnerRefNames(ownerRefList, strategy) || len(ownerRefList) == 0 {
+				continue
+			}
 			podContainerKeys := make([]string, 0, len(ownerRefList)*len(pod.Spec.Containers))
 			for _, ownerRef := range ownerRefList {
 				for _, container := range pod.Spec.Containers {
@@ -143,6 +146,19 @@ func hasExcludedOwnerRefKind(ownerRefs []metav1.OwnerReference, strategy api.Des
 		return false
 	}
 	exclude := sets.NewString(strategy.Params.RemoveDuplicates.ExcludeOwnerKinds...)
+	for _, owner := range ownerRefs {
+		if exclude.Has(owner.Kind) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasExcludedOwnerRefNames(ownerRefs []metav1.OwnerReference, strategy api.DeschedulerStrategy) bool {
+	if strategy.Params == nil || strategy.Params.RemoveDuplicates == nil {
+		return false
+	}
+	exclude := sets.NewString(strategy.Params.RemoveDuplicates.ExcludeOwnerNames...)
 	for _, owner := range ownerRefs {
 		if exclude.Has(owner.Kind) {
 			return true


### PR DESCRIPTION
Sometimes just not enough exclude only for kind, I think it would be cool to be able to exclude by other parameters, such as the name of the owner.