### PR TITLE
Fix README example install CLI

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -6,7 +6,7 @@
 
 ```shell
 helm repo add descheduler https://kubernetes-sigs.github.io/descheduler/
-helm install my-release --namespace kube-system descheduler/descheduler
+helm install my-release --namespace kube-system descheduler/descheduler-helm-chart
 ```
 
 ## Introduction
@@ -22,7 +22,7 @@ This chart bootstraps a [descheduler](https://github.com/kubernetes-sigs/desched
 To install the chart with the release name `my-release`:
 
 ```shell
-helm install --namespace kube-system my-release descheduler/descheduler
+helm install my-release --namespace kube-system descheduler/descheduler-helm-chart
 ```
 
 The command deploys _descheduler_ on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.


### PR DESCRIPTION
When executing the below command that is wrriten the README , we got an error.

```shell
$helm install my-release --namespace kube-system descheduler/descheduler

Error: failed to download "descheduler/descheduler"
```

I found that the chart name is different from README.
I think this PR may help people who want to install this chart.



```shell
$ helm repo list | grep descheduler
descheduler             https://kubernetes-sigs.github.io/descheduler/
```
```
$ helm search repo descheduler
NAME                                    CHART VERSION   APP VERSION     DESCRIPTION
descheduler/descheduler-helm-chart      0.19.0          0.19.0          Descheduler for Kubernetes is used to rebalance...
```