### PR TITLE
Use Structured Logging For Unknown Strategy Log Message

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -142,7 +142,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 					f(ctx, rs.Client, strategy, nodes, podEvictor)
 				}
 			} else {
-				klog.Errorf("Unknown strategy name '%s', skipping", name)
+				klog.ErrorS(fmt.Errorf("unknown strategy name"), "skipping strategy", "strategy", name)
 			}
 		}
 


### PR DESCRIPTION
Always use structured logging. Therefore update klog.Errorf() to instead
use klog.ErrorS().

Here is an example of the new log message.

E0428 23:58:57.048912 586 descheduler.go:145] "skipping strategy" err="unknown strategy name" strategy=ASDFPodLifeTime