### PR TITLE
nodeutilization strategy: "numberOfNodes" should work as documented

### DIFF
--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
@@ -92,8 +92,8 @@ func HighNodeUtilization(ctx context.Context, client clientset.Interface, strate
 		klog.V(1).InfoS("No node is underutilized, nothing to do here, you might tune your thresholds further")
 		return
 	}
-	if len(sourceNodes) < strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes {
-		klog.V(1).InfoS("Number of nodes underutilized is less than NumberOfNodes, nothing to do here", "underutilizedNodes", len(sourceNodes), "numberOfNodes", strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes)
+	if len(sourceNodes) <= strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes {
+		klog.V(1).InfoS("Number of nodes underutilized is less or equal than NumberOfNodes, nothing to do here", "underutilizedNodes", len(sourceNodes), "numberOfNodes", strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes)
 		return
 	}
 	if len(sourceNodes) == len(nodes) {

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization.go
@@ -19,6 +19,7 @@ package nodeutilization
 import (
 	"context"
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	clientset "k8s.io/client-go/kubernetes"
@@ -118,8 +119,8 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		return
 	}
 
-	if len(lowNodes) < strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes {
-		klog.V(1).InfoS("Number of nodes underutilized is less than NumberOfNodes, nothing to do here", "underutilizedNodes", len(lowNodes), "numberOfNodes", strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes)
+	if len(lowNodes) <= strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes {
+		klog.V(1).InfoS("Number of nodes underutilized is less or equal than NumberOfNodes, nothing to do here", "underutilizedNodes", len(lowNodes), "numberOfNodes", strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes)
 		return
 	}
 


### PR DESCRIPTION
The "numberOfNodes" paramter should take effect as documented, when underutilzed nodes count is above the configured value. Currently it takes also effect, when nodes count is equal the configured value.