### PR TITLE
Bump To Go 1.16.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.16.1
+FROM golang:1.16.7
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .


### PR DESCRIPTION
The main k/k repo was updated to Go 1.16.7 for k8s
v1.22.0 release. See below PR for reference.

https://github.com/kubernetes/kubernetes/pull/104200