### PR TITLE
Fix missing param in user-guide for PodLifeTime strategy

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -111,7 +111,8 @@ strategies:
   "PodLifeTime":
     enabled: true
     params:
-      maxPodLifeTimeSeconds: 604800 # pods run for a maximum of 7 days
+      podLifeTime:
+        maxPodLifeTimeSeconds: 604800 # pods run for a maximum of 7 days
 ```
 
 ### Balance Cluster By Node Memory Utilization


### PR DESCRIPTION
A small pr to fix missing parameter field in the following document: https://github.com/kubernetes-sigs/descheduler/blob/master/docs/user-guide.md#balance-cluster-by-pod-age

Related issue:  https://github.com/kubernetes-sigs/descheduler/issues/780