### PR TITLE
Fix TopologySpread bug that evicts non-evictable pods

### DIFF
--- a/pkg/descheduler/strategies/topologyspreadconstraint.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint.go
@@ -188,7 +188,10 @@ func RemovePodsViolatingTopologySpreadConstraint(
 	}
 
 	for pod := range podsForEviction {
-		if _, err := podEvictor.EvictPod(ctx, pod, nodeMap[pod.Spec.NodeName], "PodTopologySpread"); err != nil && !evictable.IsEvictable(pod) {
+		if !evictable.IsEvictable(pod) {
+			continue
+		}
+		if _, err := podEvictor.EvictPod(ctx, pod, nodeMap[pod.Spec.NodeName], "PodTopologySpread"); err != nil {
 			klog.ErrorS(err, "Error evicting pod", "pod", klog.KObj(pod))
 			break
 		}


### PR DESCRIPTION
TopologySpreadConstraint does not properly check if a pod is evictable before calling `EvictPod` (due to the fact that it does not rely on `ListPodsOnNode`, which takes `IsEvictable` as a parameter and does the check there for most of the other strategies).

This breaks the check out explicitly. It could also be refactored to do this check in `balanceDomains`, when building the list of evictable pods.