### PR TITLE
Place bash shebang at the top of the script + Ensure Helm installed for run-helm-tests

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 set -x
 set -o errexit

--- a/test/run-helm-tests.sh
+++ b/test/run-helm-tests.sh
@@ -29,8 +29,8 @@ mv kind-linux-amd64 kind
 export PATH=$PATH:$PWD
 kind create cluster --image kindest/node:"${K8S_VERSION}" --config=./hack/kind_config.yaml
 kind load docker-image descheduler:helm-test
-helm install descheduler-ci --set image.repository="${IMAGE_REPO}",image.tag="${IMAGE_TAG}" --namespace kube-system "${CHART_LOCATION}"
-sleep 20s
+helm install descheduler-ci --set image.repository="${IMAGE_REPO}",image.tag="${IMAGE_TAG}",schedule="* * * * *" --namespace kube-system "${CHART_LOCATION}"
+sleep 61 # sleep until Job is triggered
 helm test descheduler-ci --namespace kube-system
 
 # Delete kind cluster once test is finished

--- a/test/run-helm-tests.sh
+++ b/test/run-helm-tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/bin/bash
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/test/run-unit-tests.sh
+++ b/test/run-unit-tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 set -x
 set -o errexit


### PR DESCRIPTION
2 issues are currently causing the builds to fail:
1. Wrong placement of the bash shebang. This needs to be at the top of the file
2. Helm does not seem to be installed in the build pipeline so modifying the Makefile to ensure always installed