### PR TITLE
Add verify script for govet & fix pkg/descheduler/descheduler_test.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,10 @@ clean:
 	rm -rf _output
 	rm -rf _tmp
 
-verify: verify-gofmt verify-vendor lint lint-chart verify-spelling verify-toc verify-gen
+verify: verify-govet verify-spelling verify-gofmt verify-vendor lint lint-chart verify-toc verify-gen
+
+verify-govet:
+	./hack/verify-govet.sh
 
 verify-spelling:
 	./hack/verify-spelling.sh

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "$(dirname "${BASH_SOURCE}")/lib/init.sh"
+
+go vet ${OS_ROOT}/...


### PR DESCRIPTION
We can only use `t.Fatal` in the main test goroutine.

The solution is similar to:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-proxy/app/server_test.go#L501

Thanks for review!