### PR TITLE
[e2e] TestTooManyRestarts: check if container status is set before accessing

### DIFF
--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -191,6 +191,13 @@ func waitPodRestartCount(ctx context.Context, clientSet clientset.Interface, nam
 				t.Log("Waiting for 4 pods")
 				return false, nil
 			}
+			for i := 0; i < 4; i++ {
+				if len(podList.Items[0].Status.ContainerStatuses) < 1 {
+					t.Logf("Waiting for podList.Items[%v].Status.ContainerStatuses to be populated", i)
+					return false, nil
+				}
+			}
+
 			if podList.Items[0].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[1].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[2].Status.ContainerStatuses[0].RestartCount >= 4 && podList.Items[3].Status.ContainerStatuses[0].RestartCount >= 4 {
 				t.Log("Pod restartCount as expected")
 				return true, nil


### PR DESCRIPTION
From https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_descheduler/759/pull-descheduler-test-e2e-k8s-master-1-23/1502212010236973056:
```
=== RUN   TestTooManyRestarts
    e2e_toomanyrestarts_test.go:50: Creating testing namespace TestTooManyRestarts
    e2e_toomanyrestarts_test.go:86: Creating deployment restart-pod
--- FAIL: TestTooManyRestarts (5.14s)
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0
goroutine 1222 [running]:
testing.tRunner.func1.2({0x1c01380, 0xc00140ac78})
	/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x1c01380, 0xc00140ac78})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
sigs.k8s.io/descheduler/test/e2e.waitPodRestartCount({0x1fc4f90, 0xc000140000}, {0x2026a90, 0xc0001b4d80}, {0xc000c65e78, 0x17}, 0xc0013869c0)
	/home/prow/go/src/github.com/kubernetes-sigs/descheduler/test/e2e/e2e_toomanyrestarts_test.go:194 +0x53a
sigs.k8s.io/descheduler/test/e2e.TestTooManyRestarts(0xc0013869c0)
	/home/prow/go/src/github.com/kubernetes-sigs/descheduler/test/e2e/e2e_toomanyrestarts_test.go:100 +0xbb2
testing.tRunner(0xc0013869c0, 0x1e01da8)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
FAIL	sigs.k8s.io/descheduler/test/e2e	301.469s
```