### PR TITLE
RemoveDuplicates: take node taints, node affinity and node selector into account when computing a number of feasible nodes for the average occurence of pods per node

### DIFF
--- a/pkg/descheduler/strategies/duplicates.go
+++ b/pkg/descheduler/strategies/duplicates.go
@@ -183,9 +183,17 @@ func RemoveDuplicatePods(
 	}
 
 	// 1. how many pods can be evicted to respect uniform placement of pods among viable nodes?
-	for ownerKey, nodes := range duplicatePods {
-		upperAvg := int(math.Ceil(float64(ownerKeyOccurence[ownerKey]) / float64(nodeCount)))
-		for nodeName, pods := range nodes {
+	for ownerKey, podNodes := range duplicatePods {
+		targetNodes := getTargetNodes(podNodes, nodes)
+
+		klog.V(2).InfoS("Adjusting feasible nodes", "owner", ownerKey, "from", nodeCount, "to", len(targetNodes))
+		if len(targetNodes) < 2 {
+			klog.V(1).InfoS("Less than two feasible nodes for duplicates to land, skipping eviction", "owner", ownerKey)
+			continue
+		}
+
+		upperAvg := int(math.Ceil(float64(ownerKeyOccurence[ownerKey]) / float64(len(targetNodes))))
+		for nodeName, pods := range podNodes {
 			klog.V(2).InfoS("Average occurrence per node", "node", klog.KObj(nodeMap[nodeName]), "ownerKey", ownerKey, "avg", upperAvg)
 			// list of duplicated pods does not contain the original referential pod
 			if len(pods)+1 > upperAvg {
@@ -200,6 +208,73 @@ func RemoveDuplicatePods(
 			}
 		}
 	}
+}
+
+func getNodeAffinityNodeSelector(pod *v1.Pod) *v1.NodeSelector {
+	if pod.Spec.Affinity == nil {
+		return nil
+	}
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		return nil
+	}
+	return pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+}
+
+func getTargetNodes(podNodes map[string][]*v1.Pod, nodes []*v1.Node) []*v1.Node {
+	// In order to reduce the number of pods processed, identify pods which have
+	// equal (tolerations, nodeselectors, node affinity) terms and considered them
+	// as identical. Identical pods wrt. (tolerations, nodeselectors, node affinity) terms
+	// will produce the same result when checking if a pod is feasible for a node.
+	// Thus, improving efficiency of processing pods marked for eviction.
+
+	// Collect all distinct pods which differ in at least taints, node affinity or node selector terms
+	distinctPods := map[*v1.Pod]struct{}{}
+	for _, pods := range podNodes {
+		for _, pod := range pods {
+			duplicated := false
+			for dp := range distinctPods {
+				if utils.TolerationsEqual(pod.Spec.Tolerations, dp.Spec.Tolerations) &&
+					utils.NodeSelectorsEqual(getNodeAffinityNodeSelector(pod), getNodeAffinityNodeSelector(dp)) &&
+					reflect.DeepEqual(pod.Spec.NodeSelector, dp.Spec.NodeSelector) {
+					duplicated = true
+					continue
+				}
+			}
+			if duplicated {
+				continue
+			}
+			distinctPods[pod] = struct{}{}
+		}
+	}
+
+	// For each distinct pod get a list of nodes where it can land
+	targetNodesMap := map[string]*v1.Node{}
+	for pod := range distinctPods {
+		matchingNodes := map[string]*v1.Node{}
+		for _, node := range nodes {
+			if !utils.TolerationsTolerateTaintsWithFilter(pod.Spec.Tolerations, node.Spec.Taints, func(taint *v1.Taint) bool {
+				return taint.Effect == v1.TaintEffectNoSchedule || taint.Effect == v1.TaintEffectNoExecute
+			}) {
+				continue
+			}
+			if match, err := utils.PodMatchNodeSelector(pod, node); err == nil && !match {
+				continue
+			}
+			matchingNodes[node.Name] = node
+		}
+		if len(matchingNodes) > 1 {
+			for nodeName := range matchingNodes {
+				targetNodesMap[nodeName] = matchingNodes[nodeName]
+			}
+		}
+	}
+
+	targetNodes := []*v1.Node{}
+	for _, node := range targetNodesMap {
+		targetNodes = append(targetNodes, node)
+	}
+
+	return targetNodes
 }
 
 func hasExcludedOwnerRefKind(ownerRefs []metav1.OwnerReference, strategy api.DeschedulerStrategy) bool {

--- a/pkg/utils/predicates_test.go
+++ b/pkg/utils/predicates_test.go
@@ -335,3 +335,606 @@ func TestTolerationsEqual(t *testing.T) {
 		})
 	}
 }
