### PR TITLE
Fix Version Output For Automated Container Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ FROM golang:1.15.2
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
-RUN make
+ARG VERSION
+RUN VERSION=${VERSION} make
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,12 @@
 
 .PHONY: test
 
-# VERSION is currently based on the last commit
-VERSION?=$(shell git describe --tags --match "v*")
-COMMIT=$(shell git rev-parse HEAD)
+# VERSION is based on a date stamp plus the last commit
+VERSION?=v$(shell date +%Y%m%d)-$(shell git describe --tags --match "v*")
 BUILD=$(shell date +%FT%T%z)
 LDFLAG_LOCATION=sigs.k8s.io/descheduler/cmd/descheduler/app
 
-LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitCommit=${COMMIT}"
+LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD}"
 
 GOLANGCI_VERSION := v1.30.0
 HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint)
@@ -52,7 +51,7 @@ dev-image: build
 	docker build -f Dockerfile.dev -t $(IMAGE) .
 
 image:
-	docker build -t $(IMAGE) .
+	docker build --build-arg VERSION="$(VERSION)" -t $(IMAGE) .
 
 push-container-to-gcloud: image
 	gcloud auth configure-docker


### PR DESCRIPTION
Prior to this change the output from the command "descheduler version" when run using the official container images from k8s.gcr.io would always output an empty string. See below for an example.

```
docker run k8s.gcr.io/descheduler/descheduler:v0.19.0 /bin/descheduler version
Descheduler version {Major: Minor: GitCommit: GitVersion: BuildDate:2020-09-01T16:43:23+0000 GoVersion:go1.15 Compiler:gc Platform:linux/amd64}
```

This change makes it possible to pass the descheduler version information to the automated container image build process and also makes it work for local builds too.

Fixes #425