### PR TITLE
Added request considerations to NodeFit Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,7 @@ The following strategies accept a `nodeFit` boolean parameter which can optimize
 - A `nodeSelector` on the pod
 - Any `Tolerations` on the pod and any `Taints` on the other nodes
 - `nodeAffinity` on the pod
+- Resource `Requests` made by the pod and the resources available on other nodes 
 - Whether any of the other nodes are marked as `unschedulable`
 
 E.g.

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -145,6 +145,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 			deschedulerPolicy.MaxNoOfPodsToEvictPerNode,
 			deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace,
 			nodes,
+			getPodsAssignedToNode,
 			evictLocalStoragePods,
 			evictSystemCriticalPods,
 			ignorePvcPods,

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -51,6 +51,7 @@ type namespacePodEvictCount map[string]uint
 type PodEvictor struct {
 	client                     clientset.Interface
 	nodes                      []*v1.Node
+	nodeIndexer                podutil.GetPodsAssignedToNodeFunc
 	policyGroupVersion         string
 	dryRun                     bool
 	maxPodsToEvictPerNode      *uint
@@ -70,6 +71,7 @@ func NewPodEvictor(
 	maxPodsToEvictPerNode *uint,
 	maxPodsToEvictPerNamespace *uint,
 	nodes []*v1.Node,
+	nodeIndexer podutil.GetPodsAssignedToNodeFunc,
 	evictLocalStoragePods bool,
 	evictSystemCriticalPods bool,
 	ignorePvcPods bool,
@@ -85,6 +87,7 @@ func NewPodEvictor(
 	return &PodEvictor{
 		client:                     client,
 		nodes:                      nodes,
+		nodeIndexer:                nodeIndexer,
 		policyGroupVersion:         policyGroupVersion,
 		dryRun:                     dryRun,
 		maxPodsToEvictPerNode:      maxPodsToEvictPerNode,
@@ -286,7 +289,7 @@ func (pe *PodEvictor) Evictable(opts ...func(opts *Options)) *evictable {
 	}
 	if options.nodeFit {
 		ev.constraints = append(ev.constraints, func(pod *v1.Pod) error {
-			if !nodeutil.PodFitsAnyOtherNode(pod, pe.nodes) {
+			if !nodeutil.PodFitsAnyOtherNode(pe.nodeIndexer, pod, pe.nodes) {
 				return fmt.Errorf("pod does not fit on any other node because of nodeSelector(s), Taint(s), or nodes marked as unschedulable")
 			}
 			return nil

--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
@@ -80,9 +82,9 @@ func TestIsEvictable(t *testing.T) {
 	nodeLabelKey := "datacenter"
 	nodeLabelValue := "east"
 	type testCase struct {
-		pod                     *v1.Pod
+		description             string
+		pods                    []*v1.Pod
 		nodes                   []*v1.Node
-		runBefore               func(*v1.Pod, []*v1.Node)
 		evictFailedBarePods     bool
 		evictLocalStoragePods   bool
 		evictSystemCriticalPods bool
@@ -92,261 +94,309 @@ func TestIsEvictable(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{ // Failed pod eviction with no ownerRefs.
-			pod: test.BuildTestPod("bare_pod_failed", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.Status.Phase = v1.PodFailed
+		{
+			description: "Failed pod eviction with no ownerRefs",
+			pods: []*v1.Pod{
+				test.BuildTestPod("bare_pod_failed", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.Status.Phase = v1.PodFailed
+				}),
 			},
 			evictFailedBarePods: false,
 			result:              false,
-		}, { // Normal pod eviction with no ownerRefs and evictFailedBarePods enabled
-			pod: test.BuildTestPod("bare_pod", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-			},
+		}, {
+			description:         "Normal pod eviction with no ownerRefs and evictFailedBarePods enabled",
+			pods:                []*v1.Pod{test.BuildTestPod("bare_pod", 400, 0, n1.Name, nil)},
 			evictFailedBarePods: true,
 			result:              false,
-		}, { // Failed pod eviction with no ownerRefs
-			pod: test.BuildTestPod("bare_pod_failed_but_can_be_evicted", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.Status.Phase = v1.PodFailed
+		}, {
+			description: "Failed pod eviction with no ownerRefs",
+			pods: []*v1.Pod{
+				test.BuildTestPod("bare_pod_failed_but_can_be_evicted", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.Status.Phase = v1.PodFailed
+				}),
 			},
 			evictFailedBarePods: true,
 			result:              true,
-		}, { // Normal pod eviction with normal ownerRefs
-			pod: test.BuildTestPod("p1", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+		}, {
+			description: "Normal pod eviction with normal ownerRefs",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Normal pod eviction with normal ownerRefs and descheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p2", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+		}, {
+			description: "Normal pod eviction with normal ownerRefs and descheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p2", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Normal pod eviction with replicaSet ownerRefs
-			pod: test.BuildTestPod("p3", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+		}, {
+			description: "Normal pod eviction with replicaSet ownerRefs",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p3", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Normal pod eviction with replicaSet ownerRefs and descheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p4", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+		}, {
+			description: "Normal pod eviction with replicaSet ownerRefs and descheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p4", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Normal pod eviction with statefulSet ownerRefs
-			pod: test.BuildTestPod("p18", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetStatefulSetOwnerRefList()
+		}, {
+			description: "Normal pod eviction with statefulSet ownerRefs",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p18", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Normal pod eviction with statefulSet ownerRefs and descheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p19", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetStatefulSetOwnerRefList()
+		}, {
+			description: "Normal pod eviction with statefulSet ownerRefs and descheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p19", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					pod.ObjectMeta.OwnerReferences = test.GetStatefulSetOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Pod not evicted because it is bound to a PV and evictLocalStoragePods = false
-			pod: test.BuildTestPod("p5", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Spec.Volumes = []v1.Volume{
-					{
-						Name: "sample",
-						VolumeSource: v1.VolumeSource{
-							HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
-							EmptyDir: &v1.EmptyDirVolumeSource{
-								SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+		}, {
+			description: "Pod not evicted because it is bound to a PV and evictLocalStoragePods = false",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p5", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.Volumes = []v1.Volume{
+						{
+							Name: "sample",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+							},
 						},
-					},
-				}
+					}
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  false,
-		}, { // Pod is evicted because it is bound to a PV and evictLocalStoragePods = true
-			pod: test.BuildTestPod("p6", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Spec.Volumes = []v1.Volume{
-					{
-						Name: "sample",
-						VolumeSource: v1.VolumeSource{
-							HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
-							EmptyDir: &v1.EmptyDirVolumeSource{
-								SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+		}, {
+			description: "Pod is evicted because it is bound to a PV and evictLocalStoragePods = true",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p6", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.Volumes = []v1.Volume{
+						{
+							Name: "sample",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+							},
 						},
-					},
-				}
+					}
+				}),
 			},
 			evictLocalStoragePods:   true,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Pod is evicted because it is bound to a PV and evictLocalStoragePods = false, but it has scheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p7", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Spec.Volumes = []v1.Volume{
-					{
-						Name: "sample",
-						VolumeSource: v1.VolumeSource{
-							HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
-							EmptyDir: &v1.EmptyDirVolumeSource{
-								SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+		}, {
+			description: "Pod is evicted because it is bound to a PV and evictLocalStoragePods = false, but it has scheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p7", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.Volumes = []v1.Volume{
+						{
+							Name: "sample",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+							},
 						},
-					},
-				}
+					}
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Pod not evicted becasuse it is part of a daemonSet
-			pod: test.BuildTestPod("p8", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList()
+		}, {
+			description: "Pod not evicted becasuse it is part of a daemonSet",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p8", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  false,
-		}, { // Pod is evicted becasuse it is part of a daemonSet, but it has scheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p9", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList()
+		}, {
+			description: "Pod is evicted becasuse it is part of a daemonSet, but it has scheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p9", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					pod.ObjectMeta.OwnerReferences = test.GetDaemonSetOwnerRefList()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Pod not evicted becasuse it is a mirror pod
-			pod: test.BuildTestPod("p10", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Annotations = test.GetMirrorPodAnnotation()
+		}, {
+			description: "Pod not evicted becasuse it is a mirror poddsa",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p10", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Annotations = test.GetMirrorPodAnnotation()
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  false,
-		}, { // Pod is evicted becasuse it is a mirror pod, but it has scheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p11", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Annotations = test.GetMirrorPodAnnotation()
-				pod.Annotations["descheduler.alpha.kubernetes.io/evict"] = "true"
+		}, {
+			description: "Pod is evicted becasuse it is a mirror pod, but it has scheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p11", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Annotations = test.GetMirrorPodAnnotation()
+					pod.Annotations["descheduler.alpha.kubernetes.io/evict"] = "true"
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Pod not evicted becasuse it has system critical priority
-			pod: test.BuildTestPod("p12", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				priority := utils.SystemCriticalPriority
-				pod.Spec.Priority = &priority
+		}, {
+			description: "Pod not evicted becasuse it has system critical priority",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p12", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					priority := utils.SystemCriticalPriority
+					pod.Spec.Priority = &priority
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  false,
-		}, { // Pod is evicted becasuse it has system critical priority, but it has scheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p13", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				priority := utils.SystemCriticalPriority
-				pod.Spec.Priority = &priority
-				pod.Annotations = map[string]string{
-					"descheduler.alpha.kubernetes.io/evict": "true",
-				}
+		}, {
+			description: "Pod is evicted becasuse it has system critical priority, but it has scheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p13", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					priority := utils.SystemCriticalPriority
+					pod.Spec.Priority = &priority
+					pod.Annotations = map[string]string{
+						"descheduler.alpha.kubernetes.io/evict": "true",
+					}
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
-		}, { // Pod not evicted becasuse it has a priority higher than the configured priority threshold
-			pod: test.BuildTestPod("p14", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Spec.Priority = &highPriority
+		}, {
+			description: "Pod not evicted becasuse it has a priority higher than the configured priority threshold",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p14", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.Priority = &highPriority
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			priorityThreshold:       &lowPriority,
 			result:                  false,
-		}, { // Pod is evicted becasuse it has a priority higher than the configured priority threshold, but it has scheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p15", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.Spec.Priority = &highPriority
+		}, {
+			description: "Pod is evicted becasuse it has a priority higher than the configured priority threshold, but it has scheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p15", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					pod.Spec.Priority = &highPriority
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			priorityThreshold:       &lowPriority,
 			result:                  true,
-		}, { // Pod is evicted becasuse it has system critical priority, but evictSystemCriticalPods = true
-			pod: test.BuildTestPod("p16", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				priority := utils.SystemCriticalPriority
-				pod.Spec.Priority = &priority
+		}, {
+			description: "Pod is evicted becasuse it has system critical priority, but evictSystemCriticalPods = true",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p16", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					priority := utils.SystemCriticalPriority
+					pod.Spec.Priority = &priority
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: true,
 			result:                  true,
-		}, { // Pod is evicted becasuse it has system critical priority, but evictSystemCriticalPods = true and it has scheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p16", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				priority := utils.SystemCriticalPriority
-				pod.Spec.Priority = &priority
+		}, {
+			description: "Pod is evicted becasuse it has system critical priority, but evictSystemCriticalPods = true and it has scheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p16", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					priority := utils.SystemCriticalPriority
+					pod.Spec.Priority = &priority
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: true,
 			result:                  true,
-		}, { // Pod is evicted becasuse it has a priority higher than the configured priority threshold, but evictSystemCriticalPods = true
-			pod: test.BuildTestPod("p17", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Spec.Priority = &highPriority
-			},
-			evictLocalStoragePods:   false,
-			evictSystemCriticalPods: true,
-			priorityThreshold:       &lowPriority,
-			result:                  true,
-		}, { // Pod is evicted becasuse it has a priority higher than the configured priority threshold, but evictSystemCriticalPods = true and it has scheduler.alpha.kubernetes.io/evict annotation
-			pod: test.BuildTestPod("p17", 400, 0, n1.Name, nil),
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
-				pod.Spec.Priority = &highPriority
+		}, {
+			description: "Pod is evicted becasuse it has a priority higher than the configured priority threshold, but evictSystemCriticalPods = true",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p17", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.Priority = &highPriority
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: true,
 			priorityThreshold:       &lowPriority,
 			result:                  true,
-		}, { // Pod with no tolerations running on normal node, all other nodes tainted
-			pod:   test.BuildTestPod("p1", 400, 0, n1.Name, nil),
-			nodes: []*v1.Node{test.BuildTestNode("node2", 1000, 2000, 13, nil), test.BuildTestNode("node3", 1000, 2000, 13, nil)},
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-
-				for _, node := range nodes {
+		}, {
+			description: "Pod is evicted becasuse it has a priority higher than the configured priority threshold, but evictSystemCriticalPods = true and it has scheduler.alpha.kubernetes.io/evict annotation",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p17", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/evict": "true"}
+					pod.Spec.Priority = &highPriority
+				}),
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: true,
+			priorityThreshold:       &lowPriority,
+			result:                  true,
+		}, {
+			description: "Pod with no tolerations running on normal node, all other nodes tainted",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+				}),
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2", 1000, 2000, 13, func(node *v1.Node) {
 					node.Spec.Taints = []v1.Taint{
 						{
 							Key:    nodeTaintKey,
@@ -354,27 +404,8 @@ func TestIsEvictable(t *testing.T) {
 							Effect: v1.TaintEffectNoSchedule,
 						},
 					}
-				}
-			},
-			evictLocalStoragePods:   false,
-			evictSystemCriticalPods: false,
-			nodeFit:                 true,
-			result:                  false,
-		}, { // Pod with correct tolerations running on normal node, all other nodes tainted
-			pod: test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
-				pod.Spec.Tolerations = []v1.Toleration{
-					{
-						Key:    nodeTaintKey,
-						Value:  nodeTaintValue,
-						Effect: v1.TaintEffectNoSchedule,
-					},
-				}
-			}),
-			nodes: []*v1.Node{test.BuildTestNode("node2", 1000, 2000, 13, nil), test.BuildTestNode("node3", 1000, 2000, 13, nil)},
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-
-				for _, node := range nodes {
+				}),
+				test.BuildTestNode("node3", 1000, 2000, 13, func(node *v1.Node) {
 					node.Spec.Taints = []v1.Taint{
 						{
 							Key:    nodeTaintKey,
@@ -382,81 +413,259 @@ func TestIsEvictable(t *testing.T) {
 							Effect: v1.TaintEffectNoSchedule,
 						},
 					}
-				}
-			},
-			evictLocalStoragePods:   false,
-			evictSystemCriticalPods: false,
-			nodeFit:                 true,
-			result:                  true,
-		}, { // Pod with incorrect node selector
-			pod: test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
-				pod.Spec.NodeSelector = map[string]string{
-					nodeLabelKey: "fail",
-				}
-			}),
-			nodes: []*v1.Node{test.BuildTestNode("node2", 1000, 2000, 13, nil), test.BuildTestNode("node3", 1000, 2000, 13, nil)},
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-
-				for _, node := range nodes {
-					node.ObjectMeta.Labels = map[string]string{
-						nodeLabelKey: nodeLabelValue,
-					}
-				}
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			nodeFit:                 true,
 			result:                  false,
-		}, { // Pod with correct node selector
-			pod: test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
-				pod.Spec.NodeSelector = map[string]string{
-					nodeLabelKey: nodeLabelValue,
-				}
-			}),
-			nodes: []*v1.Node{test.BuildTestNode("node2", 1000, 2000, 13, nil), test.BuildTestNode("node3", 1000, 2000, 13, nil)},
-			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
-				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
-
-				for _, node := range nodes {
-					node.ObjectMeta.Labels = map[string]string{
-						nodeLabelKey: nodeLabelValue,
+		}, {
+			description: "Pod with correct tolerations running on normal node, all other nodes tainted",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.Tolerations = []v1.Toleration{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
 					}
-				}
+				}),
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2", 1000, 2000, 13, func(node *v1.Node) {
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+				test.BuildTestNode("node3", 1000, 2000, 13, func(node *v1.Node) {
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
 			},
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			nodeFit:                 true,
 			result:                  true,
+		}, {
+			description: "Pod with incorrect node selector",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.NodeSelector = map[string]string{
+						nodeLabelKey: "fail",
+					}
+				}),
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2", 1000, 2000, 13, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+				test.BuildTestNode("node3", 1000, 2000, 13, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			nodeFit:                 true,
+			result:                  false,
+		}, {
+			description: "Pod with correct node selector",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 400, 0, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.NodeSelector = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2", 1000, 2000, 13, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+				test.BuildTestNode("node3", 1000, 2000, 13, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			nodeFit:                 true,
+			result:                  true,
+		}, {
+			description: "Pod with correct node selector, but only available node doesn't have enough CPU",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 12, 8, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.NodeSelector = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2-TEST", 10, 16, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+				test.BuildTestNode("node3-TEST", 10, 16, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			nodeFit:                 true,
+			result:                  false,
+		}, {
+			description: "Pod with correct node selector, and one node has enough memory",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 12, 8, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.NodeSelector = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+				test.BuildTestPod("node2-pod-10GB-mem", 20, 10, "node2", func(pod *v1.Pod) {
+					pod.ObjectMeta.Labels = map[string]string{
+						"test": "true",
+					}
+				}),
+				test.BuildTestPod("node3-pod-10GB-mem", 20, 10, "node3", func(pod *v1.Pod) {
+					pod.ObjectMeta.Labels = map[string]string{
+						"test": "true",
+					}
+				}),
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2", 100, 16, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+				test.BuildTestNode("node3", 100, 20, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			nodeFit:                 true,
+			result:                  true,
+		}, {
+			description: "Pod with correct node selector, but both nodes don't have enough memory",
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 12, 8, n1.Name, func(pod *v1.Pod) {
+					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+					pod.Spec.NodeSelector = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+				test.BuildTestPod("node2-pod-10GB-mem", 10, 10, "node2", func(pod *v1.Pod) {
+					pod.ObjectMeta.Labels = map[string]string{
+						"test": "true",
+					}
+				}),
+				test.BuildTestPod("node3-pod-10GB-mem", 10, 10, "node3", func(pod *v1.Pod) {
+					pod.ObjectMeta.Labels = map[string]string{
+						"test": "true",
+					}
+				}),
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2", 100, 16, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+				test.BuildTestNode("node3", 100, 16, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+				}),
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			nodeFit:                 true,
+			result:                  false,
 		},
 	}
 
 	for _, test := range testCases {
-		test.runBefore(test.pod, test.nodes)
-		nodes := append(test.nodes, n1)
 
-		podEvictor := &PodEvictor{
-			evictLocalStoragePods:   test.evictLocalStoragePods,
-			evictSystemCriticalPods: test.evictSystemCriticalPods,
-			evictFailedBarePods:     test.evictFailedBarePods,
-			nodes:                   nodes,
-		}
+		t.Run(test.description, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-		evictable := podEvictor.Evictable()
-		var opts []func(opts *Options)
-		if test.priorityThreshold != nil {
-			opts = append(opts, WithPriorityThreshold(*test.priorityThreshold))
-		}
-		if test.nodeFit {
-			opts = append(opts, WithNodeFit(true))
-		}
-		evictable = podEvictor.Evictable(opts...)
+			nodes := append(test.nodes, n1)
 
-		result := evictable.IsEvictable(test.pod)
-		if result != test.result {
-			t.Errorf("IsEvictable should return for pod %s %t, but it returns %t", test.pod.Name, test.result, result)
-		}
+			var objs []runtime.Object
+			for _, node := range test.nodes {
+				objs = append(objs, node)
+			}
+			for _, pod := range test.pods {
+				objs = append(objs, pod)
+			}
 
+			fakeClient := fake.NewSimpleClientset(objs...)
+
+			sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+			podInformer := sharedInformerFactory.Core().V1().Pods()
+
+			getPodsAssignedToNode, err := podutil.BuildGetPodsAssignedToNodeFunc(podInformer)
+			if err != nil {
+				t.Errorf("Build get pods assigned to node function error: %v", err)
+			}
+
+			sharedInformerFactory.Start(ctx.Done())
+			sharedInformerFactory.WaitForCacheSync(ctx.Done())
+
+			podEvictor := &PodEvictor{
+				client:                     fakeClient,
+				nodes:                      nodes,
+				nodeIndexer:                getPodsAssignedToNode,
+				policyGroupVersion:         policyv1.SchemeGroupVersion.String(),
+				dryRun:                     false,
+				maxPodsToEvictPerNode:      nil,
+				maxPodsToEvictPerNamespace: nil,
+				evictLocalStoragePods:      test.evictLocalStoragePods,
+				evictSystemCriticalPods:    test.evictSystemCriticalPods,
+				evictFailedBarePods:        test.evictFailedBarePods,
+			}
+
+			var opts []func(opts *Options)
+			if test.priorityThreshold != nil {
+				opts = append(opts, WithPriorityThreshold(*test.priorityThreshold))
+			}
+			if test.nodeFit {
+				opts = append(opts, WithNodeFit(true))
+			}
+			evictable := podEvictor.Evictable(opts...)
+
+			result := evictable.IsEvictable(test.pods[0])
+			if result != test.result {
+				t.Errorf("IsEvictable should return for pod %s %t, but it returns %t", test.pods[0].Name, test.result, result)
+			}
+		})
 	}
 }
 func TestPodTypes(t *testing.T) {

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -21,9 +21,13 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	"sigs.k8s.io/descheduler/test"
 )
 
@@ -147,13 +151,13 @@ func TestPodFitsCurrentNode(t *testing.T) {
 					},
 				},
 			},
-			node: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						nodeLabelKey: nodeLabelValue,
-					},
-				},
-			},
+			node: test.BuildTestNode("node1", 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+				node.ObjectMeta.Labels = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+
+				node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+			}),
 			success: true,
 		},
 		{
@@ -181,27 +185,53 @@ func TestPodFitsCurrentNode(t *testing.T) {
 					},
 				},
 			},