+
+func TestUniqueSortNodeSelectorRequirements(t *testing.T) {
+	tests := []struct {
+		name                 string
+		requirements         []v1.NodeSelectorRequirement
+		expectedRequirements []v1.NodeSelectorRequirement
+	}{
+		{
+			name: "Identical requirements",
+			requirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1"},
+				},
+			},
+			expectedRequirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1"},
+				},
+			},
+		},
+		{
+			name: "Sorted requirements",
+			requirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1"},
+				},
+				{
+					Key:      "k2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v2"},
+				},
+			},
+			expectedRequirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1"},
+				},
+				{
+					Key:      "k2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v2"},
+				},
+			},
+		},
+		{
+			name: "Sort values",
+			requirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v2", "v1"},
+				},
+			},
+			expectedRequirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+			},
+		},
+		{
+			name: "Sort by key",
+			requirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k3",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+			},
+			expectedRequirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k2",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k3",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+			},
+		},
+		{
+			name: "Sort by operator",
+			requirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpExists,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpGt,
+					Values:   []string{"v1", "v2"},
+				},
+			},
+			expectedRequirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpExists,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpGt,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+			},
+		},
+		{
+			name: "Sort by values",
+			requirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v6", "v5"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v2", "v1"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v4", "v1"},
+				},
+			},
+			expectedRequirements: []v1.NodeSelectorRequirement{
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v2"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v1", "v4"},
+				},
+				{
+					Key:      "k1",
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"v5", "v6"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resultRequirements := uniqueSortNodeSelectorRequirements(test.requirements)
+			if !reflect.DeepEqual(resultRequirements, test.expectedRequirements) {
+				t.Errorf("Requirements not sorted as expected, \n\tgot: %#v, \n\texpected: %#v", resultRequirements, test.expectedRequirements)
+			}
+		})
+	}
+}
+
+func TestUniqueSortNodeSelectorTerms(t *testing.T) {
+	tests := []struct {
+		name          string
+		terms         []v1.NodeSelectorTerm
+		expectedTerms []v1.NodeSelectorTerm
+	}{
+		{
+			name: "Identical terms",
+			terms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+					MatchFields: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+				},
+			},
+			expectedTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+					MatchFields: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Sorted terms",
+			terms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+					MatchFields: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+				},
+			},
+			expectedTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+					MatchFields: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Sort terms",
+			terms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v2", "v1"},
+						},
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v3", "v1"},
+						},
+					},
+				},
+			},
+			expectedTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1", "v2"},
+						},
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1", "v3"},
+						},
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Unique sort terms",
+			terms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v2", "v1"},
+						},
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v2", "v1"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v2", "v1"},
+						},
+					},
+				},
+			},
+			expectedTerms: []v1.NodeSelectorTerm{
+				{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      "k1",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1", "v2"},
+						},
+						{
+							Key:      "k2",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"v1"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resultTerms := uniqueSortNodeSelectorTerms(test.terms)
+			if !reflect.DeepEqual(resultTerms, test.expectedTerms) {
+				t.Errorf("Terms not sorted as expected, \n\tgot: %#v, \n\texpected: %#v", resultTerms, test.expectedTerms)
+			}
+		})
+	}
+}
+
+func TestNodeSelectorTermsEqual(t *testing.T) {
+	tests := []struct {
+		name                        string
+		leftSelector, rightSelector v1.NodeSelector
+		equal                       bool
+	}{
+		{
+			name: "identical selectors",
+			leftSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1"},
+							},
+						},
+					},
+				},
+			},
+			rightSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1"},
+							},
+						},
+					},
+				},
+			},
+			equal: true,
+		},
+		{
+			name: "equal selectors",
+			leftSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v1"},
+							},
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+						},
+					},
+				},
+			},
+			rightSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1"},
+							},
+						},
+					},
+				},
+			},
+			equal: true,
+		},
+		{
+			name: "non-equal selectors in values",
+			leftSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1"},
+							},
+						},
+					},
+				},
+			},
+			rightSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+						},
+					},
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "non-equal selectors in keys",
+			leftSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k3",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1"},
+							},
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1"},
+							},
+						},
+					},
+				},
+			},
+			rightSelector: v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "k1",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+							{
+								Key:      "k2",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"v1", "v2"},
+							},
+						},
+					},
+				},
+			},
+			equal: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			equal := NodeSelectorsEqual(&test.leftSelector, &test.rightSelector)
+			if equal != test.equal {
+				t.Errorf("NodeSelectorsEqual expected to be %v, got %v", test.equal, equal)
+			}
+		})
+	}
+}

