### PR TITLE
Move 'total pods evicted' log message to main loop

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -130,6 +130,8 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 			}
 		}
 
+		klog.V(1).InfoS("Number of evicted pods", "totalEvicted", podEvictor.TotalEvicted())
+
 		// If there was no interval specified, send a signal to the stopChannel to end the wait.Until loop after 1 iteration
 		if rs.DeschedulingInterval.Seconds() == 0 {
 			close(stopChannel)

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -149,8 +149,6 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		lowNodes,
 		podEvictor,
 		evictable.IsEvictable)
-
-	klog.V(1).InfoS("Total number of pods evicted", "evictedPods", podEvictor.TotalEvicted())
 }
 
 // validateStrategyConfig checks if the strategy's config is valid

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -104,5 +104,4 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 			klog.ErrorS(nil, "Invalid nodeAffinityType", "nodeAffinity", nodeAffinity)
 		}
 	}
-	klog.V(1).InfoS("Number of evicted pods", "totalEvicted", podEvictor.TotalEvicted())
 }


### PR DESCRIPTION
This is logging the total pods evicted across all strategies (with the shared `podEvictor`). So, moving it out of node affinity and lowNodeUtilization, and into the main descheduler loop.

/kind bug
fixes https://github.com/kubernetes-sigs/descheduler/issues/501