### PR TITLE
Add verify script for deep-copies generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ gen:
 
 verify-gen:
 	./hack/verify-conversions.sh
+	./hack/verify-deep-copies.sh
 
 lint:
 ifndef HAS_GOLANGCI

--- a/hack/verify-deep-copies.sh
+++ b/hack/verify-deep-copies.sh
@@ -16,21 +16,21 @@ git archive --format=tar --prefix=descheduler/ "$(git write-tree)" | (cd "${_des
 _deschedulertmp="${_deschedulertmp}/descheduler"
 
 pushd "${_deschedulertmp}" > /dev/null 2>&1
-go build -o "${OS_OUTPUT_BINPATH}/conversion-gen" "k8s.io/code-generator/cmd/conversion-gen"
+go build -o "${OS_OUTPUT_BINPATH}/deepcopy-gen" "k8s.io/code-generator/cmd/deepcopy-gen"
 
-${OS_OUTPUT_BINPATH}/conversion-gen \
-		--go-header-file "hack/boilerplate/boilerplate.go.txt" \
-		--input-dirs "./pkg/apis/componentconfig/v1alpha1,./pkg/api/v1alpha1" \
-		--output-file-base zz_generated.conversion
+${OS_OUTPUT_BINPATH}/deepcopy-gen \
+                --go-header-file "hack/boilerplate/boilerplate.go.txt" \
+                --input-dirs "./pkg/apis/componentconfig,./pkg/apis/componentconfig/v1alpha1,./pkg/api,./pkg/api/v1alpha1" \
+                --output-file-base zz_generated.deepcopy
 popd > /dev/null 2>&1
 
 pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1
 if ! _out="$(diff -Naupr pkg/ "${_deschedulertmp}/pkg/")"; then
-    echo "Generated output differs:" >&2
+    echo "Generated deep-copies output differs:" >&2
     echo "${_out}" >&2
-    echo "Generated conversions verify failed. Please run ./hack/update-conversions.sh"
+    echo "Generated deep-copies verify failed. Please run ./hack/update-deep-copies.sh"
     exit 1
 fi
 popd > /dev/null 2>&1
 
-echo "Generated conversions verified."
+echo "Generated deep-copies verified."


### PR DESCRIPTION
This PR is related to: https://github.com/kubernetes-sigs/descheduler/issues/483

This PR contains changes for verifying deep-copies generator. Below are the logs,

1. When there are no changes,
```
-bash>descheduler(add-verify-script-deep-copies)$
 ->  make verify-gen
./hack/verify-conversions.sh
Generated conversions verified.
./hack/verify-deep-copies.sh
Generated deep-copies verified.
```
2. After making a change in the api similar to the change mentioned [here](https://github.com/kubernetes-sigs/descheduler/pull/507#issuecomment-792820077) for validating failed scenario,
```
-bash>descheduler(add-verify-script-deep-copies)$
 ->  ./hack/verify-deep-copies.sh
Generated deep-copies output differs:
diff -Naupr pkg/api/v1alpha1/zz_generated.deepcopy.go ./hack/../_tmp/kube-verify.whSrQp/descheduler/pkg/api/v1alpha1/zz_generated.deepcopy.go
--- pkg/api/v1alpha1/zz_generated.deepcopy.go	2021-04-08 11:16:08.000000000 +0530
+++ ./hack/../_tmp/kube-verify.whSrQp/descheduler/pkg/api/v1alpha1/zz_generated.deepcopy.go	2021-04-08 11:17:03.000000000 +0530
@@ -61,7 +61,6 @@ func (in *DeschedulerPolicy) DeepCopyInt
 		*out = new(int)
 		**out = **in
 	}
-	out.Foo = in.Foo
 	return
 }

Generated deep-copies verify failed.
```