### PR TITLE
log: inform about strategies

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -65,6 +65,10 @@ func Run(rs *options.DeschedulerServer) error {
 		return fmt.Errorf("deschedulerPolicy is nil")
 	}
 
+	for name, strategy := range deschedulerPolicy.Strategies {
+		klog.V(1).InfoS("Strategy config", "name", name, "enabled", strategy.Enabled)
+	}
+
 	evictionPolicyGroupVersion, err := eutils.SupportEviction(rs.Client)
 	if err != nil || len(evictionPolicyGroupVersion) == 0 {
 		return err
@@ -277,6 +281,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		for name, strategy := range deschedulerPolicy.Strategies {
 			if f, ok := strategyFuncs[name]; ok {
 				if strategy.Enabled {
+					klog.V(1).InfoS("Strategy run", "name", name)
 					f(ctx, rs.Client, strategy, nodes, podEvictor, getPodsAssignedToNode)
 				}
 			} else {


### PR DESCRIPTION
* traverse strategies and print enabled status
* print a log before run the strategy


```
descheduler-7489f74b98-9npjl descheduler I0126 09:28:00.709524       1 descheduler.go:69] "Strategy config" name=RemoveDuplicates enabled=true
...
...
...
descheduler-7489f74b98-9npjl descheduler I0126 09:28:00.827188       1 descheduler.go:284] "Strategy run" name=RemoveDuplicates
```

Signed-off-by: Furkan <furkan.turkal@trendyol.com>