### PR TITLE
Enable Multi-Arch Container Image Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@ FROM golang:1.15.2
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .
+ARG ARCH
 ARG VERSION
-RUN VERSION=${VERSION} make
+RUN VERSION=${VERSION} make build.$ARCH
 
 FROM scratch
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,7 @@ steps:
     - VERSION=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
     args:
-    - push
+    - push-all
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -20,7 +20,7 @@
 3. Push the release branch to the descheuler repo and ensure branch protection is enabled (not required for patch releases)
 4. Tag the repository from the `master` branch (from the `release-1.18` branch for a patch release) and push the tag `VERSION=v0.18.0 git tag -m $VERSION $VERSION; git push origin $VERSION`
 5. Checkout the tag you just created and make sure your repo is clean by git's standards `git checkout $VERSION`
-6. Build and push the container image to the staging registry `VERSION=$VERSION make push`
+6. Build and push the container image to the staging registry `VERSION=$VERSION make push-all`
 7. Publish a draft release using the tag you just created
 8. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter)
 9. Publish release

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -3,6 +3,16 @@
 Starting with descheduler release v0.10.0 container images are available in the official k8s container registry.
 * `k8s.gcr.io/descheduler/descheduler`
 
+Also, starting with descheduler release v0.20.0 multi-arch container images are provided. Currently AMD64 and ARM64
+container images are provided. Multi-arch container images cannot be pulled by [kind](https://kind.sigs.k8s.io) from
+a registry. Therefore starting with descheduler release v0.20.0 use the below process to download the official descheduler
+image into a kind cluster.
+```
+kind create cluster
+docker pull k8s.gcr.io/descheduler/descheduler:v0.20.0
+kind load docker-image k8s.gcr.io/descheduler/descheduler:v0.20.0
+```
+
 ## Policy Configuration Examples
 The [examples](https://github.com/kubernetes-sigs/descheduler/tree/master/examples) directory has descheduler policy configuration examples.
 


### PR DESCRIPTION
Previous to this change official descheduler container images only
supported the AMD64 hardware architecture. This change enables
building official descheduler container images for multiple
architectures.

The initially supported architectures are AMD64 and ARM64.

Fixes #445 