### PR TITLE
Check existing constraints before assigning

### DIFF
--- a/pkg/descheduler/strategies/topologyspreadconstraint.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint.go
@@ -19,6 +19,7 @@ package strategies
 import (
 	"context"
 	"math"
+	"reflect"
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
@@ -111,6 +112,12 @@ func RemovePodsViolatingTopologySpreadConstraint(
 				if constraint.WhenUnsatisfiable == v1.ScheduleAnyway && (strategy.Params == nil || !strategy.Params.IncludeSoftConstraints) {
 					continue
 				}
+				// Need to check v1.TopologySpreadConstraint deepEquality because 
+				// v1.TopologySpreadConstraint.LabelSelector is a pointer 
+				// and assigning new constrains would always add more keys
+				if checkIdenticalConstraints(constraint, namespaceTopologySpreadConstraints) {
+					continue
+				}
 				namespaceTopologySpreadConstraints[constraint] = struct{}{}
 			}
 		}
@@ -181,6 +188,15 @@ func RemovePodsViolatingTopologySpreadConstraint(
 			break
 		}
 	}
+}
+
+func checkIdenticalConstraints(newConstraint v1.TopologySpreadConstraint, namespaceTopologySpreadConstraints map[v1.TopologySpreadConstraint]struct{}) bool {
+	for constraint := range namespaceTopologySpreadConstraints {
+		if reflect.DeepEqual(newConstraint, constraint){
+			return true
+		}
+	}
+	return false
 }
 
 // topologyIsBalanced checks if any domains in the topology differ by more than the MaxSkew


### PR DESCRIPTION
We need to check v1.TopologySpreadConstraint deepEquality because two v1.TopologySpreadConstraints are not the same (even with same content) since they have one field that is a pointer (LabelSelector). So when we do the `namespaceTopologySpreadConstraints[constraint] = struct{}{}` we are creating a new key every time. Now that we check their deep equality, v1.TopologySpreadConstraints with same content will be inserted as the same key in the assignment.