### PR TITLE
[release-1.23] Backport context cancel panic + Go version update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.17.3
+FROM golang:1.17.7
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: descheduler
-version: 0.23.1
-appVersion: 0.23.0
+version: 0.23.2
+appVersion: 0.23.1
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:
 - kubernetes

--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -73,7 +73,7 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 			}
 
 			ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-			defer done()
+
 			pathRecorderMux := mux.NewPathRecorderMux("descheduler")
 			if !s.DisableMetrics {
 				pathRecorderMux.Handle("/metrics", legacyregistry.HandlerWithReset())
@@ -81,15 +81,20 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 
 			healthz.InstallHandler(pathRecorderMux, healthz.NamedCheck("Descheduler", healthz.PingHealthz.Check))
 
-			if _, err := SecureServing.Serve(pathRecorderMux, 0, ctx.Done()); err != nil {
+			stoppedCh, err := SecureServing.Serve(pathRecorderMux, 0, ctx.Done())
+			if err != nil {
 				klog.Fatalf("failed to start secure server: %v", err)
 				return
 			}
 
-			err := Run(ctx, s)
+			err = Run(ctx, s)
 			if err != nil {
 				klog.ErrorS(err, "descheduler server")
 			}
+
+			done()
+			// wait for metrics server to close
+			<-stoppedCh
 		},
 	}
 	cmd.SetOut(out)

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -35,9 +35,6 @@ func TestTaintsUpdated(t *testing.T) {
 		},
 	}
 
-	stopChannel := make(chan struct{})
-	defer close(stopChannel)
-
 	rs, err := options.NewDeschedulerServer()
 	if err != nil {
 		t.Fatalf("Unable to initialize server: %v", err)
@@ -47,7 +44,7 @@ func TestTaintsUpdated(t *testing.T) {
 	errChan := make(chan error, 1)
 	defer close(errChan)
 	go func() {
-		err := RunDeschedulerStrategies(ctx, rs, dp, "v1beta1", stopChannel)
+		err := RunDeschedulerStrategies(ctx, rs, dp, "v1beta1")
 		errChan <- err
 	}()
 	select {
@@ -99,5 +96,71 @@ func TestTaintsUpdated(t *testing.T) {
 		return false, nil
 	}); err != nil {
 		t.Fatalf("Unable to evict pod, node taint did not get propagated to descheduler strategies")
+	}
+}
+
+func TestRootCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	n1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
+	n2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
+	client := fakeclientset.NewSimpleClientset(n1, n2)
+	dp := &api.DeschedulerPolicy{
+		Strategies: api.StrategyList{}, // no strategies needed for this test
+	}
+
+	rs, err := options.NewDeschedulerServer()
+	if err != nil {
+		t.Fatalf("Unable to initialize server: %v", err)
+	}
+	rs.Client = client
+	rs.DeschedulingInterval = 100 * time.Millisecond
+	errChan := make(chan error, 1)
+	defer close(errChan)
+
+	go func() {
+		err := RunDeschedulerStrategies(ctx, rs, dp, "v1beta1")
+		errChan <- err
+	}()
+	cancel()
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatalf("Unable to run descheduler strategies: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Root ctx should have canceled immediately")
+	}
+}
+
+func TestRootCancelWithNoInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	n1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
+	n2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
+	client := fakeclientset.NewSimpleClientset(n1, n2)
+	dp := &api.DeschedulerPolicy{
+		Strategies: api.StrategyList{}, // no strategies needed for this test
+	}
+
+	rs, err := options.NewDeschedulerServer()
+	if err != nil {
+		t.Fatalf("Unable to initialize server: %v", err)
+	}
+	rs.Client = client
+	rs.DeschedulingInterval = 0
+	errChan := make(chan error, 1)
+	defer close(errChan)
+
+	go func() {
+		err := RunDeschedulerStrategies(ctx, rs, dp, "v1beta1")
+		errChan <- err
+	}()
+	cancel()
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatalf("Unable to run descheduler strategies: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Root ctx should have canceled immediately")
 	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -984,9 +984,7 @@ func TestDeschedulingInterval(t *testing.T) {
 		if err != nil || len(evictionPolicyGroupVersion) == 0 {
 			t.Errorf("Error when checking support for eviction: %v", err)
 		}
-
-		stopChannel := make(chan struct{})
-		if err := descheduler.RunDeschedulerStrategies(ctx, s, deschedulerPolicy, evictionPolicyGroupVersion, stopChannel); err != nil {
+		if err := descheduler.RunDeschedulerStrategies(ctx, s, deschedulerPolicy, evictionPolicyGroupVersion); err != nil {
 			t.Errorf("Error running descheduler strategies: %+v", err)
 		}
 		c <- true


### PR DESCRIPTION
Backports https://github.com/kubernetes-sigs/descheduler/pull/731 and preps for a v0.23.1 app release to address this

Fixes https://github.com/kubernetes-sigs/descheduler/issues/743
ref #741 #728 