### PR TITLE
[wip]Add same workload metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -48,9 +48,23 @@ var (
 		},
 	)
 
+	DuplicatePods = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      DeschedulerSubsystem,
+			Name:           "pods_duplicate",
+			Help:           "Number of duplicate pods on a node",
+			StabilityLevel: metrics.ALPHA,
+		},
+		// name is the name of the workload
+		// kind is the type of the workload
+		// namespace is the namespace in which workload is running
+		// node is the node on which the workload pods are running
+		[]string{"name", "kind", "namespace", "node"})
+
 	metricsList = []metrics.Registerable{
 		PodsEvicted,
 		buildInfo,
+		DuplicatePods,
 	}
 )
 

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/descheduler/metrics"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
@@ -172,6 +173,10 @@ func RemoveDuplicatePods(
 								duplicatePods[ownerKey] = make(map[string][]*v1.Pod)
 							}
 							duplicatePods[ownerKey][node.Name] = append(duplicatePods[ownerKey][node.Name], pod)
+							// We would like to see if there is a duplicate copy via metrics. If this value for any
+							// workload is greater than 1, we should add an alert for it.
+							metrics.DuplicatePods.With(map[string]string{"name": ownerKey.name,
+								"kind": ownerKey.kind, "namespace": pod.ObjectMeta.Namespace, "node": node.Name}).Inc()
 						}
 						break
 					}


### PR DESCRIPTION
A metric to count the number of duplicate pods running on a node. We can convert this to an alert later for certain components based on namespace label.

@ingvagabund - Not sure if this the correct place to inject this metric. PTAL