### PR TITLE
Add RemovePodsViolatingNodeTaints taint exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,10 +412,17 @@ pod "podA" with a toleration to tolerate a taint ``key=value:NoSchedule`` schedu
 node. If the node's taint is subsequently updated/removed, taint is no longer satisfied by its pods' tolerations
 and will be evicted.
 
+Node taints can be excluded from consideration by specifying a list of excludedTaints. If a node taint key **or**
+key=value matches an excludedTaints entry, the taint will be ignored.
+
+For example, excludedTaints entry "dedicated" would match all taints with key "dedicated", regardless of value.
+excludedTaints entry "dedicated=special-user" would match taints with key "dedicated" and value "special-user".
+
 **Parameters:**
 
 |Name|Type|
 |---|---|
+|`excludedTaints`|list(string)|
 |`thresholdPriority`|int (see [priority filtering](#priority-filtering))|
 |`thresholdPriorityClassName`|string (see [priority filtering](#priority-filtering))|
 |`namespaces`|(see [namespace filtering](#namespace-filtering))|
@@ -430,6 +437,10 @@ kind: "DeschedulerPolicy"
 strategies:
   "RemovePodsViolatingNodeTaints":
     enabled: true
+    params:
+      excludedTaints:
+      - dedicated=special-user # exclude taints with key "dedicated" and value "special-user"
+      - reserved # exclude all taints with key "reserved"
 ````
 
 ### RemovePodsViolatingTopologySpreadConstraint

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -89,6 +89,7 @@ type StrategyParameters struct {
 	LabelSelector                     *metav1.LabelSelector
 	NodeFit                           bool
 	IncludePreferNoSchedule           bool
+	ExcludedTaints                    []string
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -87,6 +87,7 @@ type StrategyParameters struct {
 	LabelSelector                     *metav1.LabelSelector              `json:"labelSelector"`
 	NodeFit                           bool                               `json:"nodeFit"`
 	IncludePreferNoSchedule           bool                               `json:"includePreferNoSchedule"`
+	ExcludedTaints                    []string                           `json:"excludedTaints,omitempty"`
 }
 
 type Percentage float64

--- a/pkg/api/v1alpha1/zz_generated.conversion.go
+++ b/pkg/api/v1alpha1/zz_generated.conversion.go
@@ -362,6 +362,7 @@ func autoConvert_v1alpha1_StrategyParameters_To_api_StrategyParameters(in *Strat
 	out.LabelSelector = (*v1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
 	out.NodeFit = in.NodeFit
 	out.IncludePreferNoSchedule = in.IncludePreferNoSchedule
+	out.ExcludedTaints = *(*[]string)(unsafe.Pointer(&in.ExcludedTaints))
 	return nil
 }
 
@@ -384,6 +385,7 @@ func autoConvert_api_StrategyParameters_To_v1alpha1_StrategyParameters(in *api.S
 	out.LabelSelector = (*v1.LabelSelector)(unsafe.Pointer(in.LabelSelector))
 	out.NodeFit = in.NodeFit
 	out.IncludePreferNoSchedule = in.IncludePreferNoSchedule
+	out.ExcludedTaints = *(*[]string)(unsafe.Pointer(&in.ExcludedTaints))
 	return nil
 }
 

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -356,6 +356,11 @@ func (in *StrategyParameters) DeepCopyInto(out *StrategyParameters) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExcludedTaints != nil {
+		in, out := &in.ExcludedTaints, &out.ExcludedTaints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -356,6 +356,11 @@ func (in *StrategyParameters) DeepCopyInto(out *StrategyParameters) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ExcludedTaints != nil {
+		in, out := &in.ExcludedTaints, &out.ExcludedTaints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/descheduler/strategies/node_taint.go
+++ b/pkg/descheduler/strategies/node_taint.go
@@ -55,12 +55,15 @@ func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interfa
 		return
 	}
 
-	var includedNamespaces, excludedNamespaces sets.String
+	var includedNamespaces, excludedNamespaces, excludedTaints sets.String
 	var labelSelector *metav1.LabelSelector
 	if strategy.Params != nil {
 		if strategy.Params.Namespaces != nil {
 			includedNamespaces = sets.NewString(strategy.Params.Namespaces.Include...)
 			excludedNamespaces = sets.NewString(strategy.Params.Namespaces.Exclude...)
+		}
+		if strategy.Params.ExcludedTaints != nil {
+			excludedTaints = sets.NewString(strategy.Params.ExcludedTaints...)
 		}
 		labelSelector = strategy.Params.LabelSelector
 	}
@@ -89,10 +92,15 @@ func RemovePodsViolatingNodeTaints(ctx context.Context, client clientset.Interfa
 		return
 	}
 
-	taintFilterFnc := func(taint *v1.Taint) bool { return taint.Effect == v1.TaintEffectNoSchedule }
+	excludeTaint := func(taint *v1.Taint) bool {
+		// Exclude taints by key *or* key=value
+		return excludedTaints.Has(taint.Key) || (taint.Value != "" && excludedTaints.Has(fmt.Sprintf("%s=%s", taint.Key, taint.Value)))
+	}
+
+	taintFilterFnc := func(taint *v1.Taint) bool { return (taint.Effect == v1.TaintEffectNoSchedule) && !excludeTaint(taint) }
 	if strategy.Params != nil && strategy.Params.IncludePreferNoSchedule {
 		taintFilterFnc = func(taint *v1.Taint) bool {
-			return taint.Effect == v1.TaintEffectNoSchedule || taint.Effect == v1.TaintEffectPreferNoSchedule
+			return (taint.Effect == v1.TaintEffectNoSchedule || taint.Effect == v1.TaintEffectPreferNoSchedule) && !excludeTaint(taint)
 		}
 	}
 


### PR DESCRIPTION
Add taint exclusion to RemovePodsViolatingNodeTaints. This permits node
taints to be ignored by allowing users to specify ignored taint keys or
ignored taint key=value pairs.

Fixes #772 