### PR TITLE
Allow to evict Failed pods with no OwnerRef

### DIFF
--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -278,7 +278,7 @@ func (ev *evictable) IsEvictable(pod *v1.Pod) bool {
 		checkErrs = append(checkErrs, fmt.Errorf("pod is a DaemonSet pod"))
 	}
 
-	if len(ownerRefList) == 0 {
+	if len(ownerRefList) == 0 && pod.Status.Phase != v1.PodFailed {
 		checkErrs = append(checkErrs, fmt.Errorf("pod does not have any ownerrefs"))
 	}
 


### PR DESCRIPTION
The suggested change allows descheduler to evict Failed pods with no OwnerRef. The PR was opened in support of the feature request: https://github.com/kubernetes-sigs/descheduler/issues/644