-			node: &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						nodeLabelKey: "no",
-					},
-				},
-			},
+			node: test.BuildTestNode("node1", 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+				node.ObjectMeta.Labels = map[string]string{
+					nodeLabelKey: "no",
+				}
+
+				node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+			}),
 			success: false,
 		},
 	}
 
+	fakeClient := &fake.Clientset{}
+	fakeClient.Fake.AddReactor("list", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &v1.PodList{Items: nil}, nil
+	})
+
 	for _, tc := range tests {
-		actual := PodFitsCurrentNode(tc.pod, tc.node)
-		if actual != tc.success {
-			t.Errorf("Test %#v failed", tc.description)
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var objs []runtime.Object
+			objs = append(objs, tc.node)
+			objs = append(objs, tc.pod)
+
+			fakeClient := fake.NewSimpleClientset(objs...)
+
+			sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+			podInformer := sharedInformerFactory.Core().V1().Pods()
+
+			getPodsAssignedToNode, err := podutil.BuildGetPodsAssignedToNodeFunc(podInformer)
+			if err != nil {
+				t.Errorf("Build get pods assigned to node function error: %v", err)
+			}
+
+			sharedInformerFactory.Start(ctx.Done())
+			sharedInformerFactory.WaitForCacheSync(ctx.Done())
+
+			actual := PodFitsCurrentNode(getPodsAssignedToNode, tc.pod, tc.node)
+			if actual != tc.success {
+				t.Errorf("Test %#v failed", tc.description)
+			}
+		})
 	}
 }
 
 func TestPodFitsAnyOtherNode(t *testing.T) {
-
 	nodeLabelKey := "kubernetes.io/desiredNode"
 	nodeLabelValue := "yes"
 	nodeTaintKey := "hardware"
@@ -215,238 +245,527 @@ func TestPodFitsAnyOtherNode(t *testing.T) {
 		pod         *v1.Pod
 		nodes       []*v1.Node
 		success     bool
+		podsOnNodes []*v1.Pod
 	}{
 		{
 			description: "Pod fits another node matching node affinity",
-			pod:         createPodManifest(nodeNames[2], nodeLabelKey, nodeLabelValue),
+			pod: test.BuildTestPod("p1", 0, 0, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+			}),
 			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[0],
-						Labels: map[string]string{
-							nodeLabelKey: nodeLabelValue,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[1],
-						Labels: map[string]string{
-							nodeLabelKey: "no",
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[2],
-					},
-				},
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[1], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: "no",
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
 			},
-			success: true,
+			podsOnNodes: []*v1.Pod{},
+			success:     true,
 		},
 		{
 			description: "Pod expected to fit one of the nodes",
-			pod:         createPodManifest(nodeNames[2], nodeLabelKey, nodeLabelValue),
+			pod: test.BuildTestPod("p1", 0, 0, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+			}),
 			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[0],
