### PR TITLE
Add run descheduler as deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Table of Contents
 
 ## Quick Start
 
-The descheduler can be run as a Job or CronJob or Deployment inside of a k8s cluster. It has the
+The descheduler can be run as a `Job`, `CronJob`, or `Deployment` inside of a k8s cluster. It has the
 advantage of being able to be run multiple times without needing user intervention.
 The descheduler pod is run as a critical pod in the `kube-system` namespace to avoid
 being evicted by itself or by the kubelet.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Table of Contents
 - [Quick Start](#quick-start)
   - [Run As A Job](#run-as-a-job)
   - [Run As A CronJob](#run-as-a-cronjob)
+  - [Run As A Deployment](#run-as-a-deployment)
   - [Install Using Helm](#install-using-helm)
   - [Install Using Kustomize](#install-using-kustomize)
 - [User Guide](#user-guide)
@@ -56,7 +57,7 @@ Table of Contents
 
 ## Quick Start
 
-The descheduler can be run as a Job or CronJob inside of a k8s cluster. It has the
+The descheduler can be run as a Job or CronJob or Deployment inside of a k8s cluster. It has the
 advantage of being able to be run multiple times without needing user intervention.
 The descheduler pod is run as a critical pod in the `kube-system` namespace to avoid
 being evicted by itself or by the kubelet.
@@ -75,6 +76,14 @@ kubectl create -f kubernetes/job/job.yaml
 kubectl create -f kubernetes/base/rbac.yaml
 kubectl create -f kubernetes/base/configmap.yaml
 kubectl create -f kubernetes/cronjob/cronjob.yaml
+```
+
+### Run As A Deployment
+
+```
+kubectl create -f kubernetes/base/rbac.yaml
+kubectl create -f kubernetes/base/configmap.yaml
+kubectl create -f kubernetes/deployment/deployment.yaml
 ```
 
 ### Install Using Helm
@@ -97,6 +106,11 @@ kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.21
 Run As A CronJob
 ```
 kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.21.0' | kubectl apply -f -
+```
+
+Run As A Deployment
+```
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.21.0' | kubectl apply -f -
 ```
 
 ## User Guide

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: descheduler
+  namespace: kube-system
+  labels:
+    app: descheduler
+spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: descheduler
+    template:
+      metadata:
+        labels:
+          app: descheduler
+      spec:
+        priorityClassName: system-cluster-critical
+        serviceAccountName: descheduler-sa
+        containers:
+          - name: descheduler
+            image: k8s.gcr.io/descheduler/descheduler:v0.21.0
+            imagePullPolicy: IfNotPresent
+            command:
+              - "/bin/descheduler"
+            args:
+              - "--policy-config-file"
+              - "/policy-dir/policy.yaml"
+              - "--descheduling-interval"
+              - "5m"
+              - "--v"
+              - "3"
+            ports:
+            - containerPort: 10258
+              protocol: TCP
+            resources:
+              requests:
+                cpu: 500m
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+            volumeMounts:
+              - mountPath: /policy-dir
+                name: policy-volume
+        volumes:
+        - name: policy-volume
+          configMap:
+            name: descheduler-policy-configmap

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -6,49 +6,49 @@ metadata:
   labels:
     app: descheduler
 spec:
-    replicas: 1
-    selector:
-      matchLabels:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: descheduler
+  template:
+    metadata:
+      labels:
         app: descheduler
-    template:
-      metadata:
-        labels:
-          app: descheduler
-      spec:
-        priorityClassName: system-cluster-critical
-        serviceAccountName: descheduler-sa
-        containers:
-          - name: descheduler
-            image: k8s.gcr.io/descheduler/descheduler:v0.21.0
-            imagePullPolicy: IfNotPresent
-            command:
-              - "/bin/descheduler"
-            args:
-              - "--policy-config-file"
-              - "/policy-dir/policy.yaml"
-              - "--descheduling-interval"
-              - "5m"
-              - "--v"
-              - "3"
-            ports:
-            - containerPort: 10258
-              protocol: TCP
-            resources:
-              requests:
-                cpu: 500m
-                memory: 256Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                  - ALL
-              privileged: false
-              readOnlyRootFilesystem: true
-              runAsNonRoot: true
-            volumeMounts:
-              - mountPath: /policy-dir
-                name: policy-volume
-        volumes:
-        - name: policy-volume
-          configMap:
-            name: descheduler-policy-configmap
+    spec:
+      priorityClassName: system-cluster-critical
+      serviceAccountName: descheduler-sa
+      containers:
+        - name: descheduler
+          image: k8s.gcr.io/descheduler/descheduler:v0.21.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/descheduler"
+          args:
+            - "--policy-config-file"
+            - "/policy-dir/policy.yaml"
+            - "--descheduling-interval"
+            - "5m"
+            - "--v"
+            - "3"
+          ports:
+          - containerPort: 10258
+            protocol: TCP
+          resources:
+            requests:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /policy-dir
+              name: policy-volume
+      volumes:
+      - name: policy-volume
+        configMap:
+          name: descheduler-policy-configmap

--- a/kubernetes/deployment/kustomization.yaml
+++ b/kubernetes/deployment/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - deployment.yaml


### PR DESCRIPTION
Changes:
- Add kubernetes YAML files to run descheduler as a long running `Deployment` resource
- Update README to include instructions to deploy descheduler using `kubectl apply` and `kustomize build`