### PR TITLE
Rename Helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,20 +11,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Fetch history
-        run: git fetch --prune --unshallow
-
-      - name: Add dependency chart repos
-        run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.2
+        uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "descheduler-helm-chart-{{ .Version }}"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ kubectl create -f kubernetes/cronjob/cronjob.yaml
 Starting with release v0.18.0 there is an official helm chart that can be used to install the
 descheduler. See the [helm chart README](https://github.com/kubernetes-sigs/descheduler/blob/master/charts/descheduler/README.md) for detailed instructions.
 
-The descheduler helm chart is also listed on the [helm hub](https://hub.helm.sh/charts/descheduler/descheduler-helm-chart).
+The descheduler helm chart is also listed on the [artifact hub](https://artifacthub.io/packages/helm/descheduler/descheduler).
 
 ### Install Using Kustomize
 

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-name: descheduler-helm-chart
+name: descheduler
 version: 0.19.0
 appVersion: 0.19.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -6,7 +6,7 @@
 
 ```shell
 helm repo add descheduler https://kubernetes-sigs.github.io/descheduler/
-helm install my-release --namespace kube-system descheduler/descheduler-helm-chart
+helm install my-release --namespace kube-system descheduler/descheduler
 ```
 
 ## Introduction
@@ -22,7 +22,7 @@ This chart bootstraps a [descheduler](https://github.com/kubernetes-sigs/desched
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install --namespace kube-system my-release descheduler/descheduler-helm-chart
+helm install --namespace kube-system my-release descheduler/descheduler
 ```
 
 The command deploys _descheduler_ on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -43,18 +43,18 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the _descheduler_ chart and their default values.
 
-| Parameter                      | Description                                                                                                           | Default                                                |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `image.repository`             | Docker repository to use                                                                                              | `k8s.gcr.io/descheduler/descheduler`                   |
-| `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                                  |
-| `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                                         |
-| `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                                   |
-| `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                                   |
-| `schedule`                     | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                                        |
-| `cmdOptions`                   | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                                      |
-| `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                                      |
-| `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                              |
-| `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                                                 |
-| `podSecurityPolicy.create`     | If `true`, create PodSecurityPolicy                                                                                   | `true`                                                 |
-| `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                                                 |
-| `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                                  |
+| Parameter                      | Description                                                                                                           | Default                              |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `image.repository`             | Docker repository to use                                                                                              | `k8s.gcr.io/descheduler/descheduler` |
+| `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                |
+| `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                       |
+| `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                 |
+| `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                 |
+| `schedule`                     | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                      |
+| `cmdOptions`                   | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                    |
+| `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                    |
+| `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`            |
+| `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                               |
+| `podSecurityPolicy.create`     | If `true`, create PodSecurityPolicy                                                                                   | `true`                               |
+| `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                               |
+| `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                |


### PR DESCRIPTION
Now that the [helm/chart-releaser](https://github.com/helm/chart-releaser/releases/tag/v1.1.0) and [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action/releases/tag/v1.1.0) can support creating a custom tag name for helm chart release the _descheduler_ helm chart no longer needs to be named to avoid tag collisions.

This PR updates the CI tooling for helm, renames the _descheduler_ helm chart to `descheduler` from `descheduler-helm-chart` and updates the related documentation.

On applying this merge request the existing helm charts will not be modified or removed and only future releases will be impacted. My suggestion would be to use the [helm/chart-releaser](https://github.com/helm/chart-releaser) with the `--commit` flag to re-create the existing charts with the new name in parallel.