### PR TITLE
Add verify scripts for make gen to run during PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ push-all: image.amd64 image.arm image.arm64
 clean:
 	rm -rf _output
 
-verify: verify-gofmt verify-vendor lint lint-chart verify-spelling verify-toc
+verify: verify-gofmt verify-vendor lint lint-chart verify-spelling verify-toc verify-gen
 
 verify-spelling:
 	./hack/verify-spelling.sh
@@ -119,6 +119,9 @@ gen:
 	./hack/update-generated-deep-copies.sh
 	./hack/update-generated-defaulters.sh
 	./hack/update-toc.sh
+
+verify-gen:
+	./hack/verify-conversions.sh
 
 lint:
 ifndef HAS_GOLANGCI

--- a/hack/verify-conversions.sh
+++ b/hack/verify-conversions.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/..
+mkdir -p "${DESCHEDULER_ROOT}/_tmp"
+_tmpdir="$(mktemp -d "${DESCHEDULER_ROOT}/_tmp/kube-verify.XXXXXX")"
+
+_deschedulertmp="${_tmpdir}"
+mkdir -p "${_deschedulertmp}"
+
+git archive --format=tar --prefix=descheduler/ "$(git write-tree)" | (cd "${_deschedulertmp}" && tar xf -)
+_deschedulertmp="${_deschedulertmp}/descheduler"
+
+pushd "${_deschedulertmp}" > /dev/null 2>&1
+go build -o "${OS_OUTPUT_BINPATH}/conversion-gen" "k8s.io/code-generator/cmd/conversion-gen"
+
+${OS_OUTPUT_BINPATH}/conversion-gen \
+		--go-header-file "hack/boilerplate/boilerplate.go.txt" \
+		--input-dirs "./pkg/apis/componentconfig/v1alpha1,./pkg/api/v1alpha1" \
+		--output-file-base zz_generated.conversion
+popd > /dev/null 2>&1
+
+pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1
+if ! _out="$(diff -Naupr pkg/ "${_deschedulertmp}/pkg/")"; then
+    echo "Generated output differs:" >&2
+    echo "${_out}" >&2
+    echo "Generated conversions verify failed."
+    exit 1
+fi
+popd > /dev/null 2>&1
+
+echo "Generated conversions verified."


### PR DESCRIPTION
This PR fixes: https://github.com/kubernetes-sigs/descheduler/issues/483

As part of this change, we want to add steps to ensure that `make gen` has been run and there are no changes being generated during the PR. 
For now, I've tested the code in local for the steps which I've added in the Makefile and below is the output for same,
```
 ->  make verify-gen
./hack/verify-makegen.sh

Diff in the PR has changed
make: *** [Makefile:112: verify-gen] Error 1
```
Since it's reporting error, which means it's pointing that the generators have been downloaded at the latest in the `_output` directory in my local.