### PR TITLE
[helm values] Add note on evict-local-storage-pods

### DIFF
--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -35,7 +35,7 @@ deschedulingInterval: 5m
 
 cmdOptions:
   v: 3
-  # evict-local-storage-pods:
+  # evict-local-storage-pods: # To enable, just uncomment the key. Don't set its value to "true".
   # max-pods-to-evict-per-node: 10
   # node-selector: "key1=value1,key2=value2"
 


### PR DESCRIPTION
Setting it to true causes:

```
Error: unknown command "true" for "descheduler"
Run 'descheduler --help' for usage.
unknown command "true" for "descheduler"
```

This is confusing as other references to this parameter (outside of helm) do ask you to set it to true.

Would be better to just accept the value here, but for now this is what I can help with.