### PR TITLE
Enable ARM32v7 Container Image Builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BRANCH?=$(shell git branch --show-current)
 SHA1?=$(shell git rev-parse HEAD)
 BUILD=$(shell date +%FT%T%z)
 LDFLAG_LOCATION=sigs.k8s.io/descheduler/pkg/version
-ARCHS = amd64 arm64
+ARCHS = amd64 arm arm64
 
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitbranch=${BRANCH} -X ${LDFLAG_LOCATION}.gitsha1=${SHA1}"
 
@@ -53,6 +53,9 @@ build:
 build.amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ${LDFLAGS} -o _output/bin/descheduler sigs.k8s.io/descheduler/cmd/descheduler
 
+build.arm:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build ${LDFLAGS} -o _output/bin/descheduler sigs.k8s.io/descheduler/cmd/descheduler
+
 build.arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ${LDFLAGS} -o _output/bin/descheduler sigs.k8s.io/descheduler/cmd/descheduler
 
@@ -65,6 +68,9 @@ image:
 image.amd64:
 	docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" -t $(IMAGE)-amd64 .
 
+image.arm:
+	docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="arm" -t $(IMAGE)-arm .
+
 image.arm64:
 	docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="arm64" -t $(IMAGE)-arm64 .
 
@@ -73,7 +79,7 @@ push: image
 	docker tag $(IMAGE) $(IMAGE_GCLOUD)
 	docker push $(IMAGE_GCLOUD)
 
-push-all: image.amd64 image.arm64
+push-all: image.amd64 image.arm image.arm64
 	gcloud auth configure-docker
 	for arch in $(ARCHS); do \
 		docker tag $(IMAGE)-$${arch} $(IMAGE_GCLOUD)-$${arch} ;\


### PR DESCRIPTION
Add ARM32v7 in addition to the currently supported architectures. This
will allow running descheduler on Raspberry Pi v3 devices.

Fixes #475 

