### PR TITLE
Update helm chart for running as deployment

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -45,6 +45,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 
 | Parameter                      | Description                                                                                                           | Default                              |
 | ------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `kind`                         | Use as CronJob or Deployment                                                                                          | `CronJob`                            |
 | `image.repository`             | Docker repository to use                                                                                              | `k8s.gcr.io/descheduler/descheduler` |
 | `image.tag`                    | Docker tag to use                                                                                                     | `v[chart appVersion]`                |
 | `image.pullPolicy`             | Docker image pull policy                                                                                              | `IfNotPresent`                       |
@@ -56,6 +57,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `startingDeadlineSeconds`      | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                |
 | `successfulJobsHistoryLimit`   | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `nil`                                |
 | `failedJobsHistoryLimit`       | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `nil`                                |
+| `deschedulingInterval`         | If using kind:Deployment, sets time between consecutive descheduler executions.                                       | `5m`                                 |
 | `cmdOptions`                   | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                    |
 | `deschedulerPolicy.strategies` | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                    |
 | `priorityClassName`            | The name of the priority class to add to pods                                                                         | `system-cluster-critical`            |

--- a/charts/descheduler/templates/_helpers.tpl
+++ b/charts/descheduler/templates/_helpers.tpl
@@ -45,6 +45,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
+Selector labels
+*/}}
+{{- define "descheduler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "descheduler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "descheduler.serviceAccountName" -}}

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.kind "CronJob" }}
 apiVersion: {{ .Values.cronJobApiVersion | default "batch/v1" }}
 kind: CronJob
 metadata:
@@ -27,8 +28,7 @@ spec:
             {{- .Values.podAnnotations | toYaml | nindent 12 }}
             {{- end }}
           labels:
-            app.kubernetes.io/name: {{ include "descheduler.name" . }}
-            app.kubernetes.io/instance: {{ .Release.Name }}
+            {{- include "descheduler.selectorLabels" . | nindent 12 }}
             {{- if .Values.podLabels }}
             {{- .Values.podLabels | toYaml | nindent 12 }}
             {{- end }}
@@ -82,3 +82,4 @@ spec:
           - name: policy-volume
             configMap:
               name: {{ template "descheduler.fullname" . }}
+{{- end }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -1,0 +1,75 @@
+{{- if eq .Values.kind "Deployment" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "descheduler.fullname" . }}
+  labels:
+    {{- include "descheduler.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "descheduler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "descheduler.selectorLabels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- .Values.podLabels | toYaml | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+        {{- .Values.podAnnotations | toYaml | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "/bin/descheduler"
+          args:
+            - "--policy-config-file"
+            - "/policy-dir/policy.yaml"
+            - "--descheduling-interval"
+            - {{ required "deschedulingInterval required for running as Deployment" .Values.deschedulingInterval }}
+            {{- range $key, $value := .Values.cmdOptions }}
+            - {{ printf "--%s" $key | quote }}
+            {{- if $value }}
+            - {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+          ports:
+            - containerPort: 10258
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /policy-dir
+              name: policy-volume
+      volumes:
+        - name: policy-volume
+          configMap:
+            name: {{ template "descheduler.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# CronJob or Deployment
+kind: CronJob
+
 image:
   repository: k8s.gcr.io/descheduler/descheduler
   # Overrides the image tag whose default is the chart version
@@ -26,6 +29,9 @@ schedule: "*/2 * * * *"
 #startingDeadlineSeconds: 200
 #successfulJobsHistoryLimit: 1
 #failedJobsHistoryLimit: 1
+
+# Required when running as a Deployment
+deschedulingInterval: 5m
 
 cmdOptions:
   v: 3


### PR DESCRIPTION
Builds off of https://github.com/kubernetes-sigs/descheduler/pull/572 to also add the deployment to helm.

`helm template` yields the following with `kind: Deployment`:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-descheduler
  labels:
    app.kubernetes.io/name: descheduler
    helm.sh/chart: descheduler-0.20.0
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "0.20.0"
    app.kubernetes.io/managed-by: Tiller
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: descheduler
      app.kubernetes.io/instance: RELEASE-NAME
  template:
    metadata:
      labels:
        app.kubernetes.io/name: descheduler
        app.kubernetes.io/instance: RELEASE-NAME
      annotations:
        checksum/config: 9fe081cdd7d5c040105f0b817cfded705b3a18c3e4258d0afef86ec00f1cf9ee
    spec:
      priorityClassName: system-cluster-critical
      serviceAccountName: RELEASE-NAME-descheduler
      containers:
        - name: descheduler
          image: "k8s.gcr.io/descheduler/descheduler:v0.20.0"
          imagePullPolicy: IfNotPresent
          command:
            - "/bin/descheduler"
          args:
            - "--policy-config-file"
            - "/policy-dir/policy.yaml"
            - "--descheduling-interval"
            - 5m
            - "--v"
            - "3"
          ports:
            - containerPort: 10258
              protocol: TCP
          resources:
            requests:
              cpu: 500m
              memory: 256Mi

          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            privileged: false
            readOnlyRootFilesystem: true
            runAsNonRoot: true
            # Required until 0.21.0 image is released
            # https://github.com/kubernetes-sigs/descheduler/issues/466
            runAsUser: 1000
          volumeMounts:
            - mountPath: /policy-dir
              name: policy-volume
      volumes:
        - name: policy-volume
          configMap:
            name: RELEASE-NAME-descheduler
```

