### PR TITLE
GIT-811: enable go-runner support for configuring log output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+ARG GORUNNER_VERSION=v2.3.1-go1.18.2-bullseye.0
+
 FROM golang:1.18.2
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
@@ -19,12 +21,16 @@ ARG ARCH
 ARG VERSION
 RUN VERSION=${VERSION} make build.$ARCH
 
+FROM k8s.gcr.io/build-image/go-runner:${GORUNNER_VERSION} as build-base
+
 FROM scratch
 
-MAINTAINER Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>
+LABEL maintainer="Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>"
 
 USER 1000
 
+COPY --from=build-base /go-runner /
 COPY --from=0 /go/src/sigs.k8s.io/descheduler/_output/bin/descheduler /bin/descheduler
 
+ENTRYPOINT [ "/go-runner" ]
 CMD ["/bin/descheduler", "--help"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,12 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+ARG GORUNNER_VERSION=v2.3.1-go1.18.2-bullseye.0
+
+FROM k8s.gcr.io/build-image/go-runner:${GORUNNER_VERSION} as build-base
+
 FROM scratch
 
-MAINTAINER Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>
+LABEL maintainer="Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>"
+
+WORKDIR /
+
+COPY --from=build-base /go-runner /
 
 USER 1000
 
 COPY _output/bin/descheduler /bin/descheduler
 
+ENTRYPOINT [ "/go-runner" ]
 CMD ["/bin/descheduler", "--help"]

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ SHA1?=$(shell git rev-parse HEAD)
 BUILD=$(shell date +%FT%T%z)
 LDFLAG_LOCATION=sigs.k8s.io/descheduler/pkg/version
 ARCHS = amd64 arm arm64
+GORUNNER_VERSION=v2.3.1-go1.18.2-bullseye.0
 
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitbranch=${BRANCH} -X ${LDFLAG_LOCATION}.gitsha1=${SHA1}"
 
@@ -60,19 +61,19 @@ build.arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ${LDFLAGS} -o _output/bin/descheduler sigs.k8s.io/descheduler/cmd/descheduler
 
 dev-image: build
-	docker build -f Dockerfile.dev -t $(IMAGE) .
+	docker build --build-arg GORUNNER_VERSION="$(GORUNNER_VERSION)" -f Dockerfile.dev -t $(IMAGE) .
 
 image:
-	docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" -t $(IMAGE) .
+	docker build --build-arg GORUNNER_VERSION="$(GORUNNER_VERSION)" --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" -t $(IMAGE) .
 
 image.amd64:
-	docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" -t $(IMAGE)-amd64 .
+	docker build --build-arg GORUNNER_VERSION="$(GORUNNER_VERSION)" --build-arg VERSION="$(VERSION)" --build-arg ARCH="amd64" -t $(IMAGE)-amd64 .
 
 image.arm:
-	docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="arm" -t $(IMAGE)-arm .
+	docker build --build-arg GORUNNER_VERSION="$(GORUNNER_VERSION)" --build-arg VERSION="$(VERSION)" --build-arg ARCH="arm" -t $(IMAGE)-arm .
 
 image.arm64:
-	docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="arm64" -t $(IMAGE)-arm64 .
+	docker build --build-arg GORUNNER_VERSION="$(GORUNNER_VERSION)" --build-arg VERSION="$(VERSION)" --build-arg ARCH="arm64" -t $(IMAGE)-arm64 .
 
 push: image
 	gcloud auth configure-docker


### PR DESCRIPTION
Closes #811 

Implementation based on the `klog` flag deprecation KEP :[KEP-2845: Deprecate klog specific flags in Kubernetes Compnents](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components#user-stories)
