### PR TITLE
Use stable batch/v1 API Group for Kubernetes 1.21

### DIFF
--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: descheduler
-version: 0.20.0
-appVersion: 0.20.0
+version: 0.21.0
+appVersion: 0.21.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:
 - kubernetes

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                       |
 | `nameOverride`                 | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                 |
 | `fullnameOverride`             | String to fully override `descheduler.fullname` template                                                              | `""`                                 |
+| `cronJobApiVersion`            | CronJob API Group Version                                                                                             | `"batch/v1"`                         |
 | `schedule`                     | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                      |
 | `startingDeadlineSeconds`      | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                |
 | `successfulJobsHistoryLimit`   | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `nil`                                |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: {{ .Values.cronJobApiVersion }}
+apiVersion: {{ .Values.cronJobApiVersion | default "batch/v1" }}
 kind: CronJob
 metadata:
   name: {{ template "descheduler.fullname" . }}

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: {{ .Values.cronJobApiVersion }}
 kind: CronJob
 metadata:
   name: {{ template "descheduler.fullname" . }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -19,6 +19,7 @@ resources:
 nameOverride: ""
 fullnameOverride: ""
 
+cronJobApiVersion: "batch/v1"  # for k8s version < 0.21.0, use "batch/v1beta1"
 schedule: "*/2 * * * *"
 #startingDeadlineSeconds: 200
 #successfulJobsHistoryLimit: 1

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -19,7 +19,7 @@ resources:
 nameOverride: ""
 fullnameOverride: ""
 
-cronJobApiVersion: "batch/v1"  # for k8s version < 0.21.0, use "batch/v1beta1"
+cronJobApiVersion: "batch/v1"  # Use "batch/v1beta1" for k8s version < 1.21.0. TODO(@7i) remove with 1.23 release
 schedule: "*/2 * * * *"
 #startingDeadlineSeconds: 200
 #successfulJobsHistoryLimit: 1

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1  # for k8s version < 0.21.0, use batch/v1beta1
 kind: CronJob
 metadata:
   name: descheduler-cronjob

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1  # for k8s version < 0.21.0, use batch/v1beta1
+apiVersion: batch/v1  # for k8s version < 1.21.0, use batch/v1beta1
 kind: CronJob
 metadata:
   name: descheduler-cronjob

--- a/test/run-helm-tests.sh
+++ b/test/run-helm-tests.sh
@@ -17,12 +17,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-K8S_VERSION=${KUBERNETES_VERSION:-v1.20.2}
+K8S_VERSION=${KUBERNETES_VERSION:-v1.21.1}
 IMAGE_REPO=${HELM_IMAGE_REPO:-descheduler}
 IMAGE_TAG=${HELM_IMAGE_TAG:-helm-test}
 CHART_LOCATION=${HELM_CHART_LOCATION:-./charts/descheduler}
 VERSION=helm-test make image
-wget https://github.com/kubernetes-sigs/kind/releases/download/v0.10.0/kind-linux-amd64
+wget https://github.com/kubernetes-sigs/kind/releases/download/v0.11.0/kind-linux-amd64
 chmod +x kind-linux-amd64
 mv kind-linux-amd64 kind
 export PATH=$PATH:$PWD


### PR DESCRIPTION
Kubernetes 1.21: CronJob Reaches GA (group version: `batch/v1`).
Ref: https://kubernetes.io/blog/2021/04/09/kubernetes-release-1.21-cronjob-ga/

WARNING: This PR should not be merged until the new Descheduler version is released.

fyi, I tried to compute the api version but it was using 1.20 for my local Kind cluster of version 1.21 so I decided against it.:
```yaml
{{/*
Return the appropriate apiVersion for CronJob.
*/}}
{{- define "cronjob.apiVersion" -}}
{{- if lt (int .Capabilities.KubeVersion.Minor) 21 -}}
{{- print "batch/v1beta1" -}}
{{- else -}}
{{- print "batch/v1" -}}
{{- end -}}
{{- end -}}
```

```yaml
apiVersion: {{ template "cronjob.apiVersion" . }}
kind: CronJob
```