### PR TITLE
RemoveFailedPods: match casing of field LifeTime to other strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ strategies:
 This strategy evicts pods that are in failed status phase.
 You can provide an optional parameter to filter by failed `reasons`.
 `reasons` can be expanded to include reasons of InitContainers as well by setting the optional parameter `includingInitContainers` to `true`.
-You can specify an optional parameter `minPodLifetimeSeconds` to evict pods that are older than specified seconds.
+You can specify an optional parameter `minPodLifeTimeSeconds` to evict pods that are older than specified seconds.
 Lastly, you can specify the optional parameter `excludeOwnerKinds` and if a pod
 has any of these `Kind`s listed as an `OwnerRef`, that pod will not be considered for eviction.
 
@@ -532,7 +532,7 @@ has any of these `Kind`s listed as an `OwnerRef`, that pod will not be considere
 
 |Name|Type|
 |---|---|
-|`minPodLifetimeSeconds`|uint|
+|`minPodLifeTimeSeconds`|uint|
 |`excludeOwnerKinds`|list(string)|
 |`reasons`|list(string)|
 |`includingInitContainers`|bool|
@@ -557,7 +557,7 @@ strategies:
          includingInitContainers: true
          excludeOwnerKinds:
          - "Job"
-         minPodLifetimeSeconds: 3600
+         minPodLifeTimeSeconds: 3600
 ```
 
 ## Filter Pods

--- a/examples/failed-pods.yaml
+++ b/examples/failed-pods.yaml
@@ -11,4 +11,4 @@ strategies:
         includingInitContainers: true
         excludeOwnerKinds:
         - "Job"
-        minPodLifetimeSeconds: 3600 # 1 hour
+        minPodLifeTimeSeconds: 3600 # 1 hour

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -112,7 +112,7 @@ type PodLifeTime struct {
 
 type FailedPods struct {
 	ExcludeOwnerKinds       []string
-	MinPodLifetimeSeconds   *uint
+	MinPodLifeTimeSeconds   *uint
 	Reasons                 []string
 	IncludingInitContainers bool
 }

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -110,7 +110,7 @@ type PodLifeTime struct {
 
 type FailedPods struct {
 	ExcludeOwnerKinds       []string `json:"excludeOwnerKinds,omitempty"`
-	MinPodLifetimeSeconds   *uint    `json:"minPodLifetimeSeconds,omitempty"`
+	MinPodLifeTimeSeconds   *uint    `json:"minPodLifeTimeSeconds,omitempty"`
 	Reasons                 []string `json:"reasons,omitempty"`
 	IncludingInitContainers bool     `json:"includingInitContainers,omitempty"`
 }

--- a/pkg/api/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/v1alpha1/zz_generated.conversion.go
@@ -212,7 +212,7 @@ func Convert_api_DeschedulerStrategy_To_v1alpha1_DeschedulerStrategy(in *api.Des
 
 func autoConvert_v1alpha1_FailedPods_To_api_FailedPods(in *FailedPods, out *api.FailedPods, s conversion.Scope) error {
 	out.ExcludeOwnerKinds = *(*[]string)(unsafe.Pointer(&in.ExcludeOwnerKinds))
-	out.MinPodLifetimeSeconds = (*uint)(unsafe.Pointer(in.MinPodLifetimeSeconds))
+	out.MinPodLifeTimeSeconds = (*uint)(unsafe.Pointer(in.MinPodLifeTimeSeconds))
 	out.Reasons = *(*[]string)(unsafe.Pointer(&in.Reasons))
 	out.IncludingInitContainers = in.IncludingInitContainers
 	return nil
@@ -225,7 +225,7 @@ func Convert_v1alpha1_FailedPods_To_api_FailedPods(in *FailedPods, out *api.Fail
 
 func autoConvert_api_FailedPods_To_v1alpha1_FailedPods(in *api.FailedPods, out *FailedPods, s conversion.Scope) error {
 	out.ExcludeOwnerKinds = *(*[]string)(unsafe.Pointer(&in.ExcludeOwnerKinds))
-	out.MinPodLifetimeSeconds = (*uint)(unsafe.Pointer(in.MinPodLifetimeSeconds))
+	out.MinPodLifeTimeSeconds = (*uint)(unsafe.Pointer(in.MinPodLifeTimeSeconds))
 	out.Reasons = *(*[]string)(unsafe.Pointer(&in.Reasons))
 	out.IncludingInitContainers = in.IncludingInitContainers
 	return nil

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -117,8 +117,8 @@ func (in *FailedPods) DeepCopyInto(out *FailedPods) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.MinPodLifetimeSeconds != nil {
-		in, out := &in.MinPodLifetimeSeconds, &out.MinPodLifetimeSeconds
+	if in.MinPodLifeTimeSeconds != nil {
+		in, out := &in.MinPodLifeTimeSeconds, &out.MinPodLifeTimeSeconds
 		*out = new(uint)
 		**out = **in
 	}

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -117,8 +117,8 @@ func (in *FailedPods) DeepCopyInto(out *FailedPods) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.MinPodLifetimeSeconds != nil {
-		in, out := &in.MinPodLifetimeSeconds, &out.MinPodLifetimeSeconds
+	if in.MinPodLifeTimeSeconds != nil {
+		in, out := &in.MinPodLifeTimeSeconds, &out.MinPodLifeTimeSeconds
 		*out = new(uint)
 		**out = **in
 	}

--- a/pkg/descheduler/strategies/failedpods.go
+++ b/pkg/descheduler/strategies/failedpods.go
@@ -3,6 +3,7 @@ package strategies
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1 "k8s.io/api/core/v1"
@@ -23,7 +24,7 @@ type validatedFailedPodsStrategyParams struct {
 	includingInitContainers bool
 	reasons                 sets.String
 	excludeOwnerKinds       sets.String
-	minPodLifetimeSeconds   *uint
+	minPodLifeTimeSeconds   *uint
 }
 
 // RemoveFailedPods removes Pods that are in failed status phase.
@@ -102,12 +103,12 @@ func validateAndParseRemoveFailedPodsParams(
 
 	var reasons, excludeOwnerKinds sets.String
 	var includingInitContainers bool
-	var minPodLifetimeSeconds *uint
+	var minPodLifeTimeSeconds *uint
 	if params.FailedPods != nil {
 		reasons = sets.NewString(params.FailedPods.Reasons...)
 		includingInitContainers = params.FailedPods.IncludingInitContainers
 		excludeOwnerKinds = sets.NewString(params.FailedPods.ExcludeOwnerKinds...)
-		minPodLifetimeSeconds = params.FailedPods.MinPodLifetimeSeconds
+		minPodLifeTimeSeconds = params.FailedPods.MinPodLifeTimeSeconds
 	}
 
 	return &validatedFailedPodsStrategyParams{
@@ -115,7 +116,7 @@ func validateAndParseRemoveFailedPodsParams(
 		includingInitContainers: includingInitContainers,
 		reasons:                 reasons,
 		excludeOwnerKinds:       excludeOwnerKinds,
-		minPodLifetimeSeconds:   minPodLifetimeSeconds,
+		minPodLifeTimeSeconds:   minPodLifeTimeSeconds,
 	}, nil
 }
 
@@ -124,10 +125,10 @@ func validateAndParseRemoveFailedPodsParams(
 func validateFailedPodShouldEvict(pod *v1.Pod, strategyParams validatedFailedPodsStrategyParams) error {
 	var errs []error
 
-	if strategyParams.minPodLifetimeSeconds != nil {
+	if strategyParams.minPodLifeTimeSeconds != nil {
 		podAgeSeconds := uint(metav1.Now().Sub(pod.GetCreationTimestamp().Local()).Seconds())
-		if podAgeSeconds < *strategyParams.minPodLifetimeSeconds {
-			errs = append(errs, fmt.Errorf("pod does not exceed the min age seconds of %d", *strategyParams.minPodLifetimeSeconds))
+		if podAgeSeconds < *strategyParams.minPodLifeTimeSeconds {
+			errs = append(errs, fmt.Errorf("pod does not exceed the min age seconds of %d", *strategyParams.minPodLifeTimeSeconds))
 		}
 	}
 

--- a/pkg/descheduler/strategies/failedpods_test.go
+++ b/pkg/descheduler/strategies/failedpods_test.go
@@ -31,7 +31,7 @@ func TestRemoveFailedPods(t *testing.T) {
 					Reasons:                 reasons,
 					IncludingInitContainers: includingInitContainers,
 					ExcludeOwnerKinds:       excludeKinds,
-					MinPodLifetimeSeconds:   minAgeSeconds,
+					MinPodLifeTimeSeconds:   minAgeSeconds,
 				},
 				NodeFit: nodeFit,
 			},
@@ -256,7 +256,7 @@ func TestValidRemoveFailedPodsParams(t *testing.T) {
 			ExcludeOwnerKinds: []string{"Job"},
 		}}},
 		{name: "validate excludeOwnerKinds params", params: &api.StrategyParameters{FailedPods: &api.FailedPods{
-			MinPodLifetimeSeconds: &OneHourInSeconds,
+			MinPodLifeTimeSeconds: &OneHourInSeconds,
 		}}},
 	}
 	for _, tc := range testCases {

--- a/test/e2e/e2e_failedpods_test.go
+++ b/test/e2e/e2e_failedpods_test.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/descheduler/strategies"
 )
 
-var oneHourPodLifetimeSeconds uint = 3600
+var oneHourPodLifeTimeSeconds uint = 3600
 
 func TestFailedPods(t *testing.T) {
 	ctx := context.Background()
@@ -61,7 +61,7 @@ func TestFailedPods(t *testing.T) {
 		"test-failed-pods-min-age-unmet": {
 			expectedEvictedCount: 0,
 			strategyParams: &deschedulerapi.StrategyParameters{
-				FailedPods: &deschedulerapi.FailedPods{MinPodLifetimeSeconds: &oneHourPodLifetimeSeconds},
+				FailedPods: &deschedulerapi.FailedPods{MinPodLifeTimeSeconds: &oneHourPodLifeTimeSeconds},
 			},
 		},
 		"test-failed-pods-exclude-job-kind": {


### PR DESCRIPTION
Strategies such as `PodLifeTime` contain field [`MaxPodLifeTimeSeconds`](https://github.com/kubernetes-sigs/descheduler/blob/49ad197dfcc96f5c06c86c192899dd339814a3b4/pkg/api/v1alpha1/types.go#L107) (notice `LifeTime`) while `RemoveFailedPods` contains field [`MinPodLifetimeSeconds `](https://github.com/kubernetes-sigs/descheduler/blob/49ad197dfcc96f5c06c86c192899dd339814a3b4/pkg/api/v1alpha1/types.go#L113) which does not match the exact casing.

Examples and documents are accurate but this PR tries to address the inconsistency between these two strategies. I realize that this is a breaking API change so I am ok with this PR being closed due to low-value / breaking-change.