### PR TITLE
Arguments must be strings, not bool or number

### DIFF
--- a/charts/descheduler/templates/_helpers.tpl
+++ b/charts/descheduler/templates/_helpers.tpl
@@ -71,31 +71,24 @@ Leader Election
 */}}
 {{- define "descheduler.leaderElection"}}
 {{- if .Values.leaderElection -}}
-- --leader-elect
-- {{ default false .Values.leaderElection.enabled }}
+- --leader-elect={{ .Values.leaderElection.enabled }}
 {{- if .Values.leaderElection.leaseDuration }}
-- --leader-elect-lease-duration
-- {{ .Values.leaderElection.leaseDuration }}
+- --leader-elect-lease-duration={{ .Values.leaderElection.leaseDuration }}
 {{- end }}
 {{- if .Values.leaderElection.renewDeadline }}
-- --leader-elect-renew-deadline
-- {{ .Values.leaderElection.renewDeadline }}
+- --leader-elect-renew-deadline={{ .Values.leaderElection.renewDeadline }}
 {{- end }}
 {{- if .Values.leaderElection.retryPeriod }}
-- --leader-elect-retry-period
-- {{ .Values.leaderElection.retryPeriod }}
+- --leader-elect-retry-period={{ .Values.leaderElection.retryPeriod }}
 {{- end }}
 {{- if .Values.leaderElection.resourceLock }}
-- --leader-elect-resource-lock
-- {{ .Values.leaderElection.resourceLock }}
+- --leader-elect-resource-lock={{ .Values.leaderElection.resourceLock }}
 {{- end }}
 {{- if .Values.leaderElection.resourceName }}
-- --leader-elect-resource-name
-- {{ .Values.leaderElection.resourceName }}
+- --leader-elect-resource-name={{ .Values.leaderElection.resourceName }}
 {{- end }}
 {{- if .Values.leaderElection.resourceNamescape }}
-- --leader-elect-resource-namespace
-- {{ .Values.leaderElection.resourceNamescape }}
+- --leader-elect-resource-namespace={{ .Values.leaderElection.resourceNamescape }}
 {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -27,7 +27,7 @@ rules:
 {{- if .Values.leaderElection.enabled }}
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  verbs: ["create"]
+  verbs: ["create", "update"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   resourceNames: ["descheduler"]

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -48,9 +48,9 @@ replicas: 1
 # Required when running as a Deployment
 leaderElection: {}
 #  enabled: true
-#  leaseDuration: 15
-#  renewDeadline: 10
-#  retryPeriod: 2
+#  leaseDuration: 15s
+#  renewDeadline: 10s
+#  retryPeriod: 2s
 #  resourceLock: "leases"
 #  resourceName: "descheduler"
 #  resourceNamescape: "kube-system"


### PR DESCRIPTION
Also, add the missing update verb in the ClusterRole and adds required time units to `leaseDuration`, `renewDeadline`, and `retryPeriod` in the Chart example.

Closes #812