### PR TITLE
Added EvictSystemCriticalPods flag to descheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _tmp/
 vendordiff.patch
 .idea/
 *.code-workspace
+.vscode/

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ parameters associated with the strategies can be configured too. By default, all
 
 The policy also includes common configuration for all the strategies:
 - `nodeSelector` - limiting the nodes which are processed
-- `evictLocalStoragePods` - allowing to evict pods with local storage
+- `evictLocalStoragePods` - allows eviction of pods with local storage
+- `evictSystemCriticalPods` - [Warning: Will evict Kubernetes system pods] allows eviction of pods with any priority, including system pods like kube-dns
 - `ignorePvcPods` - set whether PVC pods should be evicted or ignored (defaults to `false`)
 - `maxNoOfPodsToEvictPerNode` - maximum number of pods evicted from each node (summed through all strategies)
 
@@ -122,6 +123,7 @@ apiVersion: "descheduler/v1alpha1"
 kind: "DeschedulerPolicy"
 nodeSelector: prod=dev
 evictLocalStoragePods: true
+evictSystemCriticalPods: true
 maxNoOfPodsToEvictPerNode: 40
 ignorePvcPods: false
 strategies:
@@ -480,6 +482,9 @@ All strategies are able to configure a priority threshold, only pods under the t
 specify this threshold by setting `thresholdPriorityClassName`(setting the threshold to the value of the given
 priority class) or `thresholdPriority`(directly setting the threshold) parameters. By default, this threshold
 is set to the value of `system-cluster-critical` priority class.
+
+Note: Setting `evictSystemCriticalPods` to true disables priority filtering entirely.
+
 E.g.
 
 Setting `thresholdPriority`
@@ -547,12 +552,12 @@ strategies:
 
 When the descheduler decides to evict pods from a node, it employs the following general mechanism:
 
-* [Critical pods](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/) (with priorityClassName set to system-cluster-critical or system-node-critical) are never evicted.
+* [Critical pods](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/) (with priorityClassName set to system-cluster-critical or system-node-critical) are never evicted (unless `evictSystemCriticalPods: true` is set).
 * Pods (static or mirrored pods or stand alone pods) not part of an ReplicationController, ReplicaSet(Deployment), StatefulSet, or Job are
 never evicted because these pods won't be recreated.
 * Pods associated with DaemonSets are never evicted.
