### PR TITLE
Adding 'affinity' support to run 'descheduler' in CronJob or Deployment

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -40,6 +40,10 @@ spec:
           nodeSelector:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -71,6 +71,17 @@ priorityClassName: system-cluster-critical
 nodeSelector: {}
 #  foo: bar
 
+affinity: {}
+# nodeAffinity:
+#   requiredDuringSchedulingIgnoredDuringExecution:
+#     nodeSelectorTerms:
+#     - matchExpressions:
+#       - key: kubernetes.io/e2e-az-name
+#         operator: In
+#         values:
+#         - e2e-az1
+#         - e2e-az2
+
 tolerations: []
 # - key: 'management'
 #   operator: 'Equal'


### PR DESCRIPTION
I want to add 'affinity' support in order to fine tune where 'descheduler' should run.

My current use case: I want to prefer "spot" instances over "ondemand" instances