### PR TITLE
Helm chart rename - Step #1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,20 +11,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Fetch history
-        run: git fetch --prune --unshallow
-
-      - name: Add dependency chart repos
-        run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.2
+        uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: "descheduler-helm-chart-{{ .Version }}"

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,16 +1,14 @@
 apiVersion: v1
 name: descheduler-helm-chart
-version: 0.19.0
+version: 0.19.1
 appVersion: 0.19.0
-description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
+description: DEPRECATED - Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:
-- kubernetes
-- descheduler
-- kube-scheduler
+  - kubernetes
+  - descheduler
+  - kube-scheduler
 home: https://github.com/kubernetes-sigs/descheduler
 icon: https://kubernetes.io/images/favicon.png
 sources:
-- https://github.com/kubernetes-sigs/descheduler
-maintainers:
-- name: Kubernetes SIG Scheduling
-  email: kubernetes-sig-scheduling@googlegroups.com
+  - https://github.com/kubernetes-sigs/descheduler
+deprecated: true

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -43,17 +43,17 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the _descheduler_ chart and their default values.
 
-| Parameter                      | Description                                                                                                           | Default                                                |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `image.repository`             | Docker repository to use                                                                                              | `k8s.gcr.io/descheduler/descheduler`                   |
-| `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                                  |
-| `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                                         |
-| `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                                   |
-| `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                                   |
-| `schedule`                     | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                                        |
-| `cmdOptions`                   | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                                      |
-| `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                                      |
-| `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                              |
-| `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                                                 |
-| `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                                                 |
-| `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                                  |
+| Parameter                      | Description                                                                                                           | Default                              |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `image.repository`             | Docker repository to use                                                                                              | `k8s.gcr.io/descheduler/descheduler` |
+| `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                |
+| `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                       |
+| `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                 |
+| `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                 |
+| `schedule`                     | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                      |
+| `cmdOptions`                   | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                    |
+| `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                    |
+| `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`            |
+| `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                               |
+| `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                               |
+| `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                |


### PR DESCRIPTION
**IMPORTANT** - This needs to be merged before PR https://github.com/kubernetes-sigs/descheduler/pull/457 and PR https://github.com/kubernetes-sigs/descheduler/pull/459.

This PR will deprecate the existing [descheduler-helm-chart](https://artifacthub.io/packages/helm/descheduler/descheduler-helm-chart) ready for it to renamed to _descheduler_.