### PR TITLE
NonSlidingUntil for deployment

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -116,7 +116,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		ignorePvcPods = *deschedulerPolicy.IgnorePVCPods
 	}
 
-	wait.Until(func() {
+	wait.NonSlidingUntil(func() {
 		nodes, err := nodeutil.ReadyNodes(ctx, rs.Client, nodeInformer, nodeSelector)
 		if err != nil {
 			klog.V(1).InfoS("Unable to get ready nodes", "err", err)


### PR DESCRIPTION
Use [NonSlidingUntil](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/wait#NonSlidingUntil) over Until in order to account for function duration.  
Trying to make the run times on more of an interval in order to make executions times more predictable. 

Using NonSlidingWindow will make the deployment behave more like the cronjob timing wise.