### PR TITLE
[e2e] TestTooManyRestarts: check err and len before accessing pod items

### DIFF
--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -183,13 +183,17 @@ func waitPodRestartCount(ctx context.Context, clientSet clientset.Interface, nam
 			podList, err := clientSet.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 				LabelSelector: labels.SelectorFromSet(labels.Set(map[string]string{"test": "restart-pod", "name": "test-toomanyrestarts"})).String(),
 			})
-			if podList.Items[0].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[1].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[2].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[3].Status.ContainerStatuses[0].RestartCount >= 4 {
-				t.Log("Pod restartCount as expected")
-				return true, nil
-			}
 			if err != nil {
 				t.Fatalf("Unexpected err: %v", err)
 				return false, err
+			}
+			if len(podList.Items) < 4 {
+				t.Log("Waiting for 4 pods")
+				return false, nil
+			}
+			if podList.Items[0].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[1].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[2].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[3].Status.ContainerStatuses[0].RestartCount >= 4 {
+				t.Log("Pod restartCount as expected")
+				return true, nil
 			}
 		}
 	}


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_descheduler/758/pull-descheduler-test-e2e-k8s-master-1-23/1501991622580113408:
```
=== RUN   TestTooManyRestarts
    e2e_toomanyrestarts_test.go:50: Creating testing namespace TestTooManyRestarts
    e2e_toomanyrestarts_test.go:86: Creating deployment restart-pod
--- FAIL: TestTooManyRestarts (5.16s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
goroutine 1040 [running]:
testing.tRunner.func1.2({0x1c01380, 0xc00080c588})
	/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x1c01380, 0xc00080c588})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
sigs.k8s.io/descheduler/test/e2e.waitPodRestartCount({0x1fc4f90, 0xc0001b8000}, {0x2026a90, 0xc001622780}, {0xc0008afbc0, 0x17}, 0xc000d07ba0)
	/home/prow/go/src/github.com/kubernetes-sigs/descheduler/test/e2e/e2e_toomanyrestarts_test.go:186 +0x536
sigs.k8s.io/descheduler/test/e2e.TestTooManyRestarts(0xc000d07ba0)
	/home/prow/go/src/github.com/kubernetes-sigs/descheduler/test/e2e/e2e_toomanyrestarts_test.go:100 +0xbb2
testing.tRunner(0xc000d07ba0, 0x1e01d90)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
FAIL	sigs.k8s.io/descheduler/test/e2e	279.410s
```