### PR TITLE
Allow unsetting values in `cmdOptions`

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -39,10 +39,12 @@ spec:
                 - "--policy-config-file"
                 - "/policy-dir/policy.yaml"
                 {{- range $key, $value := .Values.cmdOptions }}
+                  {{- if ne (kindOf $value) "invalid" }}
                 - {{ printf "--%s" $key | quote }}
-                {{- if $value }}
+                    {{- if $value }}
                 - {{ $value | quote }}
-                {{- end }}
+                    {{- end }}
+                  {{- end }}
                 {{- end }}
               volumeMounts:
                 - mountPath: /policy-dir


### PR DESCRIPTION
By checking the value to not be an "invalid" kind it is possible to use the chart and unset
a value after installation:

```sh
helm install descheduler descheduler/descheduler-helm-chart ... --set cmdOptions.dry-run=
helm upgrade descheduler ... --reuse-values --set cmdOptions.dry-run=null
```

---
Basically I ended up doing exactly the `install` step from the example above, and when I wanted to unset that value found that I wasn't able to. Now I could just re-install descheduler I suppose, but it felt wrong to do that. Reading https://helm.sh/docs/chart_template_guide/values_files/#deleting-a-default-key it seemed that setting a value to `null` should do what I want though:
> If you need to delete a key from the default values, you may override the value of the key to be null, in which case Helm will remove the key from the overridden values merge.

What I'm not sure is whether this is intended only for the _default_ values ... but I also couldn't find a clear best practice pattern for unsetting values in general. :)

This change seems to work nicely when testing with `helm template`:

```sh
# Set the value to appear as `--dry-run`
helm template descheduler --set cmdOptions.dry-run=
# Unset the value and remove the `--dry-run`
helm template descheduler --set cmdOptions.dry-run=null
# Testing: Renders as `--dry-run` followed by `foo`
helm template descheduler --set cmdOptions.dry-run=foo
# Testing: Renders as `--dry-run`. Might be surprising for users.
helm template descheduler --set cmdOptions.dry-run=false
# Testing: Renders as `--dry-run` followed by `true`
helm template descheduler --set cmdOptions.dry-run=true
```

I think the last two cases could possibly be improved further in terms of user-that-didnt-read-much-documentation expectations as well, at the expense of making this part of the template even uglier.

_Note: This is pretty much my first venture into helm and charts, so please take all this with a grain of salt!_