### PR TITLE
Remove namespace from ClusterRoleBinding

### DIFF
--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -33,7 +33,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: descheduler-cluster-role-binding
-  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
It's not namespace scoped. This breaks some tools like kpt.