### PR TITLE
[release-1.24] Update helm chart for v0.24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,17 +105,17 @@ See the [resources | Kustomize](https://kubectl.docs.kubernetes.io/references/ku
 
 Run As A Job
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.24.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.24.1' | kubectl apply -f -
 ```
 
 Run As A CronJob
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.24.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.24.1' | kubectl apply -f -
 ```
 
 Run As A Deployment
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.24.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.24.1' | kubectl apply -f -
 ```
 
 ## User Guide

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: descheduler
-version: 0.24.0
-appVersion: 0.24.0
+version: 0.24.1
+appVersion: 0.24.1
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:
 - kubernetes

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,6 +4,7 @@ Starting with descheduler release v0.10.0 container images are available in the 
 
 Descheduler Version | Container Image                            | Architectures           |
 ------------------- |--------------------------------------------|-------------------------|
+v0.24.1             | k8s.gcr.io/descheduler/descheduler:v0.24.0 | AMD64<br>ARM64<br>ARMv7 |
 v0.24.0             | k8s.gcr.io/descheduler/descheduler:v0.24.0 | AMD64<br>ARM64<br>ARMv7 |
 v0.23.1             | k8s.gcr.io/descheduler/descheduler:v0.23.1 | AMD64<br>ARM64<br>ARMv7 |
 v0.22.0             | k8s.gcr.io/descheduler/descheduler:v0.22.0 | AMD64<br>ARM64<br>ARMv7 |

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
-            image: k8s.gcr.io/descheduler/descheduler:v0.24.0
+            image: k8s.gcr.io/descheduler/descheduler:v0.24.1
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: descheduler-sa
       containers:
         - name: descheduler
-          image: k8s.gcr.io/descheduler/descheduler:v0.24.0
+          image: k8s.gcr.io/descheduler/descheduler:v0.24.1
           imagePullPolicy: IfNotPresent
           command:
             - "/bin/descheduler"

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
-          image: k8s.gcr.io/descheduler/descheduler:v0.24.0
+          image: k8s.gcr.io/descheduler/descheduler:v0.24.1
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume


### PR DESCRIPTION
This prepares the v0.24.1 release

(this branch already tagged with `v0.24.1`, so after this merges we should be able to do the image promotion)