### PR TITLE
fix: chart path can´t be relative

### DIFF
--- a/.github/ci/ct.yaml
+++ b/.github/ci/ct.yaml
@@ -1,5 +1,5 @@
 chart-dirs:
-  - ./charts
+  - charts
 helm-extra-args: "--timeout=5m"
 check-version-increment: false
 target-branch: master


### PR DESCRIPTION
For context:

- I created a PR to check if the CI would fail with a broken template:
https://github.com/kubernetes-sigs/descheduler/pull/870

- It didn't:
https://github.com/kubernetes-sigs/descheduler/pull/870/checks

- Turns out the culprit was just the ./charts path at the config file in .github/ci/ct.yaml

There are a few other things worth discussing here:

- Chart testing is complaining about using Kubernetes SIG Scheduling as the maintainer of the chart. It expects a valid github/gitlab/something user. @damemi @ingvagabund Who should I put there? I can also put my name there if it is appropriate, now that I am making changes here.

- I still need to add chart-testing installation checking. Will do that after linting is green.