### PR TITLE
Working nodeFit feature

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -80,6 +80,7 @@ type StrategyParameters struct {
 	ThresholdPriority                 *int32
 	ThresholdPriorityClassName        string
 	LabelSelector                     *metav1.LabelSelector
+	NodeFit                           bool
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -78,6 +78,7 @@ type StrategyParameters struct {
 	ThresholdPriority                 *int32                             `json:"thresholdPriority"`
 	ThresholdPriorityClassName        string                             `json:"thresholdPriorityClassName"`
 	LabelSelector                     *metav1.LabelSelector              `json:"labelSelector"`
+	NodeFit                           bool                               `json:"nodeFit"`
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/v1alpha1/zz_generated.conversion.go
@@ -294,6 +294,7 @@ func autoConvert_v1alpha1_StrategyParameters_To_api_StrategyParameters(in *Strat
 	out.ThresholdPriority = (*int32)(unsafe.Pointer(in.ThresholdPriority))
 	out.ThresholdPriorityClassName = in.ThresholdPriorityClassName
 	out.LabelSelector = (*v1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
+	out.NodeFit = in.NodeFit
 	return nil
 }
 
@@ -313,6 +314,7 @@ func autoConvert_api_StrategyParameters_To_v1alpha1_StrategyParameters(in *api.S
 	out.ThresholdPriority = (*int32)(unsafe.Pointer(in.ThresholdPriority))
 	out.ThresholdPriorityClassName = in.ThresholdPriorityClassName
 	out.LabelSelector = (*v1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
+	out.NodeFit = in.NodeFit
 	return nil
 }
 

--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -83,7 +83,12 @@ func RemoveDuplicatePods(
 		excludedNamespaces = strategy.Params.Namespaces.Exclude
 	}
 
-	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority))
+	nodeFit := false
+	if strategy.Params != nil {
+		nodeFit = strategy.Params.NodeFit
+	}
+
+	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))
 
 	duplicatePods := make(map[podOwner]map[string][]*v1.Pod)
 	ownerKeyOccurence := make(map[podOwner]int32)

--- a/pkg/descheduler/strategies/lownodeutilization.go
+++ b/pkg/descheduler/strategies/lownodeutilization.go
@@ -78,6 +78,11 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		return
 	}
 
+	nodeFit := false
+	if strategy.Params != nil {
+		nodeFit = strategy.Params.NodeFit
+	}
+
 	thresholds := strategy.Params.NodeResourceUtilizationThresholds.Thresholds
 	targetThresholds := strategy.Params.NodeResourceUtilizationThresholds.TargetThresholds
 	if err := validateStrategyConfig(thresholds, targetThresholds); err != nil {
@@ -162,7 +167,7 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		return
 	}
 
-	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority))
+	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))
 
 	evictPodsFromTargetNodes(
 		ctx,

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -64,7 +64,12 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 		excludedNamespaces = strategy.Params.Namespaces.Exclude
 	}
 
-	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority))
+	nodeFit := false
+	if strategy.Params != nil {
+		nodeFit = strategy.Params.NodeFit
+	}
+
+	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))
 
 	for _, nodeAffinity := range strategy.Params.NodeAffinityType {
 		klog.V(2).InfoS("Executing for nodeAffinityType", "nodeAffinity", nodeAffinity)

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -70,7 +70,12 @@ func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interfa
 		return
 	}
 