-						Labels: map[string]string{
-							nodeLabelKey: "no",
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[1],
-						Labels: map[string]string{
-							nodeLabelKey: nodeLabelValue,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[2],
-					},
-				},
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: "no",
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[1], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
 			},
-			success: true,
+			podsOnNodes: []*v1.Pod{},
+			success:     true,
 		},
 		{
 			description: "Pod expected to fit none of the nodes",
-			pod:         createPodManifest(nodeNames[2], nodeLabelKey, nodeLabelValue),
+			pod: test.BuildTestPod("p1", 0, 0, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+			}),
 			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[0],
-						Labels: map[string]string{
-							nodeLabelKey: "unfit1",
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[1],
-						Labels: map[string]string{
-							nodeLabelKey: "unfit2",
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[2],
-					},
-				},
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: "unfit1",
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[1], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: "unfit2",
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
 			},
-			success: false,
+			podsOnNodes: []*v1.Pod{},
+			success:     false,
 		},
 		{
 			description: "Nodes are unschedulable but labels match, should fail",
-			pod:         createPodManifest(nodeNames[2], nodeLabelKey, nodeLabelValue),
+			pod: test.BuildTestPod("p1", 0, 0, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+			}),
 			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[0],
-						Labels: map[string]string{
-							nodeLabelKey: nodeLabelValue,
-						},
-					},
-					Spec: v1.NodeSpec{
-						Unschedulable: true,
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[1],
-						Labels: map[string]string{
-							nodeLabelKey: "no",
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[2],
-					},
-				},
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Unschedulable = true
+				}),
+				test.BuildTestNode(nodeNames[1], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: "no",
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
 			},
