### PR TITLE
Skip draining nodes that are already cordoned

### DIFF
--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -89,10 +89,10 @@ func IsReady(node *v1.Node) bool {
 		}*/
 	}
 	// Ignore nodes that are marked unschedulable
-	/*if node.Spec.Unschedulable {
-		klog.V(4).InfoS("Ignoring node since it is unschedulable", "node", klog.KObj(node.Name))
+	if node.Spec.Unschedulable {
+		klog.V(4).InfoS("Ignoring node since it is unschedulable", "node", klog.KObj(node))
 		return false
-	}*/
+	}
 	return true
 }
 

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -39,16 +39,16 @@ func TestReadyNodes(t *testing.T) {
 	node5.Status.Conditions = []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}}
 
 	if !IsReady(node1) {
-		t.Errorf("Expected %v to be ready", node2.Name)
+		t.Errorf("Expected %v to be ready", node1.Name)
 	}
 	if !IsReady(node2) {
-		t.Errorf("Expected %v to be ready", node3.Name)
+		t.Errorf("Expected %v to be ready", node2.Name)
 	}
 	if !IsReady(node3) {
-		t.Errorf("Expected %v to be ready", node4.Name)
+		t.Errorf("Expected %v to be ready", node3.Name)
 	}
-	if !IsReady(node4) {
-		t.Errorf("Expected %v to be ready", node5.Name)
+	if IsReady(node4) {
+		t.Errorf("Expected %v to be bot ready", node4.Name)
 	}
 	if IsReady(node5) {
 		t.Errorf("Expected %v to be not ready", node5.Name)

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -48,7 +48,7 @@ func TestReadyNodes(t *testing.T) {
 		t.Errorf("Expected %v to be ready", node3.Name)
 	}
 	if IsReady(node4) {
-		t.Errorf("Expected %v to be bot ready", node4.Name)
+		t.Errorf("Expected %v to be not ready", node4.Name)
 	}
 	if IsReady(node5) {
 		t.Errorf("Expected %v to be not ready", node5.Name)


### PR DESCRIPTION
We ran into a situation were we had to disable `Descheduler` because it was attempting to drain nodes which were cordoned, causing conflicts with cluster upgrade.

We found that `Descheduler` was attempting to evict _every outdated Node in the cluster_ during the worker re-image because it reacts to a Node taint which is added by the node controller when a Node is marked as unschedulable. This caused the cluster to be disrupted at a high rate which made it very unstable.

This PR ignores nodes that are marked as `unschedulable` so that `Descheduler` won't conflict with node controller taints.
Not sure why the code was in place, but commented out.