### PR TITLE
Update docs for maxNoOfPodsToEvictPerNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The policy includes a common configuration that applies to all the strategies:
 | `evictSystemCriticalPods` | `false` | [Warning: Will evict Kubernetes system pods] allows eviction of pods with any priority, including system pods like kube-dns |
 | `ignorePvcPods` | `false` | set whether PVC pods should be evicted or ignored |
 | `maxNoOfPodsToEvictPerNode` | `nil` | maximum number of pods evicted from each node (summed through all strategies) |
+| `maxNoOfPodsToEvictPerNamespace` | `nil` | maximum number of pods evicted from each namespace (summed through all strategies) |
 | `evictFailedBarePods` | `false` | allow eviction of pods without owner references and in failed phase |
 
 As part of the policy, the parameters associated with each strategy can be configured.

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -44,6 +44,7 @@ cmdOptions:
 deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"
   # maxNoOfPodsToEvictPerNode: 10
+  # maxNoOfPodsToEvictPerNamespace: 10
   # ignorePvcPods: true
   # evictLocalStoragePods: true
   strategies:


### PR DESCRIPTION
In #658, maxNoOfPodsToEvictPerNamespace policy was added, but it is not documented. This PR adds it.