### PR TITLE
Add verify scripts for defaulters generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ gen:
 verify-gen:
 	./hack/verify-conversions.sh
 	./hack/verify-deep-copies.sh
+	./hack/verify-defaulters.sh
 
 lint:
 ifndef HAS_GOLANGCI

--- a/hack/verify-conversions.sh
+++ b/hack/verify-conversions.sh
@@ -28,7 +28,7 @@ pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1
 if ! _out="$(diff -Naupr pkg/ "${_deschedulertmp}/pkg/")"; then
     echo "Generated output differs:" >&2
     echo "${_out}" >&2
-    echo "Generated conversions verify failed. Please run ./hack/update-generated-conversions.sh (and commit the result)"
+    echo "Generated conversions verify failed. Please run ./hack/update-generated-conversions.sh"
     exit 1
 fi
 popd > /dev/null 2>&1

--- a/hack/verify-defaulters.sh
+++ b/hack/verify-defaulters.sh
@@ -6,7 +6,6 @@ set -o pipefail
 
 source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
 DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/..
-mkdir -p "${DESCHEDULER_ROOT}/_tmp"
 _tmpdir="$(mktemp -d "${DESCHEDULER_ROOT}/_tmp/kube-verify.XXXXXX")"
 
 _deschedulertmp="${_tmpdir}"
@@ -16,21 +15,21 @@ git archive --format=tar --prefix=descheduler/ "$(git write-tree)" | (cd "${_des
 _deschedulertmp="${_deschedulertmp}/descheduler"
 
 pushd "${_deschedulertmp}" > /dev/null 2>&1
-go build -o "${OS_OUTPUT_BINPATH}/deepcopy-gen" "k8s.io/code-generator/cmd/deepcopy-gen"
+go build -o "${OS_OUTPUT_BINPATH}/defaulter-gen" "k8s.io/code-generator/cmd/defaulter-gen"
 
-${OS_OUTPUT_BINPATH}/deepcopy-gen \
-                --go-header-file "hack/boilerplate/boilerplate.go.txt" \
-                --input-dirs "./pkg/apis/componentconfig,./pkg/apis/componentconfig/v1alpha1,./pkg/api,./pkg/api/v1alpha1" \
-                --output-file-base zz_generated.deepcopy
+${OS_OUTPUT_BINPATH}/defaulter-gen \
+            --go-header-file "hack/boilerplate/boilerplate.go.txt" \
+            --input-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api/v1alpha1" \
+            --extra-peer-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api/v1alpha1" \
+            --output-file-base zz_generated.defaults
 popd > /dev/null 2>&1
 
 pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1
 if ! _out="$(diff -Naupr pkg/ "${_deschedulertmp}/pkg/")"; then
-    echo "Generated deep-copies output differs:" >&2
+    echo "Generated defaulters output differs:" >&2
     echo "${_out}" >&2
-    echo "Generated deep-copies verify failed. Please run ./hack/update-generated-deep-copies.sh"
-    exit 1
+    echo "Generated defaulters verify failed. Please run ./hack/update-generated-defaulters.sh"
 fi
 popd > /dev/null 2>&1
 
-echo "Generated deep-copies verified."
+echo "Generated Defaulters verified."


### PR DESCRIPTION
This PR is related to: https://github.com/kubernetes-sigs/descheduler/issues/483

This PR contains changes for verifying defaulters generator. Currently I'm facing a SIGSEGV error while trying to run verify-defaulters.sh script from local with below logs,
```
-bash>descheduler(verify-defaulters-gen)$
 ->  ./hack/verify-defaulters.sh
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0x12b69a7]

goroutine 1 [running]:
k8s.io/gengo/examples/defaulter-gen/generators.getManualDefaultingFunctions(0xc0080d6540, 0x0, 0xc009de99e0)
	/Users/pravaragrawal/Work/go_work/src/github.com/pravarag/descheduler/_tmp/kube-verify.u8W7BZ/descheduler/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go:149 +0xa7
k8s.io/gengo/examples/defaulter-gen/generators.Packages(0xc0080d6540, 0xc000132e60, 0x1353d49, 0x6, 0xc0080d6540)
	/Users/pravaragrawal/Work/go_work/src/github.com/pravarag/descheduler/_tmp/kube-verify.u8W7BZ/descheduler/vendor/k8s.io/gengo/examples/defaulter-gen/generators/defaulter.go:275 +0x79f
k8s.io/gengo/args.(*GeneratorArgs).Execute(0xc000132e60, 0xc000103050, 0x1353d49, 0x6, 0x1381050, 0x0, 0x0)
	/Users/pravaragrawal/Work/go_work/src/github.com/pravarag/descheduler/_tmp/kube-verify.u8W7BZ/descheduler/vendor/k8s.io/gengo/args/args.go:206 +0x1b7
main.main()
	/Users/pravaragrawal/Work/go_work/src/github.com/pravarag/descheduler/_tmp/kube-verify.u8W7BZ/descheduler/vendor/k8s.io/code-generator/cmd/defaulter-gen/main.go:76 +0x365
```
Opening this PR as a follow-up from this conversation: https://github.com/kubernetes-sigs/descheduler/pull/507#issuecomment-813805879