### PR TITLE
e2e_test: fix goroutine leak

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -821,7 +821,7 @@ func TestDeschedulingInterval(t *testing.T) {
 
 	deschedulerPolicy := &api.DeschedulerPolicy{}
 
-	c := make(chan bool)
+	c := make(chan bool, 1)
 	go func() {
 		evictionPolicyGroupVersion, err := eutils.SupportEviction(s.Client)
 		if err != nil || len(evictionPolicyGroupVersion) == 0 {


### PR DESCRIPTION
If the goroutine running the descheduler strategies times out, it will still write to the channel without a reader thus causing a goroutine leak. To fix this, use a buffered channel (c).