### PR TITLE
Promote NodeUsage to NodeInfo, evaluate thresholds separately

### DIFF
--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
@@ -63,16 +63,17 @@ func HighNodeUtilization(ctx context.Context, client clientset.Interface, strate
 	resourceNames := getResourceNames(targetThresholds)
 
 	sourceNodes, highNodes := classifyNodes(
-		getNodeUsage(nodes, thresholds, targetThresholds, resourceNames, getPodsAssignedToNode),
-		func(node *v1.Node, usage NodeUsage) bool {
-			return isNodeWithLowUtilization(usage)
+		getNodeUsage(nodes, resourceNames, getPodsAssignedToNode),
+		getNodeThresholds(nodes, thresholds, targetThresholds, resourceNames),
+		func(node *v1.Node, usage NodeUsage, threshold NodeThresholds) bool {
+			return isNodeWithLowUtilization(usage, threshold.lowResourceThreshold)
 		},
-		func(node *v1.Node, usage NodeUsage) bool {
+		func(node *v1.Node, usage NodeUsage, threshold NodeThresholds) bool {
 			if nodeutil.IsNodeUnschedulable(node) {
 				klog.V(2).InfoS("Node is unschedulable", "node", klog.KObj(node))
 				return false
 			}
-			return !isNodeWithLowUtilization(usage)
+			return !isNodeWithLowUtilization(usage, threshold.lowResourceThreshold)
 		})
 
 	// log message in one line
@@ -110,7 +111,7 @@ func HighNodeUtilization(ctx context.Context, client clientset.Interface, strate
 	evictable := podEvictor.Evictable(evictions.WithPriorityThreshold(thresholdPriority), evictions.WithNodeFit(nodeFit))
 
 	// stop if the total available usage has dropped to zero - no more pods can be scheduled
-	continueEvictionCond := func(nodeUsage NodeUsage, totalAvailableUsage map[v1.ResourceName]*resource.Quantity) bool {
+	continueEvictionCond := func(nodeInfo NodeInfo, totalAvailableUsage map[v1.ResourceName]*resource.Quantity) bool {
 		for name := range totalAvailableUsage {
 			if totalAvailableUsage[name].CmpInt64(0) < 1 {
 				return false


### PR DESCRIPTION
Refactoring the code so it is easier to replace the code computing the lower/higher thresholds. Also, the `getNodeUsage` is currently evaluating the thresholds which is out of what a usage means. With this PR a developer can wrap the threshold computation around the new `NodeThresholds` data type and implement a different mechanism of pre-computing them.

To help ease integration with https://github.com/kubernetes-sigs/descheduler/pull/751