### PR TITLE
Updates to include annotations to the service account

### DIFF
--- a/charts/descheduler/templates/serviceaccount.yaml
+++ b/charts/descheduler/templates/serviceaccount.yaml
@@ -5,4 +5,7 @@ metadata:
   name: {{ template "descheduler.serviceAccountName" . }}
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end }}
 {{- end -}}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -94,3 +94,5 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # Specifies custom annotations for the serviceAccount
+  annotations: {}


### PR DESCRIPTION
It would be useful to have annotations on the service account as it's required to use things such as WLI in Google Cloud (https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)