### PR TITLE
Modify resourceUsage.Value() to resourceUsage.MilliValue()

### DIFF
--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -248,7 +248,7 @@ func resourceUsagePercentages(nodeUsage NodeUsage) map[v1.ResourceName]float64 {
 	for resourceName, resourceUsage := range nodeUsage.usage {
 		cap := nodeCapacity[resourceName]
 		if !cap.IsZero() {
-			resourceUsagePercentage[resourceName] = 100 * float64(resourceUsage.Value()) / float64(cap.Value())
+			resourceUsagePercentage[resourceName] = 100 * float64(resourceUsage.MilliValue()) / float64(cap.MilliValue())
 		}
 	}
 


### PR DESCRIPTION
I have a node with a CPU that can be allocated 3000m. I actually used 2015m. I set the threshold value to 70%. So my node has not reached this threshold, but I check the log and show that the CPU usage is 100% because When calculating usagePercentage, the Value() method is used, so here is the calculation of 3/3 as 100%, I think this may be misleading.