-	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority))
+	nodeFit := false
+	if strategy.Params != nil {
+		nodeFit = strategy.Params.NodeFit
+	}
+
+	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))
 
 	for _, node := range nodes {
 		klog.V(1).InfoS("Processing node", "node", klog.KObj(node))

--- a/pkg/descheduler/strategies/pod_antiaffinity.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity.go
@@ -70,7 +70,12 @@ func RemovePodsViolatingInterPodAntiAffinity(ctx context.Context, client clients
 		return
 	}
 
-	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority))
+	nodeFit := false
+	if strategy.Params != nil {
+		nodeFit = strategy.Params.NodeFit
+	}
+
+	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))
 
 	for _, node := range nodes {
 		klog.V(1).InfoS("Processing node", "node", klog.KObj(node))

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -34,15 +34,15 @@ import (
 
 func TestPodLifeTime(t *testing.T) {
 	ctx := context.Background()
-	node := test.BuildTestNode("n1", 2000, 3000, 10, nil)
+	node1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
 	olderPodCreationTime := metav1.NewTime(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
 	newerPodCreationTime := metav1.NewTime(time.Now())
 
 	// Setup pods, one should be evicted
-	p1 := test.BuildTestPod("p1", 100, 0, node.Name, nil)
+	p1 := test.BuildTestPod("p1", 100, 0, node1.Name, nil)
 	p1.Namespace = "dev"
 	p1.ObjectMeta.CreationTimestamp = newerPodCreationTime
-	p2 := test.BuildTestPod("p2", 100, 0, node.Name, nil)
+	p2 := test.BuildTestPod("p2", 100, 0, node1.Name, nil)
 	p2.Namespace = "dev"
 	p2.ObjectMeta.CreationTimestamp = olderPodCreationTime
 
@@ -51,10 +51,10 @@ func TestPodLifeTime(t *testing.T) {
 	p2.ObjectMeta.OwnerReferences = ownerRef1
 
 	// Setup pods, zero should be evicted
-	p3 := test.BuildTestPod("p3", 100, 0, node.Name, nil)
+	p3 := test.BuildTestPod("p3", 100, 0, node1.Name, nil)
 	p3.Namespace = "dev"
 	p3.ObjectMeta.CreationTimestamp = newerPodCreationTime
-	p4 := test.BuildTestPod("p4", 100, 0, node.Name, nil)
+	p4 := test.BuildTestPod("p4", 100, 0, node1.Name, nil)
 	p4.Namespace = "dev"
 	p4.ObjectMeta.CreationTimestamp = newerPodCreationTime
 
@@ -63,10 +63,10 @@ func TestPodLifeTime(t *testing.T) {
 	p4.ObjectMeta.OwnerReferences = ownerRef2
 
 	// Setup pods, one should be evicted
-	p5 := test.BuildTestPod("p5", 100, 0, node.Name, nil)
+	p5 := test.BuildTestPod("p5", 100, 0, node1.Name, nil)
 	p5.Namespace = "dev"
 	p5.ObjectMeta.CreationTimestamp = newerPodCreationTime
-	p6 := test.BuildTestPod("p6", 100, 0, node.Name, nil)
+	p6 := test.BuildTestPod("p6", 100, 0, node1.Name, nil)
 	p6.Namespace = "dev"
 	p6.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 605))
 
@@ -75,10 +75,10 @@ func TestPodLifeTime(t *testing.T) {
 	p6.ObjectMeta.OwnerReferences = ownerRef3
 
 	// Setup pods, zero should be evicted
-	p7 := test.BuildTestPod("p7", 100, 0, node.Name, nil)
+	p7 := test.BuildTestPod("p7", 100, 0, node1.Name, nil)
 	p7.Namespace = "dev"
 	p7.ObjectMeta.CreationTimestamp = newerPodCreationTime
-	p8 := test.BuildTestPod("p8", 100, 0, node.Name, nil)
+	p8 := test.BuildTestPod("p8", 100, 0, node1.Name, nil)
 	p8.Namespace = "dev"
 	p8.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 595))
 
@@ -87,10 +87,10 @@ func TestPodLifeTime(t *testing.T) {
 	p6.ObjectMeta.OwnerReferences = ownerRef4
 
 	// Setup two old pods with different status phases
-	p9 := test.BuildTestPod("p9", 100, 0, node.Name, nil)
+	p9 := test.BuildTestPod("p9", 100, 0, node1.Name, nil)
 	p9.Namespace = "dev"
 	p9.ObjectMeta.CreationTimestamp = olderPodCreationTime
-	p10 := test.BuildTestPod("p10", 100, 0, node.Name, nil)
+	p10 := test.BuildTestPod("p10", 100, 0, node1.Name, nil)
 	p10.Namespace = "dev"
 	p10.ObjectMeta.CreationTimestamp = olderPodCreationTime
 
@@ -99,7 +99,7 @@ func TestPodLifeTime(t *testing.T) {
 	p9.ObjectMeta.OwnerReferences = ownerRef1
 	p10.ObjectMeta.OwnerReferences = ownerRef1
 
-	p11 := test.BuildTestPod("p11", 100, 0, node.Name, func(pod *v1.Pod) {
+	p11 := test.BuildTestPod("p11", 100, 0, node1.Name, func(pod *v1.Pod) {
 		pod.Spec.Volumes = []v1.Volume{
 			{
 				Name: "pvc", VolumeSource: v1.VolumeSource{
@@ -113,10 +113,10 @@ func TestPodLifeTime(t *testing.T) {
 	})
 
 	// Setup two old pods with different labels
-	p12 := test.BuildTestPod("p12", 100, 0, node.Name, nil)
+	p12 := test.BuildTestPod("p12", 100, 0, node1.Name, nil)
 	p12.Namespace = "dev"
 	p12.ObjectMeta.CreationTimestamp = olderPodCreationTime
-	p13 := test.BuildTestPod("p13", 100, 0, node.Name, nil)
+	p13 := test.BuildTestPod("p13", 100, 0, node1.Name, nil)
 	p13.Namespace = "dev"
 	p13.ObjectMeta.CreationTimestamp = olderPodCreationTime
 
@@ -131,6 +131,7 @@ func TestPodLifeTime(t *testing.T) {
 		strategy                api.DeschedulerStrategy
 		maxPodsToEvictPerNode   int
 		pods                    []v1.Pod
+		nodes                   []*v1.Node
 		expectedEvictedPodCount int
 		ignorePvcPods           bool
 	}{
@@ -144,6 +145,7 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p1, *p2},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 1,
 		},
 		{
@@ -156,6 +158,7 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p3, *p4},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 0,
 		},
 		{
@@ -168,6 +171,7 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p5, *p6},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 1,
 		},
 		{
@@ -180,6 +184,7 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p7, *p8},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 0,
 		},
 		{
@@ -195,6 +200,7 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p9, *p10},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 1,
 		},
 		{
@@ -207,6 +213,7 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p11},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 0,
 			ignorePvcPods:           true,
 		},
@@ -220,6 +227,7 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p11},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 1,
 		},
 		{
@@ -235,30 +243,30 @@ func TestPodLifeTime(t *testing.T) {
 			},
 			maxPodsToEvictPerNode:   5,
 			pods:                    []v1.Pod{*p12, *p13},
+			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 1,
 		},
 	}
 
 	for _, tc := range testCases {
 		fakeClient := &fake.Clientset{}
+
 		fakeClient.Fake.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
 			return true, &v1.PodList{Items: tc.pods}, nil
 		})
-		fakeClient.Fake.AddReactor("get", "nodes", func(action core.Action) (bool, runtime.Object, error) {
-			return true, node, nil
-		})
+
 		podEvictor := evictions.NewPodEvictor(
 			fakeClient,
 			policyv1.SchemeGroupVersion.String(),
 			false,
 			tc.maxPodsToEvictPerNode,
-			[]*v1.Node{node},
+			tc.nodes,
 			false,
 			false,
 			tc.ignorePvcPods,
 		)
 
-		PodLifeTime(ctx, fakeClient, tc.strategy, []*v1.Node{node}, podEvictor)
+		PodLifeTime(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor)
 		podsEvicted := podEvictor.TotalEvicted()
 		if podsEvicted != tc.expectedEvictedPodCount {
 			t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.description, tc.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/toomanyrestarts.go
+++ b/pkg/descheduler/strategies/toomanyrestarts.go
@@ -67,7 +67,12 @@ func RemovePodsHavingTooManyRestarts(ctx context.Context, client clientset.Inter
 		excludedNamespaces = strategy.Params.Namespaces.Exclude
 	}
 
-	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority))
+	nodeFit := false
+	if strategy.Params != nil {
+		nodeFit = strategy.Params.NodeFit
+	}
+
+	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))
 
 	for _, node := range nodes {
 		klog.V(1).InfoS("Processing node", "node", klog.KObj(node))


### PR DESCRIPTION
Implements #529.

This feature adds a `nodeFit` boolean parameter to all descheduler strategies. When `nodeFit` is set to `true`, the descheduler strategy will take "node fit" into account when evicting pods. This increases the probability that pods can be re-scheduled to a new node successfully upon eviction.

For the current implementation, "node fit" is defined by the following criteria:
- A `nodeSelector` on the pod
- Any `Tolerations` on the pod and any `Taints` on the other nodes
- `nodeAffinity` on the pod
- Whether any of the other nodes are marked as `unschedulable`