### PR TITLE
Set the klog output to stdout by default

### DIFF
--- a/cmd/descheduler/descheduler.go
+++ b/cmd/descheduler/descheduler.go
@@ -25,6 +25,7 @@ import (
 )
 
 func init() {
+	klog.SetOutput(os.Stdout)
 	klog.InitFlags(nil)
 }
 


### PR DESCRIPTION
Also, one needs to set --logtostderr=false to properly log into the stdout.

Fixes: https://github.com/kubernetes-sigs/descheduler/issues/676

Testing locally while redirecting the stdout:
```
$ ./_output/bin/descheduler --kubeconfig ~/.kube/config --policy-config-file examples/policy.yaml --v=1 --descheduling-interval 10s --logtostderr=false 2>/dev/null
Flag --logtostderr has been deprecated, will be removed in a future release, see https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components
I1216 11:24:15.663767 2350329 secure_serving.go:200] Serving securely on [::]:10258
I1216 11:24:15.663856 2350329 tlsconfig.go:240] "Starting DynamicServingCertificateController"
I1216 11:24:17.294796 2350329 lownodeutilization.go:101] "Criteria for a node under utilization" CPU=20 Mem=20 Pods=20
I1216 11:24:17.294821 2350329 lownodeutilization.go:102] "Number of underutilized nodes" totalNumber=0
I1216 11:24:17.294832 2350329 lownodeutilization.go:115] "Criteria for a node above target utilization" CPU=50 Mem=50 Pods=50
I1216 11:24:17.294839 2350329 lownodeutilization.go:116] "Number of overutilized nodes" totalNumber=3
I1216 11:24:17.294848 2350329 lownodeutilization.go:119] "No node is underutilized, nothing to do here, you might tune your thresholds further"
I1216 11:24:17.294863 2350329 duplicates.go:110] "Processing node" node="ip-10-0-136-90.ec2.internal"
I1216 11:24:17.295034 2350329 duplicates.go:110] "Processing node" node="ip-10-0-139-62.ec2.internal"
I1216 11:24:17.295143 2350329 duplicates.go:110] "Processing node" node="ip-10-0-150-141.ec2.internal"
I1216 11:24:17.295288 2350329 duplicates.go:110] "Processing node" node="ip-10-0-151-50.ec2.internal"
I1216 11:24:17.295371 2350329 duplicates.go:110] "Processing node" node="ip-10-0-168-63.ec2.internal"
I1216 11:24:17.295446 2350329 duplicates.go:110] "Processing node" node="ip-10-0-174-145.ec2.internal"
I1216 11:24:17.295664 2350329 toomanyrestarts.go:90] "Processing node" node="ip-10-0-136-90.ec2.internal"
I1216 11:24:17.295787 2350329 toomanyrestarts.go:90] "Processing node" node="ip-10-0-139-62.ec2.internal"
I1216 11:24:17.295895 2350329 toomanyrestarts.go:90] "Processing node" node="ip-10-0-150-141.ec2.internal"
I1216 11:24:17.296016 2350329 toomanyrestarts.go:90] "Processing node" node="ip-10-0-151-50.ec2.internal"
I1216 11:24:17.296087 2350329 toomanyrestarts.go:90] "Processing node" node="ip-10-0-168-63.ec2.internal"
I1216 11:24:17.296152 2350329 toomanyrestarts.go:90] "Processing node" node="ip-10-0-174-145.ec2.internal"
I1216 11:24:17.296337 2350329 pod_antiaffinity.go:92] "Processing node" node="ip-10-0-136-90.ec2.internal"
I1216 11:24:17.296610 2350329 pod_antiaffinity.go:92] "Processing node" node="ip-10-0-139-62.ec2.internal"
I1216 11:24:17.296780 2350329 pod_antiaffinity.go:92] "Processing node" node="ip-10-0-150-141.ec2.internal"
I1216 11:24:17.297087 2350329 pod_antiaffinity.go:92] "Processing node" node="ip-10-0-151-50.ec2.internal"
I1216 11:24:17.297272 2350329 pod_antiaffinity.go:92] "Processing node" node="ip-10-0-168-63.ec2.internal"
I1216 11:24:17.297460 2350329 pod_antiaffinity.go:92] "Processing node" node="ip-10-0-174-145.ec2.internal"
...
```