### PR TITLE
Update error messages in verify scripts to be more informative

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ push-all: image.amd64 image.arm image.arm64
 
 clean:
 	rm -rf _output
+	rm -rf _tmp
 
 verify: verify-gofmt verify-vendor lint lint-chart verify-spelling verify-toc verify-gen
 

--- a/hack/verify-conversions.sh
+++ b/hack/verify-conversions.sh
@@ -28,7 +28,7 @@ pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1
 if ! _out="$(diff -Naupr pkg/ "${_deschedulertmp}/pkg/")"; then
     echo "Generated output differs:" >&2
     echo "${_out}" >&2
-    echo "Generated conversions verify failed. Please run ./hack/update-conversions.sh"
+    echo "Generated conversions verify failed. Please run ./hack/update-generated-conversions.sh (and commit the result)"
     exit 1
 fi
 popd > /dev/null 2>&1

--- a/hack/verify-deep-copies.sh
+++ b/hack/verify-deep-copies.sh
@@ -28,7 +28,7 @@ pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1
 if ! _out="$(diff -Naupr pkg/ "${_deschedulertmp}/pkg/")"; then
     echo "Generated deep-copies output differs:" >&2
     echo "${_out}" >&2
-    echo "Generated deep-copies verify failed. Please run ./hack/update-deep-copies.sh"
+    echo "Generated deep-copies verify failed. Please run ./hack/update-generated-deep-copies.sh (and commit the result)"
     exit 1
 fi
 popd > /dev/null 2>&1


### PR DESCRIPTION
The error messages were incorrect, and leave out that the changes must be committed