### PR TITLE
Set Container Resources In Helm Chart

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -56,5 +56,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`            |
 | `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                               |
 | `podSecurityPolicy.create`     | If `true`, create PodSecurityPolicy                                                                                   | `true`                               |
+| `resources.cpuRequest`        | Descheduler container CPU request                                                                  | `500m`                               |
+| `resources.memoryRequest`        | Descheduler container memory request                                                                  | `256Mi`                               |
 | `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                               |
 | `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -44,6 +44,8 @@ spec:
                 - {{ $value | quote }}
                 {{- end }}
                 {{- end }}
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
               volumeMounts:
                 - mountPath: /policy-dir
                   name: policy-volume

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -8,6 +8,14 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+resources:
+  requests:
+    cpu: 500m
+    memory: 256Mi
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Prior to this commit the helm chart used to install the descheduler
CronJob did not set container requests or limits. This is considered
an anti-pattern when deploying applications on k8s.

Set descheduler container resources to make it a burstable pod. This
will ensure a high quality experience for end users when deploying
descheduler into their clusters using the instructions from the README.

The default values choosen for CPU/Memory are not based on any real data.