### PR TITLE
add StrategyOption structure to add allow strategies to be variadic

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -18,6 +18,8 @@ limitations under the License.
 package options
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -31,7 +33,8 @@ import (
 )
 
 const (
-	DefaultDeschedulerPort = 10258
+	DefaultDeschedulerPort        = 10258
+	DefaultDeschedulingRunTimeout = 1 * time.Minute
 )
 
 // DeschedulerServer configuration
@@ -50,6 +53,7 @@ func NewDeschedulerServer() (*DeschedulerServer, error) {
 	if err != nil {
 		return nil, err
 	}
+	cfg.DeschedulingRunTimeout = DefaultDeschedulingRunTimeout
 
 	secureServing := apiserveroptions.NewSecureServingOptions().WithLoopback()
 	secureServing.BindPort = DefaultDeschedulerPort
@@ -82,6 +86,7 @@ func newDefaultComponentConfig() (*componentconfig.DeschedulerConfiguration, err
 func (rs *DeschedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&rs.Logging.Format, "logging-format", "text", `Sets the log format. Permitted formats: "text", "json". Non-default formats don't honor these flags: --add-dir-header, --alsologtostderr, --log-backtrace-at, --log-dir, --log-file, --log-file-max-size, --logtostderr, --skip-headers, --skip-log-headers, --stderrthreshold, --log-flush-frequency.\nNon-default choices are currently alpha and subject to change without warning.`)
 	fs.DurationVar(&rs.DeschedulingInterval, "descheduling-interval", rs.DeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
+	fs.DurationVar(&rs.DeschedulingRunTimeout, "descheduling-run-timeout", rs.DeschedulingRunTimeout, "Time to wait for all descheduling strategies to complete for each interval run.")
 	fs.StringVar(&rs.KubeconfigFile, "kubeconfig", rs.KubeconfigFile, "File with  kube configuration.")
 	fs.StringVar(&rs.PolicyConfigFile, "policy-config-file", rs.PolicyConfigFile, "File with descheduler policy configuration.")
 	fs.BoolVar(&rs.DryRun, "dry-run", rs.DryRun, "execute descheduler in dry run mode.")

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -31,6 +31,9 @@ type DeschedulerConfiguration struct {
 	// Time interval for descheduler to run
 	DeschedulingInterval time.Duration
 
+	// Time to wait for each descheduling run to complete
+	DeschedulingRunTimeout time.Duration
+
 	// KubeconfigFile is path to kubeconfig file with authorization and master
 	// location information.
 	KubeconfigFile string

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	componentbaseconfig "k8s.io/component-base/config"
 	"time"
+
+	componentbaseconfig "k8s.io/component-base/config"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -30,6 +31,9 @@ type DeschedulerConfiguration struct {
 
 	// Time interval for descheduler to run
 	DeschedulingInterval time.Duration `json:"deschedulingInterval,omitempty"`
+
+	// Time to wait for each descheduling run to complete
+	DeschedulingRunTimeout time.Duration
 
 	// KubeconfigFile is path to kubeconfig file with authorization and master
 	// location information.

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -50,6 +50,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_DeschedulerConfiguration_To_componentconfig_DeschedulerConfiguration(in *DeschedulerConfiguration, out *componentconfig.DeschedulerConfiguration, s conversion.Scope) error {
 	out.DeschedulingInterval = time.Duration(in.DeschedulingInterval)
+	out.DeschedulingRunTimeout = time.Duration(in.DeschedulingRunTimeout)
 	out.KubeconfigFile = in.KubeconfigFile
 	out.PolicyConfigFile = in.PolicyConfigFile
 	out.DryRun = in.DryRun
@@ -68,6 +69,7 @@ func Convert_v1alpha1_DeschedulerConfiguration_To_componentconfig_DeschedulerCon
 
 func autoConvert_componentconfig_DeschedulerConfiguration_To_v1alpha1_DeschedulerConfiguration(in *componentconfig.DeschedulerConfiguration, out *DeschedulerConfiguration, s conversion.Scope) error {
 	out.DeschedulingInterval = time.Duration(in.DeschedulingInterval)
+	out.DeschedulingRunTimeout = time.Duration(in.DeschedulingRunTimeout)
 	out.KubeconfigFile = in.KubeconfigFile
 	out.PolicyConfigFile = in.PolicyConfigFile
 	out.DryRun = in.DryRun

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -66,6 +66,7 @@ func RemoveDuplicatePods(
 	strategy api.DeschedulerStrategy,
 	nodes []*v1.Node,
 	podEvictor *evictions.PodEvictor,
+	sopts ...StrategyOption,
 ) {
 	if err := validateRemoveDuplicatePodsParams(strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid RemoveDuplicatePods parameters")

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -24,7 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -66,7 +66,7 @@ func validateLowNodeUtilizationParams(params *api.StrategyParameters) error {
 
 // LowNodeUtilization evicts pods from overutilized nodes to underutilized nodes. Note that CPU/Memory requests are used
 // to calculate nodes' utilization and not the actual resource usage.
-func LowNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
+func LowNodeUtilization(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, sopts ...StrategyOption) {
 	// TODO: May be create a struct for the strategy as well, so that we don't have to pass along the all the params?
 	if err := validateLowNodeUtilizationParams(strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid LowNodeUtilization parameters")

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -22,7 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -47,7 +47,7 @@ func validatePodsViolatingNodeAffinityParams(params *api.StrategyParameters) err
 }
 
 // RemovePodsViolatingNodeAffinity evicts pods on nodes which violate node affinity
-func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, sopts ...StrategyOption) {
 	if err := validatePodsViolatingNodeAffinityParams(strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid RemovePodsViolatingNodeAffinity parameters")
 		return

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 func validateRemovePodsViolatingNodeTaintsParams(params *api.StrategyParameters) error {
@@ -48,7 +48,7 @@ func validateRemovePodsViolatingNodeTaintsParams(params *api.StrategyParameters)
 }
 
 // RemovePodsViolatingNodeTaints evicts pods on the node which violate NoSchedule Taints on nodes
-func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, sopts ...StrategyOption) {
 	if err := validateRemovePodsViolatingNodeTaintsParams(strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid RemovePodsViolatingNodeTaints parameters")
 		return

--- a/pkg/descheduler/strategies/options.go
+++ b/pkg/descheduler/strategies/options.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package strategies
+
+import "sync"
+
+// StrategyOption represents an optional paramater to a strategy evaluation
+// function. The structure of the stratey option  is loosely based on
+// (blatently plagerized from) the GRPC client option code.
+type StrategyOption interface {
+	apply(*strategyOption)
+}
+
+// WithWaitGroup provides a strategy with a wait group reference that
+// can be utilized by the strategy to informm the calling loop when
+// the strategy is run to completion. This an be usedful if the
+// strategy needs to implement a retry loop for updating k8s resources.
+func WithWaitGroup(wg *sync.WaitGroup) StrategyOption {
+	return newFuncStrategyOption(func(o *strategyOption) {
+		o.wg = wg
+	})
+}
+
+// buildStrategyOptions combines the given options into a single
+// option structure
+func buildStrategyOptions(sopts []StrategyOption) *strategyOption {
+	opts := strategyOption{}
+	for _, sopt := range sopts {
+		sopt.apply(&opts)
+	}
+	return &opts
+}
+
+// strategyOption optional parameters to strategy evaluators. Each
+// strategy implementation can choose to leverage or ignore these
+// values and thus this can be used to add additional parameters
+// to strategies without having to update each evaluator signature.
+type strategyOption struct {
+	wg *sync.WaitGroup
+}
+
+// funcStrategyOption wraps a function that modifies the
+// strategyOptions into an implementation of a StrategyOption
+// interface
+type funcStrategyOption struct {
+	f func(*strategyOption)
+}
+
+func (fso *funcStrategyOption) apply(o *strategyOption) {
+	fso.f(o)
+}
+
+func newFuncStrategyOption(f func(o *strategyOption)) *funcStrategyOption {
+	return &funcStrategyOption{f: f}
+}

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -28,7 +28,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 func validateRemovePodsViolatingInterPodAntiAffinityParams(params *api.StrategyParameters) error {
@@ -48,7 +48,7 @@ func validateRemovePodsViolatingInterPodAntiAffinityParams(params *api.StrategyP
 }
 
 // RemovePodsViolatingInterPodAntiAffinity evicts pods on the node which are having a pod affinity rules.
-func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
+func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, sopts ...StrategyOption) {
 	if err := validateRemovePodsViolatingInterPodAntiAffinityParams(strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid RemovePodsViolatingInterPodAntiAffinity parameters")
 		return

--- a/pkg/descheduler/strategies/pod_lifetime.go
+++ b/pkg/descheduler/strategies/pod_lifetime.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -56,7 +56,7 @@ func validatePodLifeTimeParams(params *api.StrategyParameters) error {
 }
 
 // PodLifeTime evicts pods on nodes that were created more than strategy.Params.MaxPodLifeTimeSeconds seconds ago.
-func PodLifeTime(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
+func PodLifeTime(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, sopts ...StrategyOption) {
 	if err := validatePodLifeTimeParams(strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid PodLifeTime parameters")
 		return

--- a/pkg/descheduler/strategies/toomanyrestarts.go
+++ b/pkg/descheduler/strategies/toomanyrestarts.go
@@ -22,7 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -49,7 +49,7 @@ func validateRemovePodsHavingTooManyRestartsParams(params *api.StrategyParameter
 // RemovePodsHavingTooManyRestarts removes the pods that have too many restarts on node.
 // There are too many cases leading this issue: Volume mount failed, app error due to nodes' different settings.
 // As of now, this strategy won't evict daemonsets, mirror pods, critical pods and pods with local storages.
-func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor) {
+func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, sopts ...StrategyOption) {
 	if err := validateRemovePodsHavingTooManyRestartsParams(strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid RemovePodsHavingTooManyRestarts parameters")
 		return

--- a/pkg/descheduler/strategies/topologyspreadconstraint.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
@@ -75,6 +75,7 @@ func RemovePodsViolatingTopologySpreadConstraint(
 	strategy api.DeschedulerStrategy,
 	nodes []*v1.Node,
 	podEvictor *evictions.PodEvictor,
+	sopts ...StrategyOption,
 ) {
 	thresholdPriority, includedNamespaces, excludedNamespaces, err := validateAndParseTopologySpreadParams(ctx, client, strategy.Params)
 	if err != nil {

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -3,8 +3,9 @@ package strategies
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/descheduler/pkg/api"
 	"testing"
+
+	"sigs.k8s.io/descheduler/pkg/api"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Adds a StrategyOption, based on the GRPC client DialOption structure along with an implementation of a `WithWaitGroup` option.

The general StrategyOption capability extends the existing strategies to be variadic and allows for additional options to be added in the future without having to extend the strategy function signature.

The WithWaitGroup StrategyOption provides for a strategy to inform the calling loop when it has completed its processing. This can be important if a given strategy cannot run to completion in a single call and wants to allow further strategies to be run. This can be relevant if a strategy needs to update k8s resources which may require a retry loop based on resource version checks. As part of this implementation an additional command line parameter `--descheduling-run-timeout` was added to prevent any strategy from indefinitely blocking the descheduler.