### PR TITLE
Sort nodes in ascending order for HighNodeUtilization

### DIFF
--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
@@ -120,6 +120,10 @@ func HighNodeUtilization(ctx context.Context, client clientset.Interface, strate
 
 		return true
 	}
+
+	// Sort the nodes by the usage in ascending order
+	sortNodesByUsage(sourceNodes, true)
+
 	evictPodsFromSourceNodes(
 		ctx,
 		sourceNodes,

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization.go
@@ -152,6 +152,9 @@ func LowNodeUtilization(ctx context.Context, client clientset.Interface, strateg
 		return true
 	}
 
+	// Sort the nodes by the usage in descending order
+	sortNodesByUsage(sourceNodes, false)
+
 	evictPodsFromSourceNodes(
 		ctx,
 		sourceNodes,

--- a/pkg/descheduler/strategies/nodeutilization/nodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/nodeutilization.go
@@ -212,9 +212,6 @@ func evictPodsFromSourceNodes(
 	strategy string,
 	continueEviction continueEvictionCond,
 ) {
-
-	sortNodesByUsage(sourceNodes)
-
 	// upper bound on total number of pods/cpu/memory and optional extended resources to be moved
 	totalAvailableUsage := map[v1.ResourceName]*resource.Quantity{
 		v1.ResourcePods:   {},
@@ -327,8 +324,8 @@ func evictPods(
 	}
 }
 
-// sortNodesByUsage sorts nodes based on usage in descending order
-func sortNodesByUsage(nodes []NodeInfo) {
+// sortNodesByUsage sorts nodes based on usage according to the given strategy.
+func sortNodesByUsage(nodes []NodeInfo, ascending bool) {
 	sort.Slice(nodes, func(i, j int) bool {
 		ti := nodes[i].usage[v1.ResourceMemory].Value() + nodes[i].usage[v1.ResourceCPU].MilliValue() + nodes[i].usage[v1.ResourcePods].Value()
 		tj := nodes[j].usage[v1.ResourceMemory].Value() + nodes[j].usage[v1.ResourceCPU].MilliValue() + nodes[j].usage[v1.ResourcePods].Value()
@@ -341,7 +338,12 @@ func sortNodesByUsage(nodes []NodeInfo) {
 			}
 		}
 
-		// To return sorted in descending order
+		// Return ascending order for HighNodeUtilization strategy
+		if ascending {
+			return ti < tj
+		}
+
+		// Return descending order for LowNodeUtilization strategy
 		return ti > tj
 	})
 }


### PR DESCRIPTION
Sort nodes in ascending order for HighNodeUtilization. 
This fixes the issue reported in https://github.com/kubernetes-sigs/descheduler/issues/756 and a part of issue in https://github.com/kubernetes-sigs/descheduler/issues/725

