### PR TITLE
README: Clarify podRestartThreshold applying to the sum over containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,9 +456,9 @@ strategies:
 
 This strategy makes sure that pods having too many restarts are removed from nodes. For example a pod with EBS/PD that
 can't get the volume/disk attached to the instance, then the pod should be re-scheduled to other nodes. Its parameters
-include `podRestartThreshold`, which is the number of restarts at which a pod should be evicted, and `includingInitContainers`,
-which determines whether init container restarts should be factored into that calculation.
-|`labelSelector`|(see [label filtering](#label-filtering))|
+include `podRestartThreshold`, which is the number of restarts (summed over all eligible containers) at which a pod
+should be evicted, and `includingInitContainers`, which determines whether init container restarts should be factored
+into that calculation.
 
 **Parameters:**
 
@@ -469,6 +469,7 @@ which determines whether init container restarts should be factored into that ca
 |`thresholdPriority`|int (see [priority filtering](#priority-filtering))|
 |`thresholdPriorityClassName`|string (see [priority filtering](#priority-filtering))|
 |`namespaces`|(see [namespace filtering](#namespace-filtering))|
+|`labelSelector`|(see [label filtering](#label-filtering))|
 |`nodeFit`|bool (see [node fit filtering](#node-fit-filtering))|
 
 **Example:**


### PR DESCRIPTION
`calcContainerRestarts` [sums over containers][1].  The new language makes that clear, avoiding potential confusion vs. an altenative that looked for pods where a single container had passed the configured threshold. For example, with three containers with 50 restarts and a threshold of 100, the actual "sum over containers" logic makes that pod a candidate for descheduling, but the "largest single container restart count" hypothetical would not have made it a candidate.

Also shifts `labelSelector` into the parameter table, because when it was added in 29ade13ce7 (#510), it landed a few lines too high.

[1]: https://github.com/kubernetes-sigs/descheduler/blob/bfd5feaf60a202cecafcf2d30cf171a138c04885/pkg/descheduler/strategies/toomanyrestarts.go#L110-L122