### PR TITLE
make livenessprobe consistent across manifests

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -68,6 +68,8 @@ spec:
                 - {{ $value | quote }}
                 {{- end }}
                 {{- end }}
+              livenessProbe:
+                {{- toYaml .Values.livenessProbe | nindent 16 }}
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
               securityContext:

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -48,13 +48,7 @@ spec:
             - containerPort: 10258
               protocol: TCP
           livenessProbe:
-            failureThreshold: 3
-            httpGet:
-              path: /healthz
-              port: 10258
-              scheme: HTTPS
-            initialDelaySeconds: 3
-            periodSeconds: 3
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -94,3 +94,12 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+
+livenessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /healthz
+    port: 10258
+    scheme: HTTPS
+  initialDelaySeconds: 3
+  periodSeconds: 10

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               port: 10258
               scheme: HTTPS
             initialDelaySeconds: 3
-            periodSeconds: 3
+            periodSeconds: 10
           resources:
             requests:
               cpu: 500m

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -36,7 +36,7 @@ spec:
               port: 10258
               scheme: HTTPS
             initialDelaySeconds: 3
-            periodSeconds: 3
+            periodSeconds: 10
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
Addresses 2 inconsistencies from #685 :
+ `livenessProbe.periodSeconds` was not consistent across manifests (`10` in one, `3` in others)
+ `charts/descheduler/templates/cronjob.yaml` was missing livenessProbe but `kubernetes/cronjob/cronjob.yaml` had it

Also:
+ Makes it possible to override via `values.yaml` for Helm

