### PR TITLE
Add support for descheduler.alpha.kubernetes.io/noevict annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,8 @@ never evicted because these pods won't be recreated.
 best effort pods are evicted before burstable and guaranteed pods.
 * All types of pods with the annotation `descheduler.alpha.kubernetes.io/evict` are eligible for eviction. This
   annotation is used to override checks which prevent eviction and users can select which pod is evicted.
+* All types of pods with the annotation `descheduler.alpha.kubernetes.io/noevict` are NOT eligible for eviction. This
+  annotation is used to override pods that would otherwise be evicted
   Users should know how and if the pod will be recreated.
 
 Setting `--v=4` or greater on the Descheduler will log all reasons why any pod is not evictable.

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -44,6 +44,10 @@ const (
 	evictPodAnnotationKey = "descheduler.alpha.kubernetes.io/evict"
 )
 
+const (
+	noEvictPodAnnotationKey = "descheduler.alpha.kubernetes.io/noevict"
+)
+
 // nodePodEvictedCount keeps count of pods evicted on node
 type nodePodEvictedCount map[*v1.Node]int
 
@@ -290,6 +294,10 @@ func (ev *evictable) IsEvictable(pod *v1.Pod) bool {
 		checkErrs = append(checkErrs, fmt.Errorf("pod is a static pod"))
 	}
 
+	if HaveDoNotEvictAnnotation(pod) {
+		checkErrs = append(checkErrs, fmt.Errorf("pod is excluded by annotation"))
+	}
+
 	for _, c := range ev.constraints {
 		if err := c(pod); err != nil {
 			checkErrs = append(checkErrs, err)
@@ -307,6 +315,12 @@ func (ev *evictable) IsEvictable(pod *v1.Pod) bool {
 // HaveEvictAnnotation checks if the pod have evict annotation
 func HaveEvictAnnotation(pod *v1.Pod) bool {
 	_, found := pod.ObjectMeta.Annotations[evictPodAnnotationKey]
+	return found
+}
+
+// HaveDoNotEvictAnnotation checks if the pod have evict annotation
+func HaveDoNotEvictAnnotation(pod *v1.Pod) bool {
+	_, found := pod.ObjectMeta.Annotations[noEvictPodAnnotationKey]
 	return found
 }
 

--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -142,6 +142,15 @@ func TestIsEvictable(t *testing.T) {
 			evictLocalStoragePods:   false,
 			evictSystemCriticalPods: false,
 			result:                  true,
+		}, { // Normal pod eviction with normal ownerRefs and descheduler.alpha.kubernetes.io/noevict annotation
+			pod: test.BuildTestPod("p20", 400, 0, n1.Name, nil),
+			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {
+				pod.Annotations = map[string]string{"descheduler.alpha.kubernetes.io/noevict": "true"}
+				pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
+			},
+			evictLocalStoragePods:   false,
+			evictSystemCriticalPods: false,
+			result:                  false,
 		}, { // Pod not evicted because it is bound to a PV and evictLocalStoragePods = false
 			pod: test.BuildTestPod("p5", 400, 0, n1.Name, nil),
 			runBefore: func(pod *v1.Pod, nodes []*v1.Node) {


### PR DESCRIPTION
Add support for a descheduler.alpha.kubernetes.io/noevict annotation which will make a pod ineligible for eviction even if passes all other tests.

The use case is that I want to, in general, allow eviction of pods with local storage. However, for a few specific deployments (e.g. caches) I want to not evict them.

I know that I can configure the descheduler to not evict pods with local storage and then annotate all of the non-cache deployments with the descheduler.alpha.kubernetes.io/evict annotation. However, there are many more of those and this PR looks simple enough