### PR TITLE
Add a parameter for making the thresholds of the LowNodeUtilization strategy relative to average values

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,10 +176,16 @@ can be configured for cpu, memory, and number of pods too in terms of percentage
 
 These thresholds, `thresholds` and `targetThresholds`, could be tuned as per your cluster requirements.
 
+Additionally, the strategy accepts a `useDeviationThresholds` parameter.
+If that parameter is set to `true`, the thresholds are considered as percentage deviations from mean resource usage.
+`thresholds` will be deducted from the mean among all nodes and `targetThresholds` will be added to the mean.
+A resource consumption above (resp. below) this window is considered as overutilization (resp. underutilization).
+
 **Parameters:**
 
 |Name|Type|
 |---|---|
+|`useDeviationThresholds`|bool|
 |`thresholds`|map(string:int)|
 |`targetThresholds`|map(string:int)|
 |`numberOfNodes`|int|

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -79,9 +79,10 @@ type Percentage float64
 type ResourceThresholds map[v1.ResourceName]Percentage
 
 type NodeResourceUtilizationThresholds struct {
-	Thresholds       ResourceThresholds
-	TargetThresholds ResourceThresholds
-	NumberOfNodes    int
+	UseDeviationThresholds bool
+	Thresholds             ResourceThresholds
+	TargetThresholds       ResourceThresholds
+	NumberOfNodes          int
 }
 
 type PodsHavingTooManyRestarts struct {

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -77,9 +77,10 @@ type Percentage float64
 type ResourceThresholds map[v1.ResourceName]Percentage
 
 type NodeResourceUtilizationThresholds struct {
-	Thresholds       ResourceThresholds `json:"thresholds,omitempty"`
-	TargetThresholds ResourceThresholds `json:"targetThresholds,omitempty"`
-	NumberOfNodes    int                `json:"numberOfNodes,omitempty"`
+	UseDeviationThresholds bool               `json:"useDeviationThresholds,omitempty"`
+	Thresholds             ResourceThresholds `json:"thresholds,omitempty"`
+	TargetThresholds       ResourceThresholds `json:"targetThresholds,omitempty"`
+	NumberOfNodes          int                `json:"numberOfNodes,omitempty"`
 }
 
 type PodsHavingTooManyRestarts struct {

--- a/pkg/api/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/v1alpha1/zz_generated.conversion.go
@@ -191,6 +191,7 @@ func Convert_api_Namespaces_To_v1alpha1_Namespaces(in *api.Namespaces, out *Name
 }
 
 func autoConvert_v1alpha1_NodeResourceUtilizationThresholds_To_api_NodeResourceUtilizationThresholds(in *NodeResourceUtilizationThresholds, out *api.NodeResourceUtilizationThresholds, s conversion.Scope) error {
+	out.UseDeviationThresholds = in.UseDeviationThresholds
 	out.Thresholds = *(*api.ResourceThresholds)(unsafe.Pointer(&in.Thresholds))
 	out.TargetThresholds = *(*api.ResourceThresholds)(unsafe.Pointer(&in.TargetThresholds))
 	out.NumberOfNodes = in.NumberOfNodes
@@ -203,6 +204,7 @@ func Convert_v1alpha1_NodeResourceUtilizationThresholds_To_api_NodeResourceUtili
 }
 
 func autoConvert_api_NodeResourceUtilizationThresholds_To_v1alpha1_NodeResourceUtilizationThresholds(in *api.NodeResourceUtilizationThresholds, out *NodeResourceUtilizationThresholds, s conversion.Scope) error {
+	out.UseDeviationThresholds = in.UseDeviationThresholds
 	out.Thresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.Thresholds))
 	out.TargetThresholds = *(*ResourceThresholds)(unsafe.Pointer(&in.TargetThresholds))
 	out.NumberOfNodes = in.NumberOfNodes


### PR DESCRIPTION
### Reason for this PR

Currently, the thresholds that can be set for the `LodNodeUtilization` strategy only allow to make sure that nodes aren't over or underutilized compared to thresholds relative to their capacities. However, sometimes, it's desirable to make sure all nodes are "similarly" utilized to ensure the proper balance of a cluster. While this is possible to implement using the current thresholds, the values needed to achieve such a balancing behavior would be dependent on the number of nodes, pods, and their memory/CPU requests, which is not very practical to configure, especially for dynamic clusters. 

### Feature of this PR

This PR enables the `descheduler` to achieve such a goal. We define an additional `useDeviationThresholds` boolean parameter (the name is maybe not the best, it can change). If `false`, the `descheduler` behaves as now. If `true`, the thresholds are considered as percentage deviations relative to the average utilizations among all nodes. 

For example. Considering only the memory metric. If nodes have utilizations of _[10%, 20%, 30%, 20%]_ and both `threshold` and `targetThreshold` are 5%. The average node utilization is _(10% + 20% + 30% + 20%) / 4 = 20%_. The first node has an utilization of 10%, which is lower than 20% (_average_) - 5% (_threshold_). The node is hence considered underutilized. The third node has an utilization of 30%, which is greater than 20% (_average_) + 5% (_targetThreshold_). The node is hence considered overutilized. Both other nodes have utilizations within the [20% - 5%, 20% + 5%] window and are hence considered appropriately utilized. 

Once nodes are labeled as _under-_ or _overutilized_, the strategy behaves exactly the same as before. 

### Code style comment

Since the only change compared to the original strategy is the way nodes are categorized as _over-_ and _underutilized_, I thought it is best to include that in the existing `LowNodeUtilization` strategy and not to create a new strategy. Another option would be to create two distinct strategies that share methods. I went for the first option as that was the easiest to implement. I would definitely not be against the second option.

### Test

We had this need/problem in our 200+ pods cluster. We deployed the `descheduler` from this PR with success in our test clusters. It passes our tests (that make sure that the correct pods are evicted when the cluster is unbalanced) and works as expected and without any detected issues for now.

### Vision

In general, the proposed feature goes into the direction of a more general intention we have with the `descheduler`: take the state of the cluster, smartly compute a new schedule for all the pods (not one by one but all at once to leverage the complete knowledge we have) according to a given strategy (ours: balanced utilization), and then implementing the transition from the current state to the desired state. This PR is our first (small) step towards that goal but is there such a plan for the `descheduler`? Overall, that  would turn the `descheduler` into a "cluster scheduler" in contrast to the current "per-pod scheduler" of Kubernetes. I know there is a plan to eventually incorporate scheduling in the tool and not to rely on the existing scheduler, but not sure if you're looking into such optimization-driven strategies.