### PR TITLE
Add default lease resource name in Helm chart's ClusterRole

### DIFF
--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -30,7 +30,7 @@ rules:
   verbs: ["create", "update"]
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]
-  resourceNames: ["{{ .Values.leaderElection.resourceName }}"]
+  resourceNames: ["{{ .Values.leaderElection.resourceName | default "descheduler" }}"]
   verbs: ["get", "patch", "delete"]
 {{- end }}
 {{- if .Values.podSecurityPolicy.create }}


### PR DESCRIPTION
Ref. #876 #881
This PR adds the default value for the lease resource name in Helm chart's ClusterRole.