### PR TITLE
[release-1.24] Fix version command to parse helm chart tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 .PHONY: test
 
 # VERSION is based on a date stamp plus the last commit
-VERSION?=v$(shell date +%Y%m%d)-$(shell git describe --tags --match "v*")
+VERSION?=v$(shell date +%Y%m%d)-$(shell git describe --tags)
 BRANCH?=$(shell git branch --show-current)
 SHA1?=$(shell git rev-parse HEAD)
 BUILD=$(shell date +%FT%T%z)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 1200s
+timeout: 1500s
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -80,9 +80,19 @@ func splitVersion(version string) (string, string) {
 	// Version from an automated container build environment(not a tag) or a local build. For example v20201009-v0.18.0-46-g939c1c0.
 	m2, _ := regexp.MatchString(`^v\d{8}-v\d+\.\d+\.\d+-\w+-\w+$`, version)
 
+	// Version tagged by helm chart releaser action
+	helm, _ := regexp.MatchString(`^v\d{8}-descheduler-helm-chart-\d+\.\d+\.\d+$`, version)
+	// Dirty version where helm chart is the last known tag
+	helm2, _ := regexp.MatchString(`^v\d{8}-descheduler-helm-chart-\d+\.\d+\.\d+-\w+-\w+$`, version)
+
 	if m1 || m2 {
 		semVer := strings.Split(version, "-")[1]
-		return strings.Trim(strings.Split(semVer, ".")[0], "v"), strings.Split(semVer, ".")[1] + "+"
+		return strings.Trim(strings.Split(semVer, ".")[0], "v"), strings.Split(semVer, ".")[1] + "." + strings.Split(semVer, ".")[2]
+	}
+
+	if helm || helm2 {
+		semVer := strings.Split(version, "-")[4]
+		return strings.Split(semVer, ".")[0], strings.Split(semVer, ".")[1] + "." + strings.Split(semVer, ".")[2]
 	}
 
 	// Something went wrong


### PR DESCRIPTION
Porting https://github.com/kubernetes-sigs/descheduler/pull/823 to 1.24