### PR TITLE
Allow setting options successfulJobsHistoryLimit and failedJobsHistoryLimit for cronjob

### DIFF
--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: descheduler
-version: 0.19.0
-appVersion: 0.19.0
+version: 0.20.0
+appVersion: 0.20.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:
 - kubernetes

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -51,7 +51,9 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                 |
 | `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                 |
 | `schedule`                     | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                      |
-| `startingDeadlineSeconds`      | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                 |
+| `startingDeadlineSeconds`      | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                |
+| `successfulJobsHistoryLimit`   | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `nil`                                |
+| `failedJobsHistoryLimit`       | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `nil`                                |
 | `cmdOptions`                   | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                    |
 | `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                    |
 | `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`            |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -10,6 +10,12 @@ spec:
   {{- if .Values.startingDeadlineSeconds }}
   startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
   {{- end }}
+  {{- if .Values.successfulJobsHistoryLimit }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  {{- end }}
+  {{- if .Values.failedJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  {{- end }}
   jobTemplate:
     spec:
       template:

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -21,6 +21,8 @@ fullnameOverride: ""
 
 schedule: "*/2 * * * *"
 #startingDeadlineSeconds: 200
+#successfulJobsHistoryLimit: 1
+#failedJobsHistoryLimit: 1
 
 cmdOptions:
   v: 3


### PR DESCRIPTION
Allow end users to optionally set the descheduler CronJob `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` when installing using helm chart.