### PR TITLE
Add helm test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,3 +135,6 @@ ifndef HAS_HELM
 	curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 && chmod 700 ./get_helm.sh && ./get_helm.sh
 endif
 	helm lint ./charts/descheduler
+
+test-helm:
+	./test/run-helm-tests.sh

--- a/charts/descheduler/templates/tests/test-descheduler-pod.yaml
+++ b/charts/descheduler/templates/tests/test-descheduler-pod.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Pod
+metadata:
+    name: descheduler-test-pod
+    annotations:
+      "helm.sh/hook": test
+spec:
+    restartPolicy: Never
+    serviceAccountName: descheduler-ci
+    containers:
+      - name: descheduler-test-container
+        image: alpine:latest
+        imagePullPolicy: IfNotPresent
+        securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - All
+            privileged: false
+            runAsNonRoot: false
+        command: ["/bin/ash"]
+        args:
+          - -c
+          - >-
+            apk --no-cache add curl &&
+            curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&
+            chmod +x ./kubectl &&
+            mv ./kubectl /usr/local/bin/kubectl &&
+            /usr/local/bin/kubectl get pods --namespace kube-system --token "$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | grep "Completed"

--- a/charts/descheduler/templates/tests/test-descheduler-pod.yaml
+++ b/charts/descheduler/templates/tests/test-descheduler-pod.yaml
@@ -17,7 +17,7 @@ spec:
               drop:
                 - All
             privileged: false
-            runAsNonRoot: false
+            runAsNonRoot: false 
         command: ["/bin/ash"]
         args:
           - -c
@@ -26,4 +26,4 @@ spec:
             curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl &&
             chmod +x ./kubectl &&
             mv ./kubectl /usr/local/bin/kubectl &&
-            /usr/local/bin/kubectl get pods --namespace kube-system --token "$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | grep "Completed"
+            /usr/local/bin/kubectl get pods --namespace kube-system --token "$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | grep "descheduler" | grep "Completed"

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -39,5 +39,18 @@ make test-unit
 make test-e2e
 ```
 
+## Run Helm Tests
+Run the helm test for a particular descheduler release by setting below variables,
+```
+HELM_IMAGE_REPO="descheduler"
+HELM_IMAGE_TAG="helm-test"
+HELM_CHART_LOCATION="./charts/descheduler"
+```
+The helm tests runs as part of descheduler CI. But, to run it manually from the descheduler root,
+
+```
+make test-helm
+```
+
 ### Miscellaneous
 See the [hack directory](https://github.com/kubernetes-sigs/descheduler/tree/master/hack) for additional tools and scripts used for developing the descheduler.

--- a/test/run-helm-tests.sh
+++ b/test/run-helm-tests.sh
@@ -18,9 +18,9 @@ set -o nounset
 set -o pipefail
 
 K8S_VERSION=${KUBERNETES_VERSION:-v1.20.2}
-HELM_IMAGE_REPO="descheduler"
-HELM_IMAGE_TAG="helm-test"
-CHARTS_PATH="./charts/descheduler"
+IMAGE_REPO=${HELM_IMAGE_REPO:-descheduler}
+IMAGE_TAG=${HELM_IMAGE_TAG:-helm-test}
+CHART_LOCATION=${HELM_CHART_LOCATION:-./charts/descheduler}
 VERSION=helm-test make image
 wget https://github.com/kubernetes-sigs/kind/releases/download/v0.10.0/kind-linux-amd64
 chmod +x kind-linux-amd64
@@ -28,7 +28,7 @@ mv kind-linux-amd64 kind
 export PATH=$PATH:$PWD
 kind create cluster --image kindest/node:"${K8S_VERSION}" --config=./hack/kind_config.yaml
 kind load docker-image descheduler:helm-test
-helm install descheduler-ci --set image.repository="${HELM_IMAGE_REPO}",image.tag="${HELM_IMAGE_TAG}" --namespace kube-system "${CHARTS_PATH}"
+helm install descheduler-ci --set image.repository="${IMAGE_REPO}",image.tag="${IMAGE_TAG}" --namespace kube-system "${CHART_LOCATION}"
 sleep 20s
 helm test descheduler-ci --namespace kube-system
 

--- a/test/run-helm-tests.sh
+++ b/test/run-helm-tests.sh
@@ -1,0 +1,36 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+K8S_VERSION=${KUBERNETES_VERSION:-v1.20.2}
+HELM_IMAGE_REPO="descheduler"
+HELM_IMAGE_TAG="helm-test"
+CHARTS_PATH="./charts/descheduler"
+VERSION=helm-test make image
+wget https://github.com/kubernetes-sigs/kind/releases/download/v0.10.0/kind-linux-amd64
+chmod +x kind-linux-amd64
+mv kind-linux-amd64 kind
+export PATH=$PATH:$PWD
+kind create cluster --image kindest/node:"${K8S_VERSION}" --config=./hack/kind_config.yaml
+kind load docker-image descheduler:helm-test
+helm install descheduler-ci --set image.repository="${HELM_IMAGE_REPO}",image.tag="${HELM_IMAGE_TAG}" --namespace kube-system "${CHARTS_PATH}"
+sleep 20s
+helm test descheduler-ci --namespace kube-system
+
+# Delete kind cluster once test is finished
+kind delete cluster


### PR DESCRIPTION
This PR Fixes: https://github.com/kubernetes-sigs/descheduler/issues/440

As part of this PR, we are enabling support for `helm test` which will be run as part of CI. A new script to run helm tests has been added under `tests/` directory using the kind cluster. Also, Makefile has been updated to add support for `helm test` as a separate check.