### PR TITLE
Update Docs and Manifests for v0.24.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ See the [resources | Kustomize](https://kubectl.docs.kubernetes.io/references/ku
 
 Run As A Job
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.22.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.24.0' | kubectl apply -f -
 ```
 
 Run As A CronJob
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.22.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.24.0' | kubectl apply -f -
 ```
 
 Run As A Deployment
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.22.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.24.0' | kubectl apply -f -
 ```
 
 ## User Guide
@@ -689,7 +689,7 @@ does not exist, descheduler won't create it and will throw an error.
 
 ### Label filtering
 
-The following strategies can configure a [standard kubernetes labelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#labelselector-v1-meta)
+The following strategies can configure a [standard kubernetes labelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta)
 to filter pods by their labels:
 
 * `PodLifeTime`
@@ -832,6 +832,8 @@ packages that it is compiled with.
 
 | Descheduler | Supported Kubernetes Version |
 |-------------|------------------------------|
+| v0.24       | v1.24                        |
+| v0.23       | v1.23                        |
 | v0.22       | v1.22                        |
 | v0.21       | v1.21                        |
 | v0.20       | v1.20                        |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,6 +4,7 @@ Starting with descheduler release v0.10.0 container images are available in the 
 
 Descheduler Version | Container Image                            | Architectures           |
 ------------------- |--------------------------------------------|-------------------------|
+v0.24.0             | k8s.gcr.io/descheduler/descheduler:v0.24.0 | AMD64<br>ARM64<br>ARMv7 |
 v0.23.1             | k8s.gcr.io/descheduler/descheduler:v0.23.1 | AMD64<br>ARM64<br>ARMv7 |
 v0.22.0             | k8s.gcr.io/descheduler/descheduler:v0.22.0 | AMD64<br>ARM64<br>ARMv7 |
 v0.21.0             | k8s.gcr.io/descheduler/descheduler:v0.21.0 | AMD64<br>ARM64<br>ARMv7 |

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
-            image: k8s.gcr.io/descheduler/descheduler:v0.23.1
+            image: k8s.gcr.io/descheduler/descheduler:v0.24.0
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: descheduler-sa
       containers:
         - name: descheduler
-          image: k8s.gcr.io/descheduler/descheduler:v0.23.1
+          image: k8s.gcr.io/descheduler/descheduler:v0.24.0
           imagePullPolicy: IfNotPresent
           command:
             - "/bin/descheduler"

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
-          image: k8s.gcr.io/descheduler/descheduler:v0.23.1
+          image: k8s.gcr.io/descheduler/descheduler:v0.24.0
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume


### PR DESCRIPTION
Changes covered as part of this PR are:

- [ ] Added v0.24 references to README
- [ ]  Update k8s manifests with v0.24.0 references
- [ ] Added table with list of supported architectures by release
