### PR TITLE
Add `--logtostderr=false` so logs are redirected to stdout by default

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -67,6 +67,7 @@ spec:
               args:
                 - "--policy-config-file"
                 - "/policy-dir/policy.yaml"
+                - "--logtostderr=false"
                 {{- range $key, $value := .Values.cmdOptions }}
                 - {{ printf "--%s" $key | quote }}
                 {{- if $value }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
             - "--policy-config-file"
             - "/policy-dir/policy.yaml"
             - "--descheduling-interval"
+            - "--logtostderr=false"
             - {{ required "deschedulingInterval required for running as Deployment" .Values.deschedulingInterval }}
             {{- range $key, $value := .Values.cmdOptions }}
             - {{ printf "--%s" $key | quote }}


### PR DESCRIPTION
Closes #811

That way the cronjob/deployments are automatically setup with the appropriate needed flag of redirecting the logs to stdout instead of stderr.

The