### PR TITLE
Rewrite the LowNodeUtilization documentation section

### DIFF
--- a/examples/low-node-utilization.yml
+++ b/examples/low-node-utilization.yml
@@ -6,6 +6,6 @@ strategies:
     params:
       nodeResourceUtilizationThresholds:
         thresholds:
-          "memory": 20
+          "memory": 50
         targetThresholds:
           "memory": 70


### PR DESCRIPTION
I had serious difficulty figuring out whether I needed HighNodeUtilization or LowNodeUtilization. The names were exactly opposite from what I expected of them. On top of that, I found the documentation about them pretty hard to read.

I rewrote the LowNodeUtilization section with more focus on the descheduling off overutilized nodes. I hope that'll make it clearer for others in the future.

I also bumped the underutilization threshold in the example. I think we want to make clearer to people that they should probably set their underutilized percentages pretty high, because otherwise descheduler won't deschedule pods if they don't have underutilized nodes.