### PR TITLE
Clarify resource percentage calculation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,11 @@ in the hope that recreation of evicted pods will be scheduled on these underutil
 parameters of this strategy are configured under `nodeResourceUtilizationThresholds`.
 
 The under utilization of nodes is determined by a configurable threshold `thresholds`. The threshold
-`thresholds` can be configured for cpu, memory, and number of pods in terms of percentage. If a node's
-usage is below threshold for all (cpu, memory, and number of pods), the node is considered underutilized.
+`thresholds` can be configured for cpu, memory, and number of pods in terms of percentage (the percentage is
+calculated as the current resources requested on the node vs [total allocatable](https://kubernetes.io/docs/concepts/architecture/nodes/#capacity).
+For pods, this means the number of pods on the node as a fraction of the pod capacity set for that node).
+
+If a node's usage is below threshold for all (cpu, memory, and number of pods), the node is considered underutilized.
 Currently, pods request resource requirements are considered for computing node resource utilization.
 
 There is another configurable threshold, `targetThresholds`, that is used to compute those potential nodes


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/descheduler/issues/514
Clarifies what we mean by "number of pods in terms of percentage" with a link to upstream docs