-* Pods with local storage are never evicted (unless `evictLocalStoragePods: true` is set)
-* Pods with PVCs are evicted unless `ignorePvcPods: true` is set.
+* Pods with local storage are never evicted (unless `evictLocalStoragePods: true` is set).
+* Pods with PVCs are evicted (unless `ignorePvcPods: true` is set).
 * In `LowNodeUtilization` and `RemovePodsViolatingInterPodAntiAffinity`, pods are evicted by their priority from low to high, and if they have same priority,
 best effort pods are evicted before burstable and guaranteed pods.
 * All types of pods with the annotation `descheduler.alpha.kubernetes.io/evict` are eligible for eviction. This

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -35,6 +35,9 @@ type DeschedulerPolicy struct {
 	// EvictLocalStoragePods allows pods using local storage to be evicted.
 	EvictLocalStoragePods *bool
 
+	// EvictSystemCriticalPods allows eviction of pods of any priority (including Kubernetes system pods)
+	EvictSystemCriticalPods *bool
+
 	// IgnorePVCPods prevents pods with PVCs from being evicted.
 	IgnorePVCPods *bool
 

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -35,6 +35,9 @@ type DeschedulerPolicy struct {
 	// EvictLocalStoragePods allows pods using local storage to be evicted.
 	EvictLocalStoragePods *bool `json:"evictLocalStoragePods,omitempty"`
 
+	// EvictSystemCriticalPods allows eviction of pods of any priority (including Kubernetes system pods)
+	EvictSystemCriticalPods *bool `json:"evictSystemCriticalPods,omitempty"`
+
 	// IgnorePVCPods prevents pods with PVCs from being evicted.
 	IgnorePVCPods *bool `json:"ignorePvcPods,omitempty"`
 

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -93,6 +93,14 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		evictLocalStoragePods = *deschedulerPolicy.EvictLocalStoragePods
 	}
 
+	evictSystemCriticalPods := false
+	if deschedulerPolicy.EvictSystemCriticalPods != nil {
+		evictSystemCriticalPods = *deschedulerPolicy.EvictSystemCriticalPods
+		if evictSystemCriticalPods {
+			klog.V(1).InfoS("Warning: EvictSystemCriticalPods is set to True. This could cause eviction of Kubernetes system pods.")
+		}
+	}
+
 	ignorePvcPods := false
 	if deschedulerPolicy.IgnorePVCPods != nil {
 		ignorePvcPods = *deschedulerPolicy.IgnorePVCPods
@@ -124,6 +132,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 			maxNoOfPodsToEvictPerNode,
 			nodes,
 			evictLocalStoragePods,
+			evictSystemCriticalPods,
 			ignorePvcPods,
 		)
 

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -46,13 +46,14 @@ const (
 type nodePodEvictedCount map[*v1.Node]int
 
 type PodEvictor struct {
-	client                clientset.Interface
-	policyGroupVersion    string
-	dryRun                bool
-	maxPodsToEvictPerNode int
-	nodepodCount          nodePodEvictedCount
-	evictLocalStoragePods bool
-	ignorePvcPods         bool
+	client                  clientset.Interface
+	policyGroupVersion      string
+	dryRun                  bool
+	maxPodsToEvictPerNode   int
+	nodepodCount            nodePodEvictedCount
+	evictLocalStoragePods   bool
+	evictSystemCriticalPods bool
+	ignorePvcPods           bool
 }
 
 func NewPodEvictor(
@@ -62,6 +63,7 @@ func NewPodEvictor(
 	maxPodsToEvictPerNode int,
 	nodes []*v1.Node,
 	evictLocalStoragePods bool,
+	evictSystemCriticalPods bool,
 	ignorePvcPods bool,
 ) *PodEvictor {
 	var nodePodCount = make(nodePodEvictedCount)
@@ -71,13 +73,14 @@ func NewPodEvictor(
 	}
 
 	return &PodEvictor{
-		client:                client,
-		policyGroupVersion:    policyGroupVersion,
-		dryRun:                dryRun,
-		maxPodsToEvictPerNode: maxPodsToEvictPerNode,
-		nodepodCount:          nodePodCount,
-		evictLocalStoragePods: evictLocalStoragePods,
-		ignorePvcPods:         ignorePvcPods,
+		client:                  client,
+		policyGroupVersion:      policyGroupVersion,
+		dryRun:                  dryRun,
+		maxPodsToEvictPerNode:   maxPodsToEvictPerNode,
+		nodepodCount:            nodePodCount,
+		evictLocalStoragePods:   evictLocalStoragePods,
+		evictSystemCriticalPods: evictSystemCriticalPods,
+		ignorePvcPods:           ignorePvcPods,
 	}
 }
 
@@ -188,42 +191,50 @@ func (pe *PodEvictor) Evictable(opts ...func(opts *Options)) *evictable {
 	}
 
 	ev := &evictable{}
+	if !pe.evictSystemCriticalPods {
+		ev.constraints = append(ev.constraints, func(pod *v1.Pod) error {
+			// Moved from IsEvictable function to allow for disabling
+			if utils.IsCriticalPriorityPod(pod) {
+				return fmt.Errorf("pod has system critical priority")
+			}
+			return nil
+		})
+
+		if options.priority != nil {
+			ev.constraints = append(ev.constraints, func(pod *v1.Pod) error {
+				if IsPodEvictableBasedOnPriority(pod, *options.priority) {
+					return nil
+				}
+				return fmt.Errorf("pod has higher priority than specified priority class threshold")
+			})
+		}
+	}
 	if !pe.evictLocalStoragePods {
 		ev.constraints = append(ev.constraints, func(pod *v1.Pod) error {
-			if IsPodWithLocalStorage(pod) {
-				return fmt.Errorf("pod has local storage and descheduler is not configured with --evict-local-storage-pods")
+			if utils.IsPodWithLocalStorage(pod) {
+				return fmt.Errorf("pod has local storage and descheduler is not configured with evictLocalStoragePods")
 			}
 			return nil
 		})
 	}
 	if pe.ignorePvcPods {
 		ev.constraints = append(ev.constraints, func(pod *v1.Pod) error {
-			if IsPodWithPVC(pod) {
+			if utils.IsPodWithPVC(pod) {
 				return fmt.Errorf("pod has a PVC and descheduler is configured to ignore PVC pods")
 			}
 			return nil
 		})
 	}
-	if options.priority != nil {
-		ev.constraints = append(ev.constraints, func(pod *v1.Pod) error {
-			if IsPodEvictableBasedOnPriority(pod, *options.priority) {
-				return nil
-			}
-			return fmt.Errorf("pod has higher priority than specified priority class threshold")
-		})
-	}
+
 	return ev
 }
 
 // IsEvictable decides when a pod is evictable
 func (ev *evictable) IsEvictable(pod *v1.Pod) bool {
 	checkErrs := []error{}
-	if IsCriticalPod(pod) {
-		checkErrs = append(checkErrs, fmt.Errorf("pod is critical"))
-	}
 
 	ownerRefList := podutil.OwnerRef(pod)
-	if IsDaemonsetPod(ownerRefList) {
+	if utils.IsDaemonsetPod(ownerRefList) {
 		checkErrs = append(checkErrs, fmt.Errorf("pod is a DaemonSet pod"))
 	}
 
@@ -231,8 +242,12 @@ func (ev *evictable) IsEvictable(pod *v1.Pod) bool {
 		checkErrs = append(checkErrs, fmt.Errorf("pod does not have any ownerrefs"))
 	}
 
-	if IsMirrorPod(pod) {
+	if utils.IsMirrorPod(pod) {
 		checkErrs = append(checkErrs, fmt.Errorf("pod is a mirror pod"))
+	}
+
+	if utils.IsStaticPod(pod) {
+		checkErrs = append(checkErrs, fmt.Errorf("pod is a static pod"))
 	}
 
 	for _, c := range ev.constraints {
@@ -245,50 +260,14 @@ func (ev *evictable) IsEvictable(pod *v1.Pod) bool {
 		klog.V(4).InfoS("Pod lacks an eviction annotation and fails the following checks", "pod", klog.KObj(pod), "checks", errors.NewAggregate(checkErrs).Error())
 		return false
 	}
+
 	return true
-}
-
-func IsCriticalPod(pod *v1.Pod) bool {
-	return utils.IsCriticalPod(pod)
-}
-
-func IsDaemonsetPod(ownerRefList []metav1.OwnerReference) bool {
-	for _, ownerRef := range ownerRefList {
-		if ownerRef.Kind == "DaemonSet" {
-			return true
-		}
-	}
-	return false
-}
-
-// IsMirrorPod checks whether the pod is a mirror pod.
-func IsMirrorPod(pod *v1.Pod) bool {
-	return utils.IsMirrorPod(pod)
 }
 
 // HaveEvictAnnotation checks if the pod have evict annotation
 func HaveEvictAnnotation(pod *v1.Pod) bool {
 	_, found := pod.ObjectMeta.Annotations[evictPodAnnotationKey]
 	return found
-}
-
-func IsPodWithLocalStorage(pod *v1.Pod) bool {
-	for _, volume := range pod.Spec.Volumes {
-		if volume.HostPath != nil || volume.EmptyDir != nil {
-			return true
-		}
-	}
-
-	return false
-}
-
-func IsPodWithPVC(pod *v1.Pod) bool {
-	for _, volume := range pod.Spec.Volumes {
-		if volume.PersistentVolumeClaim != nil {
-			return true
-		}
-	}
-	return false
 }
 
 // IsPodEvictableBasedOnPriority checks if the given pod is evictable based on priority resolved from pod Spec.

--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -74,45 +74,67 @@ func TestIsEvictable(t *testing.T) {
 	lowPriority := int32(800)
 	highPriority := int32(900)
 	type testCase struct {
-		pod                   *v1.Pod
-		runBefore             func(*v1.Pod)
-		evictLocalStoragePods bool
-		priorityThreshold     *int32
-		result                bool
+		pod                     *v1.Pod
+		runBefore               func(*v1.Pod)
+		evictLocalStoragePods   bool
+		evictSystemCriticalPods bool
+		priorityThreshold       *int32
+		result                  bool
 	}
 
 	testCases := []testCase{
-		{
+		{ // Normal pod eviction with normal ownerRefs
 			pod: test.BuildTestPod("p1", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Normal pod eviction with normal ownerRefs and descheduler.alpha.kubernetes.io/evict annotation
 			pod: test.BuildTestPod("p2", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Normal pod eviction with replicaSet ownerRefs
 			pod: test.BuildTestPod("p3", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Normal pod eviction with replicaSet ownerRefs and descheduler.alpha.kubernetes.io/evict annotation
 			pod: test.BuildTestPod("p4", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
 				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Normal pod eviction with statefulSet ownerRefs
+			pod: test.BuildTestPod("p18", 400, 0, n1.Name, nil),
+			runBefore: func(pod *v1.Pod) {
+				pod.ObjectMeta.OwnerReferences = test.GetStatefulSetOwnerRefList()
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Normal pod eviction with statefulSet ownerRefs and descheduler.alpha.kubernetes.io/evict annotation
+			pod: test.BuildTestPod("p19", 400, 0, n1.Name, nil),
+			runBefore: func(pod *v1.Pod) {
+				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+				pod.ObjectMeta.OwnerReferences = test.GetStatefulSetOwnerRefList()
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Pod not evicted because it is bound to a PV and evictLocalStoragePods = false
 			pod: test.BuildTestPod("p5", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
@@ -127,9 +149,10 @@ func TestIsEvictable(t *testing.T) {
 					},
 				}
 			},
-			evictLocalStoragePods: false,
-			result:                false,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  false,
+		}, { // Pod is evicted because it is bound to a PV and evictLocalStoragePods = true
 			pod: test.BuildTestPod("p6", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
@@ -144,9 +167,10 @@ func TestIsEvictable(t *testing.T) {
 					},
 				}
 			},
-			evictLocalStoragePods: true,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   true,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Pod is evicted because it is bound to a PV and evictLocalStoragePods = false, but it has scheduler.alpha.kubernetes.io/evict annotation
 			pod: test.BuildTestPod("p7", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
@@ -162,50 +186,56 @@ func TestIsEvictable(t *testing.T) {
 					},
 				}
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Pod not evicted becasuse it is part of a daemonSet
 			pod: test.BuildTestPod("p8", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList()
 			},
-			evictLocalStoragePods: false,
-			result:                false,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  false,
+		}, { // Pod is evicted becasuse it is part of a daemonSet, but it has scheduler.alpha.kubernetes.io/evict annotation
 			pod: test.BuildTestPod("p9", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
 				pod.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList()
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Pod not evicted becasuse it is a mirror pod
 			pod: test.BuildTestPod("p10", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 				pod.Annotations = test.GetMirrorPodAnnotation()
 			},
-			evictLocalStoragePods: false,
-			result:                false,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  false,
+		}, { // Pod is evicted becasuse it is a mirror pod, but it has scheduler.alpha.kubernetes.io/evict annotation
 			pod: test.BuildTestPod("p11", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 				pod.Annotations = test.GetMirrorPodAnnotation()
 				pod.Annotations["descheduler.alpha.kubernetes.io/evict"] = "true"
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Pod not evicted becasuse it has system critical priority
 			pod: test.BuildTestPod("p12", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 				priority := utils.SystemCriticalPriority
 				pod.Spec.Priority = &priority
 			},
-			evictLocalStoragePods: false,
-			result:                false,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  false,
+		}, { // Pod is evicted becasuse it has system critical priority, but it has scheduler.alpha.kubernetes.io/evict annotation
 			pod: test.BuildTestPod("p13", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
@@ -215,42 +245,72 @@ func TestIsEvictable(t *testing.T) {
 					"descheduler.alpha.kubernetes.io/evict": "true",
 				}
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  true,
+		}, { // Pod not evicted becasuse it has a priority higher than the configured priority threshold
 			pod: test.BuildTestPod("p14", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 				pod.Spec.Priority = &highPriority
 			},
-			evictLocalStoragePods: false,
-			priorityThreshold:     &lowPriority,
-			result:                false,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			priorityThreshold:       &lowPriority,
+			result:                  false,
+		}, { // Pod is evicted becasuse it has a priority higher than the configured priority threshold, but it has scheduler.alpha.kubernetes.io/evict annotation
 			pod: test.BuildTestPod("p15", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
 				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
 				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
 				pod.Spec.Priority = &highPriority
 			},
-			evictLocalStoragePods: false,
-			priorityThreshold:     &lowPriority,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			priorityThreshold:       &lowPriority,
+			result:                  true,
+		}, { // Pod is evicted becasuse it has system critical priority, but evictSystemCriticalPods = true
 			pod: test.BuildTestPod("p16", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
-				pod.ObjectMeta.OwnerReferences = test.GetStatefulSetOwnerRefList()
+				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				priority := utils.SystemCriticalPriority
+				pod.Spec.Priority = &priority
 			},
-			evictLocalStoragePods: false,
-			result:                true,
-		}, {
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: true,
+			result:                  true,
+		}, { // Pod is evicted becasuse it has system critical priority, but evictSystemCriticalPods = true and it has scheduler.alpha.kubernetes.io/evict annotation
+			pod: test.BuildTestPod("p16", 400, 0, n1.Name, nil),
+			runBefore: func(pod *v1.Pod) {
+				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+				priority := utils.SystemCriticalPriority
+				pod.Spec.Priority = &priority
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: true,
+			result:                  true,
+		}, { // Pod is evicted becasuse it has a priority higher than the configured priority threshold, but evictSystemCriticalPods = true
 			pod: test.BuildTestPod("p17", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod) {
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetStatefulSetOwnerRefList()
+				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				pod.Spec.Priority = &highPriority
 			},
-			evictLocalStoragePods: false,
-			result:                true,
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: true,
+			priorityThreshold:       &lowPriority,
+			result:                  true,
+		}, { // Pod is evicted becasuse it has a priority higher than the configured priority threshold, but evictSystemCriticalPods = true and it has scheduler.alpha.kubernetes.io/evict annotation
+			pod: test.BuildTestPod("p17", 400, 0, n1.Name, nil),
+			runBefore: func(pod *v1.Pod) {
+				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+				pod.Spec.Priority = &highPriority
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: true,
+			priorityThreshold:       &lowPriority,
+			result:                  true,
 		},
 	}
 
@@ -258,7 +318,8 @@ func TestIsEvictable(t *testing.T) {
 		test.runBefore(test.pod)
 
 		podEvictor := &PodEvictor{
-			evictLocalStoragePods: test.evictLocalStoragePods,
+			evictLocalStoragePods:   test.evictLocalStoragePods,
+			evictSystemCriticalPods: test.evictSystemCriticalPods,
 		}
 
 		evictable := podEvictor.Evictable()
@@ -301,18 +362,18 @@ func TestPodTypes(t *testing.T) {
 	}
 	// A Mirror Pod.
 	p4.Annotations = test.GetMirrorPodAnnotation()
-	if !IsMirrorPod(p4) {
+	if !utils.IsMirrorPod(p4) {
 		t.Errorf("Expected p4 to be a mirror pod.")
 	}
-	if !IsPodWithLocalStorage(p3) {
+	if !utils.IsPodWithLocalStorage(p3) {
 		t.Errorf("Expected p3 to be a pod with local storage.")
 	}
 	ownerRefList := podutil.OwnerRef(p2)
-	if !IsDaemonsetPod(ownerRefList) {
+	if !utils.IsDaemonsetPod(ownerRefList) {
 		t.Errorf("Expected p2 to be a daemonset pod.")
 	}
 	ownerRefList = podutil.OwnerRef(p1)
-	if IsDaemonsetPod(ownerRefList) || IsPodWithLocalStorage(p1) || IsCriticalPod(p1) || IsMirrorPod(p1) {
+	if utils.IsDaemonsetPod(ownerRefList) || utils.IsPodWithLocalStorage(p1) || utils.IsCriticalPriorityPod(p1) || utils.IsMirrorPod(p1) || utils.IsStaticPod(p1) {
 		t.Errorf("Expected p1 to be a normal pod.")
 	}
 

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -211,6 +211,7 @@ func TestFindDuplicatePods(t *testing.T) {
 				[]*v1.Node{node1, node2},
 				false,
 				false,
+				false,
 			)
 
 			RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, []*v1.Node{node1, node2}, podEvictor)
@@ -405,6 +406,7 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 				false,
 				testCase.maxPodsToEvictPerNode,
 				testCase.nodes,
+				false,
 				false,
 				false,
 			)

--- a/pkg/descheduler/strategies/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/lownodeutilization_test.go
@@ -446,6 +446,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				nodes,
 				false,
 				false,
+				false,
 			)
 
 			strategy := api.DeschedulerStrategy{
@@ -765,6 +766,7 @@ func TestWithTaints(t *testing.T) {
 				false,
 				item.evictionsExpected,
 				item.nodes,
+				false,
 				false,
 				false,
 			)

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -157,6 +157,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			false,
 			tc.maxPodsToEvictPerNode,
 			tc.nodes,
+			false,
 			false,
 			false,
 		)

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -119,6 +119,7 @@ func TestPodAntiAffinity(t *testing.T) {
 			false,
 			test.maxPodsToEvictPerNode,
 			[]*v1.Node{node},
+			false,
 			false,
 			false,
 		)

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -253,6 +253,7 @@ func TestPodLifeTime(t *testing.T) {
 			tc.maxPodsToEvictPerNode,
 			[]*v1.Node{node},
 			false,
+			false,
 			tc.ignorePvcPods,
 		)
 

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -22,7 +22,7 @@ import (
 
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -171,6 +171,7 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 			false,
 			tc.maxPodsToEvictPerNode,
 			[]*v1.Node{node},
+			false,
 			false,
 			false,
 		)

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -3,8 +3,9 @@ package strategies
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/descheduler/pkg/api"
 	"testing"
+
+	"sigs.k8s.io/descheduler/pkg/api"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -456,6 +457,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				false,
 				100,
 				tc.nodes,
+				false,
 				false,
 				false,
 			)

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -14,7 +14,7 @@
 
 #!/bin/bash
 
-# This just run e2e tests.
+# This just runs e2e tests.
 if [ -n "$KIND_E2E" ]; then
     K8S_VERSION=${KUBERNETES_VERSION:-v1.18.2}
     curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/


### PR DESCRIPTION
Fixes #378

The `evictSystemCriticalPods` flag disables priority checking by the descheduler. When this flag is true, pods of any priority are evicted, including system pods like `kube-dns`. Daemonsets, Mirror Pods, Static Pods, and pods without owner references are not evicted when this flag is true. If `thresholdPriority` or `thresholdPriorityClassName` are set, and `evictSystemCriticalPods` is true, then the threshold priority filtering will be disabled.