### PR TITLE
Stop redeclaring and re-starting structured logging

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -275,6 +276,8 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		} else {
 			podEvictorClient = rs.Client
 		}
+		eventBroadcaster := record.NewBroadcaster()
+		eventBroadcaster.StartStructuredLogging(3)
 
 		klog.V(3).Infof("Building a pod evictor")
 		podEvictor := evictions.NewPodEvictor(
@@ -285,6 +288,7 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 			deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace,
 			nodes,
 			!rs.DisableMetrics,
+			eventBroadcaster,
 		)
 
 		for name, strategy := range deschedulerPolicy.Strategies {

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -313,6 +314,9 @@ func TestFindDuplicatePods(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"v1",
@@ -321,6 +325,7 @@ func TestFindDuplicatePods(t *testing.T) {
 				nil,
 				testCase.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			nodeFit := false
@@ -751,6 +756,9 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -759,6 +767,7 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 				nil,
 				testCase.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/failedpods_test.go
+++ b/pkg/descheduler/strategies/failedpods_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -268,6 +269,9 @@ func TestRemoveFailedPods(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -276,6 +280,7 @@ func TestRemoveFailedPods(t *testing.T) {
 				nil,
 				tc.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -215,6 +216,9 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -223,6 +227,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			nodeFit := false

--- a/pkg/descheduler/strategies/node_taint_test.go
+++ b/pkg/descheduler/strategies/node_taint_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -331,6 +332,9 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -339,6 +343,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			strategy := api.DeschedulerStrategy{

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -500,6 +501,9 @@ func TestHighNodeUtilization(t *testing.T) {
 			//	return true, nil, fmt.Errorf("Wrong node: %v", getAction.GetName())
 			//})
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"v1",
@@ -508,6 +512,7 @@ func TestHighNodeUtilization(t *testing.T) {
 				nil,
 				testCase.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			strategy := api.DeschedulerStrategy{
@@ -712,6 +717,9 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"policy/v1",
@@ -720,6 +728,7 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 				nil,
 				item.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -765,6 +766,9 @@ func TestLowNodeUtilization(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -773,6 +777,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				nil,
 				test.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			strategy := api.DeschedulerStrategy{
@@ -1086,6 +1091,9 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -1094,6 +1102,7 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				nil,
 				item.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -211,6 +212,9 @@ func TestPodAntiAffinity(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -219,6 +223,7 @@ func TestPodAntiAffinity(t *testing.T) {
 				test.maxNoOfPodsToEvictPerNamespace,
 				test.nodes,
 				false,
+				eventBroadcaster,
 			)
 			strategy := api.DeschedulerStrategy{
 				Params: &api.StrategyParameters{

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -389,6 +390,9 @@ func TestPodLifeTime(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -397,6 +401,7 @@ func TestPodLifeTime(t *testing.T) {
 				tc.maxPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -243,6 +244,9 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -251,6 +255,7 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -1215,6 +1216,9 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				return false, nil, nil // fallback to the default reactor
 			})
 
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"v1",
@@ -1223,6 +1227,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				nil,
 				tc.nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			nodeFit := false

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -138,6 +139,10 @@ func TestRemoveDuplicates(t *testing.T) {
 			if err != nil || len(evictionPolicyGroupVersion) == 0 {
 				t.Fatalf("Error creating eviction policy group %v", err)
 			}
+
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				clientSet,
 				evictionPolicyGroupVersion,
@@ -146,6 +151,7 @@ func TestRemoveDuplicates(t *testing.T) {
 				nil,
 				nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			t.Log("Running DeschedulerStrategy strategy")

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	v1qos "k8s.io/kubectl/pkg/util/qos"
 	"k8s.io/utils/pointer"
 
@@ -206,6 +207,7 @@ func runPodLifetimeStrategy(
 			maxPodsToEvictPerNamespace,
 			nodes,
 			false,
+			nil,
 		),
 		evictions.NewEvictorFilter(
 			nodes,
@@ -1424,6 +1426,10 @@ func initPodEvictorOrFail(t *testing.T, clientSet clientset.Interface, getPodsAs
 	if err != nil || len(evictionPolicyGroupVersion) == 0 {
 		t.Fatalf("Error creating eviction policy group: %v", err)
 	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(3)
+
 	return evictions.NewPodEvictor(
 		clientSet,
 		evictionPolicyGroupVersion,
@@ -1432,5 +1438,6 @@ func initPodEvictorOrFail(t *testing.T, clientSet clientset.Interface, getPodsAs
 		nil,
 		nodes,
 		false,
+		eventBroadcaster,
 	)
 }

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -131,6 +132,10 @@ func TestTooManyRestarts(t *testing.T) {
 			if err != nil || len(evictionPolicyGroupVersion) == 0 {
 				t.Fatalf("Error creating eviction policy group: %v", err)
 			}
+
+			eventBroadcaster := record.NewBroadcaster()
+			eventBroadcaster.StartStructuredLogging(3)
+
 			podEvictor := evictions.NewPodEvictor(
 				clientSet,
 				evictionPolicyGroupVersion,
@@ -139,6 +144,7 @@ func TestTooManyRestarts(t *testing.T) {
 				nil,
 				nodes,
 				false,
+				eventBroadcaster,
 			)
 
 			// Run RemovePodsHavingTooManyRestarts strategy


### PR DESCRIPTION
Fixes #884

Did a bit more investigation and this is the graph of the same setup without this change (green) and with this change (yellow):

![image](https://user-images.githubusercontent.com/2432275/180223214-c76668de-b3f1-4f8f-beb0-db2df12ef4ce.png)

So removing eventBroadcaster + StartStructuredLogging from the loop fixes the leak. (specially StartStructuredLogging() call)

I am not sure I should be passing the Broadcaster as a new field of PodEvictor as I am doing right now, please let me know.

It should affect other strategies, but it affected only RemoveDuplicates in my case because of the scenario that I had (bunch of deployments with a bunch of replicas), so it had evictions every time at every cycle. (I think that any user with a lot of eveitions at every cycle, in any strategy, should be saying memory going up because of this issue...)