--- a/pkg/utils/predicates_test.go
+++ b/pkg/utils/predicates_test.go
@@ -1,0 +1,337 @@
+package utils
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestUniqueSortTolerations(t *testing.T) {
+	tests := []struct {
+		name                string
+		tolerations         []v1.Toleration
+		expectedTolerations []v1.Toleration
+	}{
+		{
+			name: "sort by key",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key3",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value3",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key3",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value3",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "sort by value",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value3",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value3",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+		{
+			name: "sort by effect",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectPreferNoSchedule,
+				},
+			},
+			expectedTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoExecute,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectPreferNoSchedule,
+				},
+			},
+		},
+		{
+			name: "sort unique",
+			tolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			expectedTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resultTolerations := uniqueSortTolerations(test.tolerations)
+			if !reflect.DeepEqual(resultTolerations, test.expectedTolerations) {
+				t.Errorf("tolerations not sorted as expected, \n\tgot: %#v, \n\texpected: %#v", resultTolerations, test.expectedTolerations)
+			}
+		})
+	}
+}
+
+func TestTolerationsEqual(t *testing.T) {
+	tests := []struct {
+		name                              string
+		leftTolerations, rightTolerations []v1.Toleration
+		equal                             bool
+	}{
+		{
+			name: "identical lists",
+			leftTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			rightTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			equal: true,
+		},
+		{
+			name: "equal lists",
+			leftTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			rightTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			equal: true,
+		},
+		{
+			name: "non-equal lists",
+			leftTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			rightTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoExecute,
+				},
+			},
+			equal: false,
+		},
+		{
+			name: "different sizes lists",
+			leftTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+			},
+			rightTolerations: []v1.Toleration{
+				{
+					Key:      "key1",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value1",
+					Effect:   v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:      "key2",
+					Operator: v1.TolerationOpEqual,
+					Value:    "value2",
+					Effect:   v1.TaintEffectNoExecute,
+				},
+			},
+			equal: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			equal := TolerationsEqual(test.leftTolerations, test.rightTolerations)
+			if equal != test.equal {
+				t.Errorf("TolerationsEqual expected to be %v, got %v", test.equal, equal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Nodes with taints which are not tolerated by evicted pods will never run the pods. The same holds for node affinity and node selector. So increase the number of pods per feasible nodes to decrease the number of evicted pods.

Fixes: https://github.com/kubernetes-sigs/descheduler/issues/551

**TODO**:
- [x] take taints into account
- [x] take node selector into account