### PR TITLE
Use lease resource name from Helm value

### DIFF
--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
   verbs: ["create", "update"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  resourceNames: ["descheduler"]
+  resourceNames: ["{{ .Values.leaderElection.resourceName }}"]
   verbs: ["get", "patch", "delete"]
 {{- end }}
 {{- if .Values.podSecurityPolicy.create }}


### PR DESCRIPTION
This PR makes the lease name of Helm value and the ClusterRole's lease resource name consistent.