-			success: false,
+			podsOnNodes: []*v1.Pod{},
+			success:     false,
 		},
 		{
-			description: "Two nodes matches node selector, one of them is tained, should pass",
-			pod:         createPodManifest(nodeNames[2], nodeLabelKey, nodeLabelValue),
+			description: "Both nodes are tained, should fail",
+			pod: test.BuildTestPod("p1", 2000, 2*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+			}),
 			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[0],
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+				test.BuildTestNode(nodeNames[1], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{},
+			success:     false,
+		},
+		{
+			description: "Two nodes matches node selector, one of them is tained, there is a pod on the available node, and requests are low, should pass",
+			pod: test.BuildTestPod("p1", 2000, 2*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+			}),
+			nodes: []*v1.Node{
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+				test.BuildTestNode(nodeNames[1], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{
+				test.BuildTestPod("test-pod", 12*1000, 20*1000*1000*1000, nodeNames[1], func(pod *v1.Pod) {
+					pod.ObjectMeta = metav1.ObjectMeta{
+						Namespace: "test",
 						Labels: map[string]string{
-							nodeLabelKey: nodeLabelValue,
+							"test": "true",
 						},
-					},
-					Spec: v1.NodeSpec{
-						Taints: []v1.Taint{
-							{
-								Key:    nodeTaintKey,
-								Value:  nodeTaintValue,
-								Effect: v1.TaintEffectNoSchedule,
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[1],
-						Labels: map[string]string{
-							nodeLabelKey: nodeLabelValue,
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[2],
-					},
-				},
+					}
+					pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(40*1000*1000*1000, resource.DecimalSI)
+				}),
 			},
 			success: true,
 		},
 		{
-			description: "Both nodes are tained, should fail",
-			pod:         createPodManifest(nodeNames[2], nodeLabelKey, nodeLabelValue),
+			description: "Two nodes matches node selector, one of them is tained, but CPU requests are too big, should fail",
+			pod: test.BuildTestPod("p1", 2000, 2*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+			}),
 			nodes: []*v1.Node{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[0],
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+				// Notice that this node only has 4 cores, the pod already on the node below requests 3 cores, and the pod above requests 2 cores
+				test.BuildTestNode(nodeNames[1], 4000, 8*1000*1000*1000, 12, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(200*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{
+				test.BuildTestPod("3-core-pod", 3000, 4*1000*1000*1000, nodeNames[1], func(pod *v1.Pod) {
+					pod.ObjectMeta = metav1.ObjectMeta{
+						Namespace: "test",
 						Labels: map[string]string{
-							nodeLabelKey: nodeLabelValue,
+							"test": "true",
 						},
-					},
-					Spec: v1.NodeSpec{
-						Taints: []v1.Taint{
-							{
-								Key:    nodeTaintKey,
-								Value:  nodeTaintValue,
-								Effect: v1.TaintEffectNoSchedule,
-							},
+					}
+					pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+				}),
+			},
+			success: false,
+		},
+		{
+			description: "Two nodes matches node selector, one of them is tained, but memory requests are too big, should fail",
+			pod: test.BuildTestPod("p1", 2000, 5*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+			}),
+			nodes: []*v1.Node{
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
 						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[1],
+					}
+				}),
+				// Notice that this node only has 8GB of memory, the pod already on the node below requests 4GB, and the pod above requests 5GB
+				test.BuildTestNode(nodeNames[1], 10*1000, 8*1000*1000*1000, 12, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(200*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{
+				test.BuildTestPod("4GB-mem-pod", 2000, 4*1000*1000*1000, nodeNames[1], func(pod *v1.Pod) {
+					pod.ObjectMeta = metav1.ObjectMeta{
+						Namespace: "test",
 						Labels: map[string]string{
-							nodeLabelKey: nodeLabelValue,
+							"test": "true",
 						},
-					},
-					Spec: v1.NodeSpec{
-						Taints: []v1.Taint{
-							{
-								Key:    nodeTaintKey,
-								Value:  nodeTaintValue,
-								Effect: v1.TaintEffectNoExecute,
-							},
+					}
+					pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+				}),
+			},
+			success: false,
+		},
+		{
+			description: "Two nodes matches node selector, one of them is tained, but ephemeral storage requests are too big, should fail",
+			pod: test.BuildTestPod("p1", 2000, 4*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+			}),
+			nodes: []*v1.Node{
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
 						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nodeNames[2],
-					},
-				},
+					}
+				}),
+				// Notice that this node only has 20GB of storage, the pod already on the node below requests 11GB, and the pod above requests 10GB
+				test.BuildTestNode(nodeNames[1], 10*1000, 8*1000*1000*1000, 12, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(20*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{
+				test.BuildTestPod("11GB-storage-pod", 2000, 4*1000*1000*1000, nodeNames[1], func(pod *v1.Pod) {
+					pod.ObjectMeta = metav1.ObjectMeta{
+						Namespace: "test",
+						Labels: map[string]string{
+							"test": "true",
+						},
+					}
+					pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(11*1000*1000*1000, resource.DecimalSI)
+				}),
+			},
+			success: false,
+		},
+		{
+			description: "Two nodes matches node selector, one of them is tained, but custom resource requests are too big, should fail",
+			pod: test.BuildTestPod("p1", 2000, 2*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+				pod.Spec.Containers[0].Resources.Requests["example.com/custom-resource"] = *resource.NewQuantity(10, resource.DecimalSI)
+			}),
+			nodes: []*v1.Node{
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+					node.Status.Allocatable["example.com/custom-resource"] = *resource.NewQuantity(15, resource.DecimalSI)
+				}),
+				// Notice that this node only has 15 of the custom resource, the pod already on the node below requests 10, and the pod above requests 10
+				test.BuildTestNode(nodeNames[1], 10*1000, 8*1000*1000*1000, 12, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(200*1000*1000*1000, resource.DecimalSI)
+					node.Status.Allocatable["example.com/custom-resource"] = *resource.NewQuantity(15, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{
+				test.BuildTestPod("10-custom-resource-pod", 0, 0, nodeNames[1], func(pod *v1.Pod) {
+					pod.ObjectMeta = metav1.ObjectMeta{
+						Namespace: "test",
+						Labels: map[string]string{
+							"test": "true",
+						},
+					}
+					pod.Spec.Containers[0].Resources.Requests["example.com/custom-resource"] = *resource.NewQuantity(10, resource.DecimalSI)
+				}),
+			},
+			success: false,
+		},
+		{
+			description: "Two nodes matches node selector, one of them is tained, CPU requests will fit, and pod Overhead is low enough, should pass",
+			pod: test.BuildTestPod("p1", 1000, 2*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+			}),
+			nodes: []*v1.Node{
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+				// Notice that this node has 5 CPU cores, the pod below requests 2 cores, and has CPU overhead of 1 cores, and the pod above requests 1 core
+				test.BuildTestNode(nodeNames[1], 5000, 8*1000*1000*1000, 12, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(200*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{
+				test.BuildTestPod("3-core-pod", 2000, 4*1000*1000*1000, nodeNames[1], func(pod *v1.Pod) {
+					pod.ObjectMeta = metav1.ObjectMeta{
+						Namespace: "test",
+						Labels: map[string]string{
+							"test": "true",
+						},
+					}
+					pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+					pod.Spec.Overhead = createResourceList(1000, 1000*1000*1000, 1000*1000*1000)
+				}),
+			},
+			success: true,
+		},
+		{
+			description: "Two nodes matches node selector, one of them is tained, CPU requests will fit, but pod Overhead is too high, should fail",
+			pod: test.BuildTestPod("p1", 2000, 2*1000*1000*1000, nodeNames[2], func(pod *v1.Pod) {
+				pod.Spec.NodeSelector = map[string]string{
+					nodeLabelKey: nodeLabelValue,
+				}
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+			}),
+			nodes: []*v1.Node{
+				test.BuildTestNode(nodeNames[0], 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(1000*1000*1000*1000, resource.DecimalSI)
+					node.Spec.Taints = []v1.Taint{
+						{
+							Key:    nodeTaintKey,
+							Value:  nodeTaintValue,
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+				// Notice that this node only has 5 CPU cores, the pod below requests 2 cores, but has CPU overhead of 2 cores, and the pod above requests 2 cores
+				test.BuildTestNode(nodeNames[1], 5000, 8*1000*1000*1000, 12, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeLabelKey: nodeLabelValue,
+					}
+
+					node.Status.Allocatable[v1.ResourceEphemeralStorage] = *resource.NewQuantity(200*1000*1000*1000, resource.DecimalSI)
+				}),
+				test.BuildTestNode(nodeNames[2], 0, 0, 0, nil),
+			},
+			podsOnNodes: []*v1.Pod{
+				test.BuildTestPod("3-core-pod", 2000, 4*1000*1000*1000, nodeNames[1], func(pod *v1.Pod) {
+					pod.ObjectMeta = metav1.ObjectMeta{
+						Namespace: "test",
+						Labels: map[string]string{
+							"test": "true",
+						},
+					}
+					pod.Spec.Containers[0].Resources.Requests[v1.ResourceEphemeralStorage] = *resource.NewQuantity(10*1000*1000*1000, resource.DecimalSI)
+					pod.Spec.Overhead = createResourceList(2000, 1000*1000*1000, 1000*1000*1000)
+				}),
 			},
 			success: false,
 		},
 	}
 
 	for _, tc := range tests {
-		actual := PodFitsAnyOtherNode(tc.pod, tc.nodes)
-		if actual != tc.success {
-			t.Errorf("Test %#v failed", tc.description)
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var objs []runtime.Object
+			for _, node := range tc.nodes {
+				objs = append(objs, node)
+			}
+			for _, pod := range tc.podsOnNodes {
+				objs = append(objs, pod)
+			}
+			objs = append(objs, tc.pod)
+
+			fakeClient := fake.NewSimpleClientset(objs...)
+
+			sharedInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+			podInformer := sharedInformerFactory.Core().V1().Pods()
+
+			getPodsAssignedToNode, err := podutil.BuildGetPodsAssignedToNodeFunc(podInformer)
+			if err != nil {
+				t.Errorf("Build get pods assigned to node function error: %v", err)
+			}
+
+			sharedInformerFactory.Start(ctx.Done())
+			sharedInformerFactory.WaitForCacheSync(ctx.Done())
+
+			actual := PodFitsAnyOtherNode(getPodsAssignedToNode, tc.pod, tc.nodes)
+			if actual != tc.success {
+				t.Errorf("Test %#v failed", tc.description)
+			}
+		})
 	}
 }
 
-func createPodManifest(nodeName string, nodeSelectorKey string, nodeSelectorValue string) *v1.Pod {
-	return (&v1.Pod{
-		Spec: v1.PodSpec{
-			NodeName: nodeName,
-			Affinity: &v1.Affinity{
-				NodeAffinity: &v1.NodeAffinity{
-					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
-						NodeSelectorTerms: []v1.NodeSelectorTerm{
-							{
-								MatchExpressions: []v1.NodeSelectorRequirement{
-									{
-										Key:      nodeSelectorKey,
-										Operator: "In",
-										Values: []string{
-											nodeSelectorValue,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	})
+// createResourceList builds a small resource list of core resources
+func createResourceList(cpu int64, memory int64, ephemeralStorage int64) v1.ResourceList {
+	resourceList := make(map[v1.ResourceName]resource.Quantity)
+	resourceList[v1.ResourceCPU] = *resource.NewMilliQuantity(cpu, resource.DecimalSI)
+	resourceList[v1.ResourceMemory] = *resource.NewQuantity(memory, resource.DecimalSI)
+	resourceList[v1.ResourceEphemeralStorage] = *resource.NewQuantity(ephemeralStorage, resource.DecimalSI)
+	return resourceList
 }

--- a/pkg/descheduler/strategies/failedpods_test.go
+++ b/pkg/descheduler/strategies/failedpods_test.go
@@ -166,13 +166,27 @@ func TestRemoveFailedPods(t *testing.T) {
 		{
 			description: "nodeFit=true, 1 unschedulable node, 1 container terminated with reason NodeAffinity, 0 eviction",
 			strategy:    createStrategy(true, false, nil, nil, nil, true),
-			nodes: []*v1.Node{test.BuildTestNode("node1", 2000, 3000, 10, func(node *v1.Node) {
-				node.Spec.Unschedulable = true
-			})},
+			nodes: []*v1.Node{
+				test.BuildTestNode("node1", 2000, 3000, 10, nil),
+				test.BuildTestNode("node2", 2000, 2000, 10, func(node *v1.Node) {
+					node.Spec.Unschedulable = true
+				}),
+			},
 			expectedEvictedPodCount: 0,
 			pods: []*v1.Pod{
 				buildTestPod("p1", "node1", newPodStatus("", "", nil, &v1.ContainerState{
 					Terminated: &v1.ContainerStateTerminated{Reason: "NodeAffinity"},
+				}), nil),
+			},
+		},
+		{
+			description:             "nodeFit=true, only available node does not have enough resources, 1 container terminated with reason CreateContainerConfigError, 0 eviction",
+			strategy:                createStrategy(true, false, []string{"CreateContainerConfigError"}, nil, nil, true),
+			nodes:                   []*v1.Node{test.BuildTestNode("node1", 1, 1, 10, nil), test.BuildTestNode("node2", 0, 0, 10, nil)},
+			expectedEvictedPodCount: 0,
+			pods: []*v1.Pod{
+				buildTestPod("p1", "node1", newPodStatus("", "", nil, &v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{Reason: "CreateContainerConfigError"},
 				}), nil),
 			},
 		},
@@ -261,6 +275,7 @@ func TestRemoveFailedPods(t *testing.T) {
 				nil,
 				nil,
 				tc.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,

--- a/pkg/descheduler/strategies/node_affinity.go
+++ b/pkg/descheduler/strategies/node_affinity.go
@@ -95,8 +95,8 @@ func RemovePodsViolatingNodeAffinity(ctx context.Context, client clientset.Inter
 					getPodsAssignedToNode,
 					podutil.WrapFilterFuncs(podFilter, func(pod *v1.Pod) bool {
 						return evictable.IsEvictable(pod) &&
-							!nodeutil.PodFitsCurrentNode(pod, node) &&
-							nodeutil.PodFitsAnyNode(pod, nodes)
+							!nodeutil.PodFitsCurrentNode(getPodsAssignedToNode, pod, node) &&
+							nodeutil.PodFitsAnyNode(getPodsAssignedToNode, pod, nodes)
 					}),
 				)
 				if err != nil {

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -222,6 +222,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -62,6 +62,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			Unschedulable: true,
 		}
 	})
+	node5 := test.BuildTestNode("n5", 1, 1, 1, nil)
 
 	p1 := test.BuildTestPod("p1", 100, 0, node1.Name, nil)
 	p2 := test.BuildTestPod("p2", 100, 0, node1.Name, nil)
@@ -224,6 +225,15 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			expectedEvictedPodCount: 0, //p2 gets evicted
 			nodeFit:                 true,
 		},
+		{
+			description:             "Critical and non critical pods, pods not tolerating node taint can't be evicted because the only available node does not have enough resources.",
+			pods:                    []*v1.Pod{p2, p7, p9, p10},
+			nodes:                   []*v1.Node{node1, node5},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: true,
+			expectedEvictedPodCount: 0, //p2 and p7 can't be evicted
+			nodeFit:                 true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -259,6 +269,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
+				getPodsAssignedToNode,
 				tc.evictLocalStoragePods,
 				tc.evictSystemCriticalPods,
 				false,

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
@@ -82,7 +82,7 @@ func HighNodeUtilization(ctx context.Context, client clientset.Interface, strate
 		"Pods", thresholds[v1.ResourcePods],
 	}
 	for name := range thresholds {
-		if !isBasicResource(name) {
+		if !nodeutil.IsBasicResource(name) {
 			keysAndValues = append(keysAndValues, string(name), int64(thresholds[name]))
 		}
 	}
@@ -159,7 +159,7 @@ func setDefaultForThresholds(thresholds, targetThresholds api.ResourceThresholds
 	targetThresholds[v1.ResourceMemory] = MaxResourcePercentage
 
 	for name := range thresholds {
-		if !isBasicResource(name) {
+		if !nodeutil.IsBasicResource(name) {
 			targetThresholds[name] = MaxResourcePercentage
 		}
 	}

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
@@ -385,6 +385,50 @@ func TestHighNodeUtilization(t *testing.T) {
 			},
 			expectedPodsEvicted: 0,
 		},
+		{
+			name: "Other node does not have enough Memory",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  30,
+				v1.ResourcePods: 30,
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode(n1NodeName, 4000, 200, 9, nil),
+				test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+			},
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 400, 50, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p2", 400, 50, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p3", 400, 50, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p4", 400, 50, n1NodeName, test.SetDSOwnerRef),
+				test.BuildTestPod("p5", 400, 100, n2NodeName, func(pod *v1.Pod) {
+					// A pod requesting more memory than is available on node1
+					test.SetRSOwnerRef(pod)
+				}),
+			},
+			expectedPodsEvicted: 0,
+		},
+		{
+			name: "Other node does not have enough Memory",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  30,
+				v1.ResourcePods: 30,
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode(n1NodeName, 4000, 200, 9, nil),
+				test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+			},
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 400, 50, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p2", 400, 50, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p3", 400, 50, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p4", 400, 50, n1NodeName, test.SetDSOwnerRef),
+				test.BuildTestPod("p5", 400, 100, n2NodeName, func(pod *v1.Pod) {
+					// A pod requesting more memory than is available on node1
+					test.SetRSOwnerRef(pod)
+				}),
+			},
+			expectedPodsEvicted: 0,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -463,6 +507,7 @@ func TestHighNodeUtilization(t *testing.T) {
 				nil,
 				nil,
 				testCase.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,
@@ -667,6 +712,7 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 				&item.evictionsExpected,
 				nil,
 				item.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization.go
@@ -94,7 +94,7 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		"Pods", thresholds[v1.ResourcePods],
 	}
 	for name := range thresholds {
-		if !isBasicResource(name) {
+		if !nodeutil.IsBasicResource(name) {
 			keysAndValues = append(keysAndValues, string(name), int64(thresholds[name]))
 		}
 	}
@@ -108,7 +108,7 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		"Pods", targetThresholds[v1.ResourcePods],
 	}
 	for name := range targetThresholds {
-		if !isBasicResource(name) {
+		if !nodeutil.IsBasicResource(name) {
 			keysAndValues = append(keysAndValues, string(name), int64(targetThresholds[name]))
 		}
 	}

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
@@ -643,6 +643,112 @@ func TestLowNodeUtilization(t *testing.T) {
 			},
 			expectedPodsEvicted: 3,
 		},
+		{
+			name: "without priorities, but only other node doesn't match pod node affinity for p4 and p5",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  30,
+				v1.ResourcePods: 30,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  50,
+				v1.ResourcePods: 50,
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode(n1NodeName, 500, 200, 9, nil),
+				test.BuildTestNode(n2NodeName, 200, 200, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeSelectorKey: notMatchingNodeSelectorValue,
+					}
+				}),
+			},
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 10, 0, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p2", 10, 0, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p3", 10, 0, n1NodeName, test.SetRSOwnerRef),
+				// These won't be evicted.
+				test.BuildTestPod("p4", 400, 100, n1NodeName, func(pod *v1.Pod) {
+					// A pod that requests too much CPU
+					test.SetNormalOwnerRef(pod)
+				}),
+				test.BuildTestPod("p5", 400, 0, n1NodeName, func(pod *v1.Pod) {
+					// A pod with local storage.
+					test.SetNormalOwnerRef(pod)
+					pod.Spec.Volumes = []v1.Volume{
+						{
+							Name: "sample",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+							},
+						},
+					}
+					// A Mirror Pod.
+					pod.Annotations = test.GetMirrorPodAnnotation()
+				}),
+				test.BuildTestPod("p6", 400, 0, n1NodeName, func(pod *v1.Pod) {
+					// A Critical Pod.
+					pod.Namespace = "kube-system"
+					priority := utils.SystemCriticalPriority
+					pod.Spec.Priority = &priority
+				}),
+				test.BuildTestPod("p9", 0, 0, n2NodeName, test.SetRSOwnerRef),
+			},
+			expectedPodsEvicted: 3,
+		},
+		{
+			name: "without priorities, but only other node doesn't match pod node affinity for p4 and p5",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  30,
+				v1.ResourcePods: 30,
+			},
+			targetThresholds: api.ResourceThresholds{
+				v1.ResourceCPU:  50,
+				v1.ResourcePods: 50,
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode(n1NodeName, 500, 200, 9, nil),
+				test.BuildTestNode(n2NodeName, 200, 200, 10, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						nodeSelectorKey: notMatchingNodeSelectorValue,
+					}
+				}),
+			},
+			pods: []*v1.Pod{
+				test.BuildTestPod("p1", 10, 0, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p2", 10, 0, n1NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p3", 10, 0, n1NodeName, test.SetRSOwnerRef),
+				// These won't be evicted.
+				test.BuildTestPod("p4", 400, 100, n1NodeName, func(pod *v1.Pod) {
+					// A pod that requests too much CPU
+					test.SetNormalOwnerRef(pod)
+				}),
+				test.BuildTestPod("p5", 400, 0, n1NodeName, func(pod *v1.Pod) {
+					// A pod with local storage.
+					test.SetNormalOwnerRef(pod)
+					pod.Spec.Volumes = []v1.Volume{
+						{
+							Name: "sample",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{Path: "somePath"},
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewQuantity(int64(10), resource.BinarySI)},
+							},
+						},
+					}
+					// A Mirror Pod.
+					pod.Annotations = test.GetMirrorPodAnnotation()
+				}),
+				test.BuildTestPod("p6", 400, 0, n1NodeName, func(pod *v1.Pod) {
+					// A Critical Pod.
+					pod.Namespace = "kube-system"
+					priority := utils.SystemCriticalPriority
+					pod.Spec.Priority = &priority
+				}),
+				test.BuildTestPod("p9", 0, 0, n2NodeName, test.SetRSOwnerRef),
+			},
+			expectedPodsEvicted: 3,
+		},
 	}
 
 	for _, test := range testCases {
@@ -720,6 +826,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				nil,
 				nil,
 				test.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,
@@ -1032,6 +1139,7 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				&item.evictionsExpected,
 				nil,
 				item.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,

--- a/pkg/descheduler/strategies/nodeutilization/nodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/nodeutilization_test.go
@@ -18,11 +18,12 @@ package nodeutilization
 
 import (
 	"fmt"
+	"math"
+	"testing"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"math"
 	"sigs.k8s.io/descheduler/pkg/api"
-	"testing"
 )
 
 var (

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -47,6 +47,7 @@ func TestPodAntiAffinity(t *testing.T) {
 			Unschedulable: true,
 		}
 	})
+	node4 := test.BuildTestNode("n4", 2, 2, 1, nil)
 
 	p1 := test.BuildTestPod("p1", 100, 0, node1.Name, nil)
 	p2 := test.BuildTestPod("p2", 100, 0, node1.Name, nil)
@@ -174,6 +175,14 @@ func TestPodAntiAffinity(t *testing.T) {
 			nodes:                   []*v1.Node{node1},
 			expectedEvictedPodCount: 0,
 		},
+		{
+			description:             "Won't evict pods because only other node doesn't have enough resources",
+			maxPodsToEvictPerNode:   &uint3,
+			pods:                    []*v1.Pod{p1, p2, p3, p4},
+			nodes:                   []*v1.Node{node1, node4},
+			expectedEvictedPodCount: 0,
+			nodeFit:                 true,
+		},
 	}
 
 	for _, test := range tests {
@@ -209,6 +218,7 @@ func TestPodAntiAffinity(t *testing.T) {
 				test.maxPodsToEvictPerNode,
 				test.maxNoOfPodsToEvictPerNamespace,
 				test.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -298,6 +298,7 @@ func TestPodLifeTime(t *testing.T) {
 				nil,
 				nil,
 				tc.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				tc.ignorePvcPods,

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -484,6 +484,38 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			namespaces: []string{"ns1"},
 		},
 		{
+			name: "2 domains size [2 6], maxSkew=2, can't move any because node1 does not have enough CPU",
+			nodes: []*v1.Node{
+				test.BuildTestNode("n1", 200, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("n2", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       1,
+					node:        "n1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(2),
+				},
+				{
+					count:  1,
+					node:   "n1",
+					labels: map[string]string{"foo": "bar"},
+				},
+				{
+					count:  6,
+					node:   "n2",
+					labels: map[string]string{"foo": "bar"},
+				},
+			}),
+			expectedEvictedCount: 0,
+			strategy: api.DeschedulerStrategy{
+				Params: &api.StrategyParameters{
+					NodeFit: true,
+				},
+			},
+			namespaces: []string{"ns1"},
+		},
+		{
 			// see https://github.com/kubernetes-sigs/descheduler/issues/564
 			name: "Multiple constraints (6 nodes/2 zones, 4 pods)",
 			nodes: []*v1.Node{
@@ -686,7 +718,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			namespaces:           []string{"ns1"},
 		},
 		{
-			name: "2 domains, sizes [2,0], maxSkew=1, move 0 pods since pod does not tolerate the tainted node",
+			name: "2 domains, sizes [2,0], maxSkew=1, move 1 pods since pod does not tolerate the tainted node",
 			nodes: []*v1.Node{
 				test.BuildTestNode("n1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
 				test.BuildTestNode("n2", 2000, 3000, 10, func(n *v1.Node) {
@@ -717,6 +749,43 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			expectedEvictedCount: 0,
 			strategy:             api.DeschedulerStrategy{},
 			namespaces:           []string{"ns1"},
+		},
+		{
+			name: "2 domains, sizes [2,0], maxSkew=1, move 0 pods since pod does not tolerate the tainted node, and NodeFit is enabled",
+			nodes: []*v1.Node{
+				test.BuildTestNode("n1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("n2", 2000, 3000, 10, func(n *v1.Node) {
+					n.Labels["zone"] = "zoneB"
+					n.Spec.Taints = []v1.Taint{
+						{
+							Key:    "taint-test",
+							Value:  "test",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					}
+				}),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       1,
+					node:        "n1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{
+					count:        1,
+					node:         "n1",
+					labels:       map[string]string{"foo": "bar"},
+					nodeSelector: map[string]string{"zone": "zoneA"},
+				},
+			}),
+			expectedEvictedCount: 0,
+			strategy: api.DeschedulerStrategy{
+				Params: &api.StrategyParameters{
+					NodeFit: true,
+				},
+			},
+			namespaces: []string{"ns1"},
 		},
 		{
 			name: "2 domains, sizes [2,0], maxSkew=1, move 1 pod for node with PreferNoSchedule Taint",
@@ -902,6 +971,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				nil,
 				nil,
 				tc.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,

--- a/pkg/utils/pod.go
+++ b/pkg/utils/pod.go
@@ -6,23 +6,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
-)
-
-const (
-	// owner: @jinxu
-	// beta: v1.10
-	//
-	// New local storage types to support local storage capacity isolation
-	LocalStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIsolation"
-
-	// owner: @egernst
-	// alpha: v1.16
-	//
-	// Enables PodOverhead, for accounting pod overheads which are specific to a given RuntimeClass
-	PodOverhead featuregate.Feature = "PodOverhead"
 )
 
 // GetResourceRequest finds and returns the request value for a specific resource.
@@ -53,11 +37,6 @@ func GetResourceRequestQuantity(pod *v1.Pod, resourceName v1.ResourceName) resou
 		requestQuantity = resource.Quantity{Format: resource.DecimalSI}
 	}
 
-	if resourceName == v1.ResourceEphemeralStorage && !utilfeature.DefaultFeatureGate.Enabled(LocalStorageCapacityIsolation) {
-		// if the local storage capacity isolation feature gate is disabled, pods request 0 disk
-		return requestQuantity
-	}
-
 	for _, container := range pod.Spec.Containers {
 		if rQuantity, ok := container.Resources.Requests[resourceName]; ok {
 			requestQuantity.Add(rQuantity)
@@ -72,9 +51,9 @@ func GetResourceRequestQuantity(pod *v1.Pod, resourceName v1.ResourceName) resou
 		}
 	}
 
-	// if PodOverhead feature is supported, add overhead for running a pod
-	// to the total requests if the resource total is non-zero
-	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(PodOverhead) {
+	// We assume pod overhead feature gate is enabled.
+	// We can't import the scheduler settings so we will inherit the default.
+	if pod.Spec.Overhead != nil {
 		if podOverhead, ok := pod.Spec.Overhead[resourceName]; ok && !requestQuantity.IsZero() {
 			requestQuantity.Add(podOverhead)
 		}
@@ -162,9 +141,9 @@ func PodRequestsAndLimits(pod *v1.Pod) (reqs, limits v1.ResourceList) {
 		maxResourceList(limits, container.Resources.Limits)
 	}
 
-	// if PodOverhead feature is supported, add overhead for running a pod
-	// to the sum of reqeuests and to non-zero limits:
-	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(PodOverhead) {
+	// We assume pod overhead feature gate is enabled.
+	// We can't import the scheduler settings so we will inherit the default.
+	if pod.Spec.Overhead != nil {
 		addResourceList(reqs, pod.Spec.Overhead)
 
 		for name, quantity := range pod.Spec.Overhead {

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -147,6 +147,7 @@ func TestRemoveDuplicates(t *testing.T) {
 				nil,
 				nil,
 				nodes,
+				getPodsAssignedToNode,
 				true,
 				false,
 				false,

--- a/test/e2e/e2e_failedpods_test.go
+++ b/test/e2e/e2e_failedpods_test.go
@@ -83,7 +83,7 @@ func TestFailedPods(t *testing.T) {
 			defer jobClient.Delete(ctx, job.Name, metav1.DeleteOptions{PropagationPolicy: &deletePropagationPolicy})
 			waitForJobPodPhase(ctx, t, clientSet, job, v1.PodFailed)
 
-			podEvictor := initPodEvictorOrFail(t, clientSet, nodes)
+			podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode, nodes)
 
 			t.Logf("Running RemoveFailedPods strategy for %s", name)
 			strategies.RemoveFailedPods(

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -137,6 +137,7 @@ func TestTooManyRestarts(t *testing.T) {
 				nil,
 				nil,
 				nodes,
+				getPodsAssignedToNode,
 				true,
 				false,
 				false,

--- a/test/e2e/e2e_topologyspreadconstraint_test.go
+++ b/test/e2e/e2e_topologyspreadconstraint_test.go
@@ -77,7 +77,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			defer deleteRC(ctx, t, clientSet, violatorRc)
 			waitForRCPodsRunning(ctx, t, clientSet, violatorRc)
 
-			podEvictor := initPodEvictorOrFail(t, clientSet, nodes)
+			podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode, nodes)
 
 			// Run TopologySpreadConstraint strategy
 			t.Logf("Running RemovePodsViolatingTopologySpreadConstraint strategy for %s", name)


### PR DESCRIPTION
Fixes #604
Fixes #529
Fixes #574
Fixes #579

## Main Features 
- Requests are now calculated and used to determine if a pod can be evicted when `NodeFit` == `True`
- All strategies consider the exact same predicates when determining if a pod can be evicted

## Description
This PR adds checks for resource requests when the [NodeFit](https://github.com/kubernetes-sigs/descheduler#node-fit-filtering) pod filtering flag is enabled. The `NodeFit` flag instructs the Descheduler to determine if there is a node in the cluster the pod might fit on before evicting the pod. In the past this check did not consider the CPU, memory, storage, and other `requests` on these nodes. It now considers any and all `requests` made by the pod and the nodes, including custom resources.

Originally I only intended to add checks for resource `requests` to the `TopologySpread` strategy. As I did this, I ended up modifying global functions in `pkg/descheduler/node/node.go` which control eviction filtering logic. This has the side effect of aligning all strategies that can enable the `NodeFit` flag with my original feature. So even though I didn't intend to fix #574 and #529, they were automatically implemented by fixing #604.

I would have broken these out into two PRs (as suggested by @damemi), but once I finished #604 I realized all that was needed for #529 and #574 were a few extra test cases.

I'd love some feedback on my implementation, especially regarding the changes I've made to the `TopologySpread` strategy.
