### PR TITLE
Split pod evictor and evictor filter

### DIFF
--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -320,15 +320,25 @@ func TestFindDuplicatePods(t *testing.T) {
 				nil,
 				nil,
 				testCase.nodes,
+				false,
+			)
+
+			nodeFit := false
+			if testCase.strategy.Params != nil {
+				nodeFit = testCase.strategy.Params.NodeFit
+			}
+
+			evictorFilter := evictions.NewEvictorFilter(
+				testCase.nodes,
 				getPodsAssignedToNode,
 				false,
 				false,
 				false,
 				false,
-				false,
+				evictions.WithNodeFit(nodeFit),
 			)
 
-			RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+			RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != testCase.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)
@@ -748,15 +758,19 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 				nil,
 				nil,
 				testCase.nodes,
-				getPodsAssignedToNode,
 				false,
+			)
+
+			evictorFilter := evictions.NewEvictorFilter(
+				testCase.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,
 				false,
 			)
 
-			RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+			RemoveDuplicatePods(ctx, fakeClient, testCase.strategy, testCase.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != testCase.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", testCase.description, testCase.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -222,15 +222,25 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
+				false,
+			)
+
+			nodeFit := false
+			if tc.strategy.Params != nil {
+				nodeFit = tc.strategy.Params.NodeFit
+			}
+
+			evictorFilter := evictions.NewEvictorFilter(
+				tc.nodes,
 				getPodsAssignedToNode,
 				false,
 				false,
 				false,
 				false,
-				false,
+				evictions.WithNodeFit(nodeFit),
 			)
 
-			RemovePodsViolatingNodeAffinity(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			RemovePodsViolatingNodeAffinity(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -338,11 +338,6 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
-				getPodsAssignedToNode,
-				tc.evictLocalStoragePods,
-				tc.evictSystemCriticalPods,
-				false,
-				false,
 				false,
 			)
 
@@ -354,7 +349,17 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				},
 			}
 
