### PR TITLE
Move Inactive Maintainers to Emeritus Status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN VERSION=${VERSION} make build.$ARCH
 
 FROM scratch
 
-MAINTAINER Avesh Agarwal <avesh.ncsu@gmail.com>
+MAINTAINER Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>
 
 USER 1000
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@
 # limitations under the License.
 FROM scratch
 
-MAINTAINER Avesh Agarwal <avesh.ncsu@gmail.com>
+MAINTAINER Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>
 
 USER 1000
 

--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,7 @@
 approvers:
-- aveshagarwal
-- k82cn
-- ravisantoshgudimetla
 - damemi
+- ingvagabund
+- seanmalloy
 reviewers:
 - aveshagarwal
 - k82cn
@@ -11,3 +10,7 @@ reviewers:
 - seanmalloy
 - ingvagabund
 - lixiang233
+emeritus_approvers:
+- aveshagarwal
+- k82cn
+- ravisantoshgudimetla


### PR DESCRIPTION
For roughly the past year damemi has been the only active approver for
the descheduler. Therefore move the inactive approvers to emeritus
status. This will help clarify to contributors who should be assigned to
pull requests.