### PR TITLE
LowNodeUtilization: express usagePercentage multiplied by 100

### DIFF
--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -248,7 +248,7 @@ func resourceUsagePercentages(nodeUsage NodeUsage) map[v1.ResourceName]float64 {
 	for resourceName, resourceUsage := range nodeUsage.usage {
 		cap := nodeCapacity[resourceName]
 		if !cap.IsZero() {
-			resourceUsagePercentage[resourceName] = float64(resourceUsage.Value()) / float64(cap.Value())
+			resourceUsagePercentage[resourceName] = 100 * float64(resourceUsage.Value()) / float64(cap.Value())
 		}
 	}
 


### PR DESCRIPTION
Entry params are in interval <0; 100>. Have logs respect that as well.

To log `usagePercentage=map[cpu:75 memory:0 pods:66.66666666666667]` instead of `usagePercentage=map[cpu:0.75 memory:0 pods:0.6666666666666667]`

```
$ go test -v sigs.k8s.io/descheduler/pkg/descheduler/strategies -run TestLowNodeUtilization
=== RUN   TestLowNodeUtilization
=== RUN   TestLowNodeUtilization/no_evictable_pods
I1124 14:51:07.941383  462893 lownodeutilization.go:268] "Node is underutilized" node="n2" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
I1124 14:51:07.941418  462893 lownodeutilization.go:274] "Node is appropriately utilized" node="n3" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
I1124 14:51:07.941433  462893 lownodeutilization.go:271] "Node is overutilized" node="n1" usage=map[cpu:2400m memory:0 pods:6] usagePercentage=map[cpu:75 memory:0 pods:66.66666666666667]
=== RUN   TestLowNodeUtilization/without_priorities
I1124 14:51:07.941985  462893 lownodeutilization.go:271] "Node is overutilized" node="n1" usage=map[cpu:3200m memory:0 pods:8] usagePercentage=map[cpu:100 memory:0 pods:88.88888888888889]
I1124 14:51:07.942046  462893 lownodeutilization.go:268] "Node is underutilized" node="n2" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
I1124 14:51:07.942291  462893 lownodeutilization.go:274] "Node is appropriately utilized" node="n3" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
=== RUN   TestLowNodeUtilization/without_priorities_stop_when_cpu_capacity_is_depleted
I1124 14:51:07.942612  462893 lownodeutilization.go:271] "Node is overutilized" node="n1" usage=map[cpu:3200m memory:2400 pods:8] usagePercentage=map[cpu:100 memory:80 pods:88.88888888888889]
I1124 14:51:07.942623  462893 lownodeutilization.go:268] "Node is underutilized" node="n2" usage=map[cpu:400m memory:2100 pods:1] usagePercentage=map[cpu:25 memory:70 pods:10]
I1124 14:51:07.942632  462893 lownodeutilization.go:274] "Node is appropriately utilized" node="n3" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
=== RUN   TestLowNodeUtilization/with_priorities
I1124 14:51:07.942829  462893 lownodeutilization.go:271] "Node is overutilized" node="n1" usage=map[cpu:3200m memory:0 pods:8] usagePercentage=map[cpu:100 memory:0 pods:88.88888888888889]
I1124 14:51:07.942839  462893 lownodeutilization.go:268] "Node is underutilized" node="n2" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
I1124 14:51:07.942848  462893 lownodeutilization.go:274] "Node is appropriately utilized" node="n3" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
=== RUN   TestLowNodeUtilization/without_priorities_evicting_best-effort_pods_only
I1124 14:51:07.943053  462893 lownodeutilization.go:271] "Node is overutilized" node="n1" usage=map[cpu:1600m memory:0 pods:8] usagePercentage=map[cpu:50 memory:0 pods:88.88888888888889]
I1124 14:51:07.943063  462893 lownodeutilization.go:268] "Node is underutilized" node="n2" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
I1124 14:51:07.943073  462893 lownodeutilization.go:274] "Node is appropriately utilized" node="n3" usage=map[cpu:0 memory:0 pods:0] usagePercentage=map[cpu:0 memory:0 pods:0]
```