### PR TITLE
Run as user 1000 so pod can be runAsNonRoot for security purposes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ FROM scratch
 
 MAINTAINER Avesh Agarwal <avesh.ncsu@gmail.com>
 
+USER 1000
+
 COPY --from=0 /go/src/sigs.k8s.io/descheduler/_output/bin/descheduler /bin/descheduler
 
 CMD ["/bin/descheduler", "--help"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,6 +15,8 @@ FROM scratch
 
 MAINTAINER Avesh Agarwal <avesh.ncsu@gmail.com>
 
+USER 1000
+
 COPY _output/bin/descheduler /bin/descheduler
 
 CMD ["/bin/descheduler", "--help"]


### PR DESCRIPTION
Can add this to the cronjob/job kubernetes manifests
```
securityContext:
  runAsNonRoot: true
  readOnlyRootFilesystem: true
```

/cc @seanmalloy 