### PR TITLE
Set Container Resources In YAML Manifests

### DIFF
--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -27,6 +27,10 @@ spec:
               - "/policy-dir/policy.yaml"
               - "--v"
               - "3"
+            resources:
+              requests:
+                cpu: "500m"
+                memory: "256Mi"
           restartPolicy: "Never"
           serviceAccountName: descheduler-sa
           volumes:

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -25,6 +25,10 @@ spec:
             - "/policy-dir/policy.yaml"
             - "--v"
             - "3"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "256Mi"
       restartPolicy: "Never"
       serviceAccountName: descheduler-sa
       volumes:


### PR DESCRIPTION
Prior to this commit the YAML manifests used to install the descheduler
Job and CronJob did not set container requests or limits. This is
considered an anti-pattern when deploying applications on k8s.

Set descheduler container resources to make it a burstable pod. This
will ensure a high quality experience for end users when deploying
descheduler into their clusters using the instructions from the README.

The values choosen for CPU/Memory are not based on any real data.