### PR TITLE
add warning when enabling both dryRun and leaderElection

### DIFF
--- a/charts/descheduler/templates/NOTES.txt
+++ b/charts/descheduler/templates/NOTES.txt
@@ -4,4 +4,9 @@ Descheduler installed as a {{ .Values.kind }}.
 {{- if eq .Values.replicas 1.0}}
 WARNING: You set replica count as 1 and workload kind as Deployment however leaderElection is not enabled. Consider enabling Leader Election for HA mode.
 {{- end}}
+{{- if .Values.leaderElection }}
+{{- if and (hasKey .Values.cmdOptions "dry-run") (eq (get .Values.cmdOptions "dry-run") true) }}
+WARNING: You enabled DryRun mode, you can't use Leader Election.
+{{- end}}
+{{- end}}
 {{- end}}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -46,6 +46,7 @@ replicas: 1
 
 # Specifies whether Leader Election resources should be created
 # Required when running as a Deployment
+# NOTE: Leader election can't be activated if DryRun enabled
 leaderElection: {}
 #  enabled: true
 #  leaseDuration: 15s

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -79,6 +79,10 @@ func Run(ctx context.Context, rs *options.DeschedulerServer) error {
 		return fmt.Errorf("leaderElection must be used with deschedulingInterval")
 	}
 
+	if rs.LeaderElection.LeaderElect && rs.DryRun {
+		klog.V(1).InfoS("Warning: DryRun is set to True. You need to disable it to use Leader Election.")
+	}
+
 	if rs.LeaderElection.LeaderElect && !rs.DryRun {
 		if err := NewLeaderElection(runFn, rsclient, &rs.LeaderElection, ctx); err != nil {
 			return fmt.Errorf("leaderElection: %w", err)


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>
Co-authored-by: Emin <emin.aktas@trendyol.com>

We've tried to install Descheduler using Helm chart and enabled both `dryRun` and `leaderElection` mode in `values.yaml`. And noticed leader election does not work due to `dryRun` activated. So thought a warning might be useful in this case.