### PR TITLE
Correct Helm Chart Docs For Container Requests and Limits

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -59,8 +59,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`            |
 | `rbac.create`                  | If `true`, create & use RBAC resources                                                                                | `true`                               |
 | `podSecurityPolicy.create`     | If `true`, create PodSecurityPolicy                                                                                   | `true`                               |
-| `resources.cpuRequest`        | Descheduler container CPU request                                                                  | `500m`                               |
-| `resources.memoryRequest`        | Descheduler container memory request                                                                  | `256Mi`                               |
+| `resources`                    | Descheduler container CPU and memory requests/limits                                                                  | _see values.yaml_                    |
 | `serviceAccount.create`        | If `true`, create a service account for the cron job                                                                  | `true`                               |
 | `serviceAccount.name`          | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                |
-| `nodeSelector`          | Node selectors to run the descheduler cronjob on specific nodes | `nil`                                |
+| `nodeSelector`                 | Node selectors to run the descheduler cronjob on specific nodes                                                       | `nil`                                |


### PR DESCRIPTION
The resources.cpuRequest and resources.memoryRequest varialbes are
not valid in the helm chart values.yaml file. The correct varialbe
name for setting the requests and limits is resources.

Also, fixed white space alignment in the markdown table.