### PR TITLE
Validation fail fast

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -84,7 +84,7 @@ type Strategy interface {
 	Name() api.StrategyName
 	Enabled() bool
 	Validate() error
-	Run(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc)
+	Run(ctx context.Context, nodes []*v1.Node, podEvictor *evictions.PodEvictor, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc)
 }
 
 func cachedClient(
@@ -213,8 +213,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		ignorePvcPods = *deschedulerPolicy.IgnorePVCPods
 	}
 
-	// initialize stratagies
-	strategyList, err := initializeStratagies(rs.Client, deschedulerPolicy.Strategies)
+	strategyList, err := initializeStrategies(rs.Client, deschedulerPolicy.Strategies)
 	if err != nil {
 		return err
 	}
@@ -297,7 +296,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 	return nil
 }
 
-func initializeStratagies(client clientset.Interface, strategyList api.StrategyList) ([]Strategy, error) {
+func initializeStrategies(client clientset.Interface, strategyList api.StrategyList) ([]Strategy, error) {
 	var stats []Strategy
 	removeDuplicatePods, err := strategies.NewRemoveDuplicatesStrategy(client, strategyList)
 	if err != nil {

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -305,7 +305,7 @@ func TestFindDuplicatePods(t *testing.T) {
 			)
 
 			s, _ := NewRemoveDuplicatesStrategy(fakeClient, api.StrategyList{RemoveDuplicates: testCase.strategy})
-			s.Run(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, testCase.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != testCase.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)
@@ -733,7 +733,7 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 			)
 
 			s, _ := NewRemoveDuplicatesStrategy(fakeClient, api.StrategyList{RemoveDuplicates: testCase.strategy})
-			s.Run(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, testCase.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != testCase.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -304,7 +304,8 @@ func TestFindDuplicatePods(t *testing.T) {
 				false,
 			)
 
-			RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewRemoveDuplicatesStrategy(fakeClient, api.StrategyList{RemoveDuplicates: testCase.strategy})
+			s.Run(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != testCase.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)
@@ -731,7 +732,8 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 				false,
 			)
 
-			RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewRemoveDuplicatesStrategy(fakeClient, api.StrategyList{RemoveDuplicates: testCase.strategy})
+			s.Run(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != testCase.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/errors.go
+++ b/pkg/descheduler/strategies/errors.go
@@ -1,0 +1,1 @@
+package strategies

--- a/pkg/descheduler/strategies/errors.go
+++ b/pkg/descheduler/strategies/errors.go
@@ -1,1 +1,0 @@
-package strategies

--- a/pkg/descheduler/strategies/failedpods.go
+++ b/pkg/descheduler/strategies/failedpods.go
@@ -67,13 +67,11 @@ func (s *RemoveFailedPodsStrategy) Validate() error {
 // Run removes Pods that are in failed status phase.
 func (s *RemoveFailedPodsStrategy) Run(
 	ctx context.Context,
-	client clientset.Interface,
-	strategy api.DeschedulerStrategy,
 	nodes []*v1.Node,
 	podEvictor *evictions.PodEvictor,
 	getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc,
 ) {
-	strategyParams, err := validateAndParseRemoveFailedPodsParams(ctx, client, strategy.Params)
+	strategyParams, err := validateAndParseRemoveFailedPodsParams(ctx, s.client, s.strategy.Params)
 	if err != nil {
 		klog.ErrorS(err, "Invalid RemoveFailedPods parameters")
 		return
@@ -86,8 +84,8 @@ func (s *RemoveFailedPodsStrategy) Run(
 	)
 
 	var labelSelector *metav1.LabelSelector
-	if strategy.Params != nil {
-		labelSelector = strategy.Params.LabelSelector
+	if s.strategy.Params != nil {
+		labelSelector = s.strategy.Params.LabelSelector
 	}
 
 	podFilter, err := podutil.NewOptions().

--- a/pkg/descheduler/strategies/failedpods_test.go
+++ b/pkg/descheduler/strategies/failedpods_test.go
@@ -268,7 +268,8 @@ func TestRemoveFailedPods(t *testing.T) {
 				false,
 			)
 
-			RemoveFailedPods(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewRemoveFailedPodsStrategy(fakeClient, api.StrategyList{RemoveFailedPods: tc.strategy})
+			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/failedpods_test.go
+++ b/pkg/descheduler/strategies/failedpods_test.go
@@ -269,7 +269,7 @@ func TestRemoveFailedPods(t *testing.T) {
 			)
 
 			s, _ := NewRemoveFailedPodsStrategy(fakeClient, api.StrategyList{RemoveFailedPods: tc.strategy})
-			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -230,7 +230,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			)
 
 			s, _ := NewRemovePodsViolatingNodeAffinityStrategy(fakeClient, api.StrategyList{RemovePodsViolatingNodeAffinity: tc.strategy})
-			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -229,7 +229,8 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				false,
 			)
 
-			RemovePodsViolatingNodeAffinity(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewRemovePodsViolatingNodeAffinityStrategy(fakeClient, api.StrategyList{RemovePodsViolatingNodeAffinity: tc.strategy})
+			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -83,31 +83,31 @@ func (s *RemovePodsViolatingNodeTaintsStrategy) Validate() error {
 }
 
 // Run evicts pods on the node which violate NoSchedule Taints on nodes
-func (s *RemovePodsViolatingNodeTaintsStrategy) Run(ctx context.Context, client clientset.Interface, strategy api.DeschedulerStrategy, nodes []*v1.Node, podEvictor *evictions.PodEvictor, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc) {
-	if err := validateRemovePodsViolatingNodeTaintsParams(strategy.Params); err != nil {
+func (s *RemovePodsViolatingNodeTaintsStrategy) Run(ctx context.Context, nodes []*v1.Node, podEvictor *evictions.PodEvictor, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc) {
+	if err := validateRemovePodsViolatingNodeTaintsParams(s.strategy.Params); err != nil {
 		klog.ErrorS(err, "Invalid RemovePodsViolatingNodeTaints parameters")
 		return
 	}
 
 	var includedNamespaces, excludedNamespaces sets.String
 	var labelSelector *metav1.LabelSelector
-	if strategy.Params != nil {
-		if strategy.Params.Namespaces != nil {
-			includedNamespaces = sets.NewString(strategy.Params.Namespaces.Include...)
-			excludedNamespaces = sets.NewString(strategy.Params.Namespaces.Exclude...)
+	if s.strategy.Params != nil {
+		if s.strategy.Params.Namespaces != nil {
+			includedNamespaces = sets.NewString(s.strategy.Params.Namespaces.Include...)
+			excludedNamespaces = sets.NewString(s.strategy.Params.Namespaces.Exclude...)
 		}
-		labelSelector = strategy.Params.LabelSelector
+		labelSelector = s.strategy.Params.LabelSelector
 	}
 
-	thresholdPriority, err := utils.GetPriorityFromStrategyParams(ctx, client, strategy.Params)
+	thresholdPriority, err := utils.GetPriorityFromStrategyParams(ctx, s.client, s.strategy.Params)
 	if err != nil {
 		klog.ErrorS(err, "Failed to get threshold priority from strategy's params")
 		return
 	}
 
 	nodeFit := false
-	if strategy.Params != nil {
-		nodeFit = strategy.Params.NodeFit
+	if s.strategy.Params != nil {
+		nodeFit = s.strategy.Params.NodeFit
 	}
 
 	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -273,7 +273,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			}
 
 			s, _ := NewRemovePodsViolatingNodeTaintsStrategy(fakeClient, api.StrategyList{RemovePodsViolatingNodeTaints: strategy})
-			s.Run(ctx, fakeClient, strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, Unexpected no of pods evicted: pods evicted: %d, expected: %d", tc.description, actualEvictedPodCount, tc.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -272,7 +272,8 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				},
 			}
 
-			RemovePodsViolatingNodeTaints(ctx, fakeClient, strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewRemovePodsViolatingNodeTaintsStrategy(fakeClient, api.StrategyList{RemovePodsViolatingNodeTaints: strategy})
+			s.Run(ctx, fakeClient, strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, Unexpected no of pods evicted: pods evicted: %d, expected: %d", tc.description, actualEvictedPodCount, tc.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
@@ -479,8 +479,9 @@ func TestHighNodeUtilization(t *testing.T) {
 					NodeFit: true,
 				},
 			}
-			HighNodeUtilization(ctx, fakeClient, strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
 
+			s, _ := NewHighNodeUtilizationStrategy(fakeClient, api.StrategyList{HighNodeUtilization: strategy})
+			s.Run(ctx, fakeClient, strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if testCase.expectedPodsEvicted != podsEvicted {
 				t.Errorf("Expected %v pods to be evicted but %v got evicted", testCase.expectedPodsEvicted, podsEvicted)
@@ -675,8 +676,8 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 				false,
 			)
 
-			HighNodeUtilization(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
-
+			s, _ := NewHighNodeUtilizationStrategy(fakeClient, api.StrategyList{HighNodeUtilization: strategy})
+			s.Run(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
 			if item.evictionsExpected != podEvictor.TotalEvicted() {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, podEvictor.TotalEvicted())
 			}

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
@@ -481,7 +481,7 @@ func TestHighNodeUtilization(t *testing.T) {
 			}
 
 			s, _ := NewHighNodeUtilizationStrategy(fakeClient, api.StrategyList{HighNodeUtilization: strategy})
-			s.Run(ctx, fakeClient, strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, testCase.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if testCase.expectedPodsEvicted != podsEvicted {
 				t.Errorf("Expected %v pods to be evicted but %v got evicted", testCase.expectedPodsEvicted, podsEvicted)
@@ -677,7 +677,7 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 			)
 
 			s, _ := NewHighNodeUtilizationStrategy(fakeClient, api.StrategyList{HighNodeUtilization: strategy})
-			s.Run(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, item.nodes, podEvictor, getPodsAssignedToNode)
 			if item.evictionsExpected != podEvictor.TotalEvicted() {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, podEvictor.TotalEvicted())
 			}

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
@@ -739,7 +739,7 @@ func TestLowNodeUtilization(t *testing.T) {
 			}
 
 			s, _ := NewLowNodeUtilizationStrategy(fakeClient, api.StrategyList{LowNodeUtilization: strategy})
-			s.Run(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, test.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if test.expectedPodsEvicted != podsEvicted {
 				t.Errorf("Expected %v pods to be evicted but %v got evicted", test.expectedPodsEvicted, podsEvicted)
@@ -1042,7 +1042,7 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 			)
 
 			s, _ := NewLowNodeUtilizationStrategy(fakeClient, api.StrategyList{LowNodeUtilization: strategy})
-			s.Run(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, item.nodes, podEvictor, getPodsAssignedToNode)
 			if item.evictionsExpected != podEvictor.TotalEvicted() {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, podEvictor.TotalEvicted())
 			}

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
@@ -737,8 +737,9 @@ func TestLowNodeUtilization(t *testing.T) {
 					NodeFit: true,
 				},
 			}
-			LowNodeUtilization(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
 
+			s, _ := NewLowNodeUtilizationStrategy(fakeClient, api.StrategyList{LowNodeUtilization: strategy})
+			s.Run(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if test.expectedPodsEvicted != podsEvicted {
 				t.Errorf("Expected %v pods to be evicted but %v got evicted", test.expectedPodsEvicted, podsEvicted)
@@ -1040,8 +1041,8 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				false,
 			)
 
-			LowNodeUtilization(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
-
+			s, _ := NewLowNodeUtilizationStrategy(fakeClient, api.StrategyList{LowNodeUtilization: strategy})
+			s.Run(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
 			if item.evictionsExpected != podEvictor.TotalEvicted() {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, podEvictor.TotalEvicted())
 			}

--- a/pkg/descheduler/strategies/nodeutilization/nodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/nodeutilization.go
@@ -31,6 +31,11 @@ import (
 	"sigs.k8s.io/descheduler/pkg/utils"
 )
 
+const (
+	LowNodeUtilization  api.StrategyName = "LowNodeUtilization"
+	HighNodeUtilization api.StrategyName = "HighNodeUtilization"
+)
+
 // NodeUsage stores a node's info, pods on it, thresholds and its resource usage
 type NodeUsage struct {
 	node    *v1.Node

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -222,7 +222,7 @@ func TestPodAntiAffinity(t *testing.T) {
 			}
 
 			s, _ := NewRemovePodsViolatingInterPodAntiAffinityStrategy(fakeClient, api.StrategyList{RemovePodsViolatingInterPodAntiAffinity: strategy})
-			s.Run(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, test.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != test.expectedEvictedPodCount {
 				t.Errorf("Unexpected no of pods evicted: pods evicted: %d, expected: %d", podsEvicted, test.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -221,7 +221,8 @@ func TestPodAntiAffinity(t *testing.T) {
 				},
 			}
 
-			RemovePodsViolatingInterPodAntiAffinity(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewRemovePodsViolatingInterPodAntiAffinityStrategy(fakeClient, api.StrategyList{RemovePodsViolatingInterPodAntiAffinity: strategy})
+			s.Run(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != test.expectedEvictedPodCount {
 				t.Errorf("Unexpected no of pods evicted: pods evicted: %d, expected: %d", podsEvicted, test.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -306,7 +306,7 @@ func TestPodLifeTime(t *testing.T) {
 			)
 
 			s, _ := NewPodLifeTimeStrategy(fakeClient, api.StrategyList{PodLifeTime: tc.strategy})
-			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, tc.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != tc.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.description, tc.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -305,7 +305,8 @@ func TestPodLifeTime(t *testing.T) {
 				false,
 			)
 
-			PodLifeTime(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewPodLifeTimeStrategy(fakeClient, api.StrategyList{PodLifeTime: tc.strategy})
+			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != tc.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.description, tc.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/strategies.go
+++ b/pkg/descheduler/strategies/strategies.go
@@ -1,0 +1,14 @@
+package strategies
+
+import "sigs.k8s.io/descheduler/pkg/api"
+
+const (
+	RemoveDuplicates                            api.StrategyName = "RemoveDuplicates"
+	RemoveFailedPods                            api.StrategyName = "RemoveFailedPods"
+	RemovePodsViolatingNodeAffinity             api.StrategyName = "RemovePodsViolatingNodeAffinity"
+	RemovePodsViolatingNodeTaints               api.StrategyName = "RemovePodsViolatingNodeTaints"
+	RemovePodsViolatingInterPodAntiAffinity     api.StrategyName = "RemovePodsViolatingInterPodAntiAffinity"
+	PodLifeTime                                 api.StrategyName = "PodLifeTime"
+	RemovePodsHavingTooManyRestarts             api.StrategyName = "RemovePodsHavingTooManyRestarts"
+	RemovePodsViolatingTopologySpreadConstraint api.StrategyName = "RemovePodsViolatingTopologySpreadConstraint"
+)

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -242,7 +242,7 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 			)
 
 			s, _ := NewRemovePodsHavingTooManyRestartsStrategy(fakeClient, api.StrategyList{PodLifeTime: tc.strategy})
-			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -241,7 +241,8 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 				false,
 			)
 
-			RemovePodsHavingTooManyRestarts(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s, _ := NewRemovePodsHavingTooManyRestartsStrategy(fakeClient, api.StrategyList{PodLifeTime: tc.strategy})
+			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -908,7 +908,9 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				false,
 				false,
 			)
-			RemovePodsViolatingTopologySpreadConstraint(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+
+			s, _ := NewRemovePodsViolatingTopologySpreadConstraintStrategy(fakeClient, api.StrategyList{PodLifeTime: tc.strategy})
+			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != tc.expectedEvictedCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.name, tc.expectedEvictedCount, podsEvicted)

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -910,7 +910,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			)
 
 			s, _ := NewRemovePodsViolatingTopologySpreadConstraintStrategy(fakeClient, api.StrategyList{PodLifeTime: tc.strategy})
-			s.Run(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			s.Run(ctx, tc.nodes, podEvictor, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != tc.expectedEvictedCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.name, tc.expectedEvictedCount, podsEvicted)


### PR DESCRIPTION
Still a wip, but the goal i'm trying to solve is to fail validation of our config before we begin running.
Alternatively we could add metrics to show the strategies failing due to misconfiguration. 

Relates to https://github.com/kubernetes-sigs/descheduler/issues/701