-			RemovePodsViolatingNodeTaints(ctx, fakeClient, strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			evictorFilter := evictions.NewEvictorFilter(
+				tc.nodes,
+				getPodsAssignedToNode,
+				tc.evictLocalStoragePods,
+				tc.evictSystemCriticalPods,
+				false,
+				false,
+				evictions.WithNodeFit(tc.nodeFit),
+			)
+
+			RemovePodsViolatingNodeTaints(ctx, fakeClient, strategy, tc.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, Unexpected no of pods evicted: pods evicted: %d, expected: %d", tc.description, actualEvictedPodCount, tc.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
@@ -507,11 +507,6 @@ func TestHighNodeUtilization(t *testing.T) {
 				nil,
 				nil,
 				testCase.nodes,
-				getPodsAssignedToNode,
-				false,
-				false,
-				false,
-				false,
 				false,
 			)
 
@@ -524,7 +519,18 @@ func TestHighNodeUtilization(t *testing.T) {
 					NodeFit: true,
 				},
 			}
-			HighNodeUtilization(ctx, fakeClient, strategy, testCase.nodes, podEvictor, getPodsAssignedToNode)
+
+			evictorFilter := evictions.NewEvictorFilter(
+				testCase.nodes,
+				getPodsAssignedToNode,
+				false,
+				false,
+				false,
+				false,
+				evictions.WithNodeFit(strategy.Params.NodeFit),
+			)
+
+			HighNodeUtilization(ctx, fakeClient, strategy, testCase.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 
 			podsEvicted := podEvictor.TotalEvicted()
 			if testCase.expectedPodsEvicted != podsEvicted {
@@ -713,15 +719,19 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 				&item.evictionsExpected,
 				nil,
 				item.nodes,
-				getPodsAssignedToNode,
 				false,
+			)
+
+			evictorFilter := evictions.NewEvictorFilter(
+				item.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,
 				false,
 			)
 
-			HighNodeUtilization(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
+			HighNodeUtilization(ctx, fakeClient, strategy, item.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 
 			if item.evictionsExpected != podEvictor.TotalEvicted() {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, podEvictor.TotalEvicted())

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
@@ -772,11 +772,6 @@ func TestLowNodeUtilization(t *testing.T) {
 				nil,
 				nil,
 				test.nodes,
-				getPodsAssignedToNode,
-				false,
-				false,
-				false,
-				false,
 				false,
 			)
 
@@ -791,7 +786,18 @@ func TestLowNodeUtilization(t *testing.T) {
 					NodeFit: true,
 				},
 			}
-			LowNodeUtilization(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
+
+			evictorFilter := evictions.NewEvictorFilter(
+				test.nodes,
+				getPodsAssignedToNode,
+				false,
+				false,
+				false,
+				false,
+				evictions.WithNodeFit(strategy.Params.NodeFit),
+			)
+
+			LowNodeUtilization(ctx, fakeClient, strategy, test.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 
 			podsEvicted := podEvictor.TotalEvicted()
 			if test.expectedPodsEvicted != podsEvicted {
@@ -1087,15 +1093,19 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				&item.evictionsExpected,
 				nil,
 				item.nodes,
-				getPodsAssignedToNode,
 				false,
+			)
+
+			evictorFilter := evictions.NewEvictorFilter(
+				item.nodes,
+				getPodsAssignedToNode,
 				false,
 				false,
 				false,
 				false,
 			)
 
-			LowNodeUtilization(ctx, fakeClient, strategy, item.nodes, podEvictor, getPodsAssignedToNode)
+			LowNodeUtilization(ctx, fakeClient, strategy, item.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 
 			if item.evictionsExpected != podEvictor.TotalEvicted() {
 				t.Errorf("Expected %v evictions, got %v", item.evictionsExpected, podEvictor.TotalEvicted())

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -218,11 +218,6 @@ func TestPodAntiAffinity(t *testing.T) {
 				test.maxPodsToEvictPerNode,
 				test.maxNoOfPodsToEvictPerNamespace,
 				test.nodes,
-				getPodsAssignedToNode,
-				false,
-				false,
-				false,
-				false,
 				false,
 			)
 			strategy := api.DeschedulerStrategy{
@@ -231,7 +226,17 @@ func TestPodAntiAffinity(t *testing.T) {
 				},
 			}
 
-			RemovePodsViolatingInterPodAntiAffinity(ctx, fakeClient, strategy, test.nodes, podEvictor, getPodsAssignedToNode)
+			evictorFilter := evictions.NewEvictorFilter(
+				test.nodes,
+				getPodsAssignedToNode,
+				false,
+				false,
+				false,
+				false,
+				evictions.WithNodeFit(test.nodeFit),
+			)
+
+			RemovePodsViolatingInterPodAntiAffinity(ctx, fakeClient, strategy, test.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != test.expectedEvictedPodCount {
 				t.Errorf("Unexpected no of pods evicted: pods evicted: %d, expected: %d", podsEvicted, test.expectedEvictedPodCount)

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -340,15 +340,19 @@ func TestPodLifeTime(t *testing.T) {
 				tc.maxPodsToEvictPerNode,
 				tc.maxPodsToEvictPerNamespace,
 				tc.nodes,
+				false,
+			)
+
+			evictorFilter := evictions.NewEvictorFilter(
+				tc.nodes,
 				getPodsAssignedToNode,
 				false,
 				false,
 				tc.ignorePvcPods,
 				false,
-				false,
 			)
 
-			PodLifeTime(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			PodLifeTime(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != tc.expectedEvictedPodCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.description, tc.expectedEvictedPodCount, podsEvicted)

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -250,15 +250,20 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
+				false,
+			)
+
+			evictorFilter := evictions.NewEvictorFilter(
+				tc.nodes,
 				getPodsAssignedToNode,
 				false,
 				false,
 				false,
 				false,
-				false,
+				evictions.WithNodeFit(tc.strategy.Params.NodeFit),
 			)
 
-			RemovePodsHavingTooManyRestarts(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+			RemovePodsHavingTooManyRestarts(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			actualEvictedPodCount := podEvictor.TotalEvicted()
 			if actualEvictedPodCount != tc.expectedEvictedPodCount {
 				t.Errorf("Test %#v failed, expected %v pod evictions, but got %v pod evictions\n", tc.description, tc.expectedEvictedPodCount, actualEvictedPodCount)

--- a/pkg/descheduler/strategies/topologyspreadconstraint.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint.go
@@ -46,12 +46,14 @@ type topology struct {
 	pods []*v1.Pod
 }
 
+// nolint: gocyclo
 func RemovePodsViolatingTopologySpreadConstraint(
 	ctx context.Context,
 	client clientset.Interface,
 	strategy api.DeschedulerStrategy,
 	nodes []*v1.Node,
 	podEvictor *evictions.PodEvictor,
+	evictorFilter *evictions.EvictorFilter,
 	getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc,
 ) {
 	strategyParams, err := validation.ValidateAndParseStrategyParams(ctx, client, strategy.Params)
@@ -60,11 +62,13 @@ func RemovePodsViolatingTopologySpreadConstraint(
 		return
 	}
 
-	evictable := podEvictor.Evictable(
-		evictions.WithPriorityThreshold(strategyParams.ThresholdPriority),
-		evictions.WithNodeFit(strategyParams.NodeFit),
-		evictions.WithLabelSelector(strategyParams.LabelSelector),
-	)
+	isEvictable := evictorFilter.Filter
+
+	if strategyParams.LabelSelector != nil && !strategyParams.LabelSelector.Empty() {
+		isEvictable = podutil.WrapFilterFuncs(isEvictable, func(pod *v1.Pod) bool {
+			return strategyParams.LabelSelector.Matches(labels.Set(pod.Labels))
+		})
+	}
 
 	nodeMap := make(map[string]*v1.Node, len(nodes))
 	for _, node := range nodes {
@@ -168,12 +172,12 @@ func RemovePodsViolatingTopologySpreadConstraint(
 				klog.V(2).InfoS("Skipping topology constraint because it is already balanced", "constraint", constraint)
 				continue
 			}
-			balanceDomains(client, getPodsAssignedToNode, podsForEviction, constraint, constraintTopologies, sumPods, evictable.IsEvictable, nodes)
+			balanceDomains(client, getPodsAssignedToNode, podsForEviction, constraint, constraintTopologies, sumPods, evictorFilter.Filter, nodes)
 		}
 	}
 
 	for pod := range podsForEviction {
-		if !evictable.IsEvictable(pod) {
+		if !isEvictable(pod) {
 			continue
 		}
 		if _, err := podEvictor.EvictPod(ctx, pod, nodeMap[pod.Spec.NodeName], "PodTopologySpread"); err != nil {
@@ -234,6 +238,7 @@ func balanceDomains(
 
 	idealAvg := sumPods / float64(len(constraintTopologies))
 	sortedDomains := sortDomains(constraintTopologies, isEvictable)
+
 	// i is the index for belowOrEqualAvg
 	// j is the index for aboveAvg
 	i := 0

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -971,14 +971,25 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				nil,
 				nil,
 				tc.nodes,
+				false,
+			)
+
+			nodeFit := false
+			if tc.strategy.Params != nil {
+				nodeFit = tc.strategy.Params.NodeFit
+			}
+
+			evictorFilter := evictions.NewEvictorFilter(
+				tc.nodes,
 				getPodsAssignedToNode,
 				false,
 				false,
 				false,
 				false,
-				false,
+				evictions.WithNodeFit(nodeFit),
 			)
-			RemovePodsViolatingTopologySpreadConstraint(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, getPodsAssignedToNode)
+
+			RemovePodsViolatingTopologySpreadConstraint(ctx, fakeClient, tc.strategy, tc.nodes, podEvictor, evictorFilter, getPodsAssignedToNode)
 			podsEvicted := podEvictor.TotalEvicted()
 			if podsEvicted != tc.expectedEvictedCount {
 				t.Errorf("Test error for description: %s. Expected evicted pods count %v, got %v", tc.name, tc.expectedEvictedCount, podsEvicted)

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -145,11 +145,6 @@ func TestRemoveDuplicates(t *testing.T) {
 				nil,
 				nil,
 				nodes,
-				getPodsAssignedToNode,
-				true,
-				false,
-				false,
-				false,
 				false,
 			)
 
@@ -165,6 +160,14 @@ func TestRemoveDuplicates(t *testing.T) {
 				},
 				workerNodes,
 				podEvictor,
+				evictions.NewEvictorFilter(
+					nodes,
+					getPodsAssignedToNode,
+					true,
+					false,
+					false,
+					false,
+				),
 				getPodsAssignedToNode,
 			)
 

--- a/test/e2e/e2e_failedpods_test.go
+++ b/test/e2e/e2e_failedpods_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	"sigs.k8s.io/descheduler/pkg/descheduler/strategies"
 )
 
@@ -96,6 +97,14 @@ func TestFailedPods(t *testing.T) {
 				},
 				nodes,
 				podEvictor,
+				evictions.NewEvictorFilter(
+					nodes,
+					getPodsAssignedToNode,
+					true,
+					false,
+					false,
+					false,
+				),
 				getPodsAssignedToNode,
 			)
 			t.Logf("Finished RemoveFailedPods strategy for %s", name)

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -138,13 +138,9 @@ func TestTooManyRestarts(t *testing.T) {
 				nil,
 				nil,
 				nodes,
-				getPodsAssignedToNode,
-				true,
-				false,
-				false,
-				false,
 				false,
 			)
+
 			// Run RemovePodsHavingTooManyRestarts strategy
 			t.Log("Running RemovePodsHavingTooManyRestarts strategy")
 			strategies.RemovePodsHavingTooManyRestarts(
@@ -161,6 +157,14 @@ func TestTooManyRestarts(t *testing.T) {
 				},
 				workerNodes,
 				podEvictor,
+				evictions.NewEvictorFilter(
+					nodes,
+					getPodsAssignedToNode,
+					true,
+					false,
+					false,
+					false,
+				),
 				getPodsAssignedToNode,
 			)
 

--- a/test/e2e/e2e_topologyspreadconstraint_test.go
+++ b/test/e2e/e2e_topologyspreadconstraint_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	"sigs.k8s.io/descheduler/pkg/descheduler/strategies"
 )
 
@@ -92,6 +93,14 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				},
 				nodes,
 				podEvictor,
+				evictions.NewEvictorFilter(
+					nodes,
+					getPodsAssignedToNode,
+					true,
+					false,
+					false,
+					false,
+				),
 				getPodsAssignedToNode,
 			)
 			t.Logf("Finished RemovePodsViolatingTopologySpreadConstraint strategy for %s", name)


### PR DESCRIPTION
The evictor filter is planned to be moved under a plugin. In order to initialize the evictor filter outside of the strategies, the `PodEvictor` is split into a pod evictor (responsible for actually evicting pods) and an evictor filter (responsible for deciding whether a pod can be evicted).

Pre-requisite for https://github.com/kubernetes-sigs/descheduler/issues/837