### PR TITLE
Check existing constraints before assigning

### DIFF
--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -1043,47 +1043,51 @@ func getDefaultTopologyConstraints(maxSkew int32) []v1.TopologySpreadConstraint 
 }
 
 func TestCheckIdenticalConstraints(t *testing.T) {
-	newConstrainSame := v1.TopologySpreadConstraint{
+	newConstraintSame := v1.TopologySpreadConstraint{
 		MaxSkew:           2,
 		TopologyKey:       "zone",
 		WhenUnsatisfiable: v1.DoNotSchedule,
 		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 	}
-	newConstrainDifferent := v1.TopologySpreadConstraint{
+	newConstraintDifferent := v1.TopologySpreadConstraint{
 		MaxSkew:           3,
 		TopologyKey:       "node",
 		WhenUnsatisfiable: v1.DoNotSchedule,
 		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
 	}
-	namespaceTopologySpreadConstraint := make(map[v1.TopologySpreadConstraint]struct{})
-	namespaceTopologySpreadConstraint[v1.TopologySpreadConstraint{
-		MaxSkew:           2,
-		TopologyKey:       "zone",
-		WhenUnsatisfiable: v1.DoNotSchedule,
-		LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
-	}] = struct{}{}
+	namespaceTopologySpreadConstraint := []v1.TopologySpreadConstraint{}
+	namespaceTopologySpreadConstraint = []v1.TopologySpreadConstraint{
+		{
+			MaxSkew:           2,
+			TopologyKey:       "zone",
+			WhenUnsatisfiable: v1.DoNotSchedule,
+			LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+		},
+	}
 	testCases := []struct {
 		name                               string
-		namespaceTopologySpreadConstraints map[v1.TopologySpreadConstraint]struct{}
+		namespaceTopologySpreadConstraints []v1.TopologySpreadConstraint
 		newConstraint                      v1.TopologySpreadConstraint
 		expectedResult                     bool
 	}{
 		{
 			name:                               "new constraint is identical",
 			namespaceTopologySpreadConstraints: namespaceTopologySpreadConstraint,
-			newConstraint:                      newConstrainSame, expectedResult: true},
+			newConstraint:                      newConstraintSame,
+			expectedResult:                     true,
+		},
 		{
 			name:                               "new constraint is different",
 			namespaceTopologySpreadConstraints: namespaceTopologySpreadConstraint,
-			newConstraint:                      newConstrainDifferent, expectedResult: false,
+			newConstraint:                      newConstraintDifferent,
+			expectedResult:                     false,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			isIdentitcal := hasIdenticalConstraints(tc.newConstraint, tc.namespaceTopologySpreadConstraints)
-			if isIdentitcal != tc.expectedResult {
-				t.Errorf("Test error for description: %s. Expected result %v, got %v", tc.name, tc.expectedResult, isIdentitcal)
+			isIdentical := hasIdenticalConstraints(tc.newConstraint, tc.namespaceTopologySpreadConstraints)
+			if isIdentical != tc.expectedResult {
+				t.Errorf("Test error for description: %s. Expected result %v, got %v", tc.name, tc.expectedResult, isIdentical)
 			}
 		})
 	}


### PR DESCRIPTION
We need to check v1.TopologySpreadConstraint deepEquality because two v1.TopologySpreadConstraints are not the same (even with same content) since they have one field that is a pointer (LabelSelector). So when we do the namespaceTopologySpreadConstraints[constraint] = struct{}{} we are creating a new key every time. Now that we check their deep equality, v1.TopologySpreadConstraints with same content will be inserted as the same key in the assignment.

(recreated it, again)