### PR TITLE
TestTaintsUpdated: Drop errChan, it's usefull only during the startup

### DIFF
--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -44,20 +44,16 @@ func TestTaintsUpdated(t *testing.T) {
 	}
 	rs.Client = client
 	rs.DeschedulingInterval = 100 * time.Millisecond
-	errChan := make(chan error, 1)
-	defer close(errChan)
+
 	go func() {
 		err := RunDeschedulerStrategies(ctx, rs, dp, "v1beta1", stopChannel)
-		errChan <- err
-	}()
-	select {
-	case err := <-errChan:
 		if err != nil {
-			t.Fatalf("Unable to run descheduler strategies: %v", err)
+			t.Logf("ERROR: Unable to run descheduler strategies: %v", err)
 		}
-	case <-time.After(300 * time.Millisecond):
-		// Wait for few cycles and then verify the only pod still exists
-	}
+	}()
+
+	// Wait for few cycles and then verify the only pod still exists
+	time.Sleep(300 * time.Millisecond)
 
 	pods, err := client.CoreV1().Pods(p1.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Otherwise, one can get:
```
panic: send on closed channel

goroutine 76 [running]:
sigs.k8s.io/descheduler/pkg/descheduler.TestTaintsUpdated.func1(0x2d1b390, 0xc000126010, 0xc0000d8c60, 0xc00038fbd0, 0xc000111320, 0xc000239380)
	/home/travis/gopath/src/github.com/openshift/descheduler/_output/local/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler_test.go:51 +0xbe
created by sigs.k8s.io/descheduler/pkg/descheduler.TestTaintsUpdated
	/home/travis/gopath/src/github.com/openshift/descheduler/_output/local/go/src/sigs.k8s.io/descheduler/pkg/descheduler/descheduler_test.go:49 +0x6db
FAIL	sigs.k8s.io/descheduler/pkg/descheduler	0.845s
```