### PR TITLE
[release-1.24] helm chart fixes

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -69,8 +69,8 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `serviceAccount.create`             | If `true`, create a service account for the cron job                                                                  | `true`                               |
 | `serviceAccount.name`               | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                |
 | `serviceAccount.annotations`        | Specifies custom annotations for the serviceAccount                                                                   | `{}`                                 |
-| `podAnnotations`                    | Annotations to add to Pods                                                                                            | `{}`                                 |
-| `podLabels`                         | Labels to add to Pods                                                                                                 | `{}`                                 |
+| `podAnnotations`                    | Annotations to add to the descheduler Pods                                                                            | `{}`                                 |
+| `podLabels`                         | Labels to add to the descheduler Pods                                                                                 | `{}`                                 |
 | `nodeSelector`                      | Node selectors to run the descheduler cronjob/deployment on specific nodes                                            | `nil`                                |
 | `service.enabled`                   | If `true`, create a service for deployment                                                                            | `false`                              |
 | `serviceMonitor.enabled`            | If `true`, create a ServiceMonitor for deployment                                                                     | `false`                              |

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -69,6 +69,8 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `serviceAccount.create`             | If `true`, create a service account for the cron job                                                                  | `true`                               |
 | `serviceAccount.name`               | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                |
 | `serviceAccount.annotations`        | Specifies custom annotations for the serviceAccount                                                                   | `{}`                                 |
+| `podAnnotations`                    | Annotations to add to Pods                                                                                            | `{}`                                 |
+| `podLabels`                         | Labels to add to Pods                                                                                                 | `{}`                                 |
 | `nodeSelector`                      | Node selectors to run the descheduler cronjob/deployment on specific nodes                                            | `nil`                                |
 | `service.enabled`                   | If `true`, create a service for deployment                                                                            | `false`                              |
 | `serviceMonitor.enabled`            | If `true`, create a ServiceMonitor for deployment                                                                     | `false`                              |

--- a/charts/descheduler/templates/_helpers.tpl
+++ b/charts/descheduler/templates/_helpers.tpl
@@ -71,31 +71,24 @@ Leader Election
 */}}
 {{- define "descheduler.leaderElection"}}
 {{- if .Values.leaderElection -}}
-- --leader-elect
-- {{ default false .Values.leaderElection.enabled }}
+- --leader-elect={{ .Values.leaderElection.enabled }}
 {{- if .Values.leaderElection.leaseDuration }}
-- --leader-elect-lease-duration
-- {{ .Values.leaderElection.leaseDuration }}
+- --leader-elect-lease-duration={{ .Values.leaderElection.leaseDuration }}
 {{- end }}
 {{- if .Values.leaderElection.renewDeadline }}
-- --leader-elect-renew-deadline
-- {{ .Values.leaderElection.renewDeadline }}
+- --leader-elect-renew-deadline={{ .Values.leaderElection.renewDeadline }}
 {{- end }}
 {{- if .Values.leaderElection.retryPeriod }}
-- --leader-elect-retry-period
-- {{ .Values.leaderElection.retryPeriod }}
+- --leader-elect-retry-period={{ .Values.leaderElection.retryPeriod }}
 {{- end }}
 {{- if .Values.leaderElection.resourceLock }}
-- --leader-elect-resource-lock
-- {{ .Values.leaderElection.resourceLock }}
+- --leader-elect-resource-lock={{ .Values.leaderElection.resourceLock }}
 {{- end }}
 {{- if .Values.leaderElection.resourceName }}
-- --leader-elect-resource-name
-- {{ .Values.leaderElection.resourceName }}
+- --leader-elect-resource-name={{ .Values.leaderElection.resourceName }}
 {{- end }}
 {{- if .Values.leaderElection.resourceNamescape }}
-- --leader-elect-resource-namespace
-- {{ .Values.leaderElection.resourceNamescape }}
+- --leader-elect-resource-namespace={{ .Values.leaderElection.resourceNamescape }}
 {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -27,7 +27,7 @@ rules:
 {{- if .Values.leaderElection.enabled }}
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  verbs: ["create"]
+  verbs: ["create", "update"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
   resourceNames: ["descheduler"]

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -136,6 +136,10 @@ serviceAccount:
   # Specifies custom annotations for the serviceAccount
   annotations: {}
 
+podAnnotations: {}
+
+podLabels: {}
+
 livenessProbe:
   failureThreshold: 3
   httpGet:

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -48,9 +48,9 @@ replicas: 1
 # Required when running as a Deployment
 leaderElection: {}
 #  enabled: true
-#  leaseDuration: 15
-#  renewDeadline: 10
-#  retryPeriod: 2
+#  leaseDuration: 15s
+#  renewDeadline: 10s
+#  retryPeriod: 2s
 #  resourceLock: "leases"
 #  resourceName: "descheduler"
 #  resourceNamescape: "kube-system"


### PR DESCRIPTION
This cherry-picks the changes from https://github.com/kubernetes-sigs/descheduler/pull/814 and https://github.com/kubernetes-sigs/descheduler/pull/813 to fix helm chart changes that should have been included in 1.24