### PR TITLE
fix: events memory leak. Using new events implementation and take recorder out of EvictPod

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -18,6 +18,8 @@ limitations under the License.
 package options
 
 import (
+	"time"
+
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -27,7 +29,6 @@ import (
 	"sigs.k8s.io/descheduler/pkg/apis/componentconfig"
 	"sigs.k8s.io/descheduler/pkg/apis/componentconfig/v1alpha1"
 	deschedulerscheme "sigs.k8s.io/descheduler/pkg/descheduler/scheme"
-	"time"
 )
 
 const (
@@ -39,6 +40,7 @@ type DeschedulerServer struct {
 	componentconfig.DeschedulerConfiguration
 
 	Client         clientset.Interface
+	EventClient    clientset.Interface
 	SecureServing  *apiserveroptions.SecureServingOptionsWithLoopback
 	DisableMetrics bool
 }

--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: descheduler-cluster-role
 rules:
-- apiGroups: [""]
+- apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "update"]
 - apiGroups: [""]

--- a/pkg/descheduler/client/client.go
+++ b/pkg/descheduler/client/client.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func CreateClient(kubeconfig string) (clientset.Interface, error) {
+func CreateClient(kubeconfig string, userAgt string) (clientset.Interface, error) {
 	var cfg *rest.Config
 	if len(kubeconfig) != 0 {
 		master, err := GetMasterFromKubeconfig(kubeconfig)
@@ -47,7 +47,11 @@ func CreateClient(kubeconfig string) (clientset.Interface, error) {
 		}
 	}
 
-	return clientset.NewForConfig(cfg)
+	if len(userAgt) != 0 {
+		return clientset.NewForConfig(rest.AddUserAgent(cfg, userAgt))
+	} else {
+		return clientset.NewForConfig(cfg)
+	}
 }
 
 func GetMasterFromKubeconfig(filename string) (string, error) {

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -27,6 +27,7 @@ func TestTaintsUpdated(t *testing.T) {
 	}
 
 	client := fakeclientset.NewSimpleClientset(n1, n2, p1)
+	eventClient := fakeclientset.NewSimpleClientset(n1, n2, p1)
 	dp := &api.DeschedulerPolicy{
 		Strategies: api.StrategyList{
 			"RemovePodsViolatingNodeTaints": api.DeschedulerStrategy{
@@ -40,6 +41,7 @@ func TestTaintsUpdated(t *testing.T) {
 		t.Fatalf("Unable to initialize server: %v", err)
 	}
 	rs.Client = client
+	rs.EventClient = eventClient
 	rs.DeschedulingInterval = 100 * time.Millisecond
 	errChan := make(chan error, 1)
 	defer close(errChan)
@@ -104,6 +106,7 @@ func TestRootCancel(t *testing.T) {
 	n1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
 	n2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
 	client := fakeclientset.NewSimpleClientset(n1, n2)
+	eventClient := fakeclientset.NewSimpleClientset(n1, n2)
 	dp := &api.DeschedulerPolicy{
 		Strategies: api.StrategyList{}, // no strategies needed for this test
 	}
@@ -113,6 +116,7 @@ func TestRootCancel(t *testing.T) {
 		t.Fatalf("Unable to initialize server: %v", err)
 	}
 	rs.Client = client
+	rs.EventClient = eventClient
 	rs.DeschedulingInterval = 100 * time.Millisecond
 	errChan := make(chan error, 1)
 	defer close(errChan)
@@ -137,6 +141,7 @@ func TestRootCancelWithNoInterval(t *testing.T) {
 	n1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
 	n2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
 	client := fakeclientset.NewSimpleClientset(n1, n2)
+	eventClient := fakeclientset.NewSimpleClientset(n1, n2)
 	dp := &api.DeschedulerPolicy{
 		Strategies: api.StrategyList{}, // no strategies needed for this test
 	}
@@ -146,6 +151,7 @@ func TestRootCancelWithNoInterval(t *testing.T) {
 		t.Fatalf("Unable to initialize server: %v", err)
 	}
 	rs.Client = client
+	rs.EventClient = eventClient
 	rs.DeschedulingInterval = 0
 	errChan := make(chan error, 1)
 	defer close(errChan)

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -27,9 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
-	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/metrics"
 	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
@@ -57,6 +55,7 @@ type PodEvictor struct {
 	nodepodCount               nodePodEvictedCount
 	namespacePodCount          namespacePodEvictCount
 	metricsEnabled             bool
+	eventRecorder              events.EventRecorder
 }
 
 func NewPodEvictor(
@@ -67,6 +66,7 @@ func NewPodEvictor(
 	maxPodsToEvictPerNamespace *uint,
 	nodes []*v1.Node,
 	metricsEnabled bool,
+	eventRecorder events.EventRecorder,
 ) *PodEvictor {
 	var nodePodCount = make(nodePodEvictedCount)
 	var namespacePodCount = make(namespacePodEvictCount)
@@ -85,6 +85,7 @@ func NewPodEvictor(
 		nodepodCount:               nodePodCount,
 		namespacePodCount:          namespacePodCount,
 		metricsEnabled:             metricsEnabled,
+		eventRecorder:              eventRecorder,
 	}
 }
 
@@ -166,11 +167,14 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 		klog.V(1).InfoS("Evicted pod in dry run mode", "pod", klog.KObj(pod), "reason", opts.Reason, "strategy", strategy, "node", pod.Spec.NodeName)
 	} else {
 		klog.V(1).InfoS("Evicted pod", "pod", klog.KObj(pod), "reason", opts.Reason, "strategy", strategy, "node", pod.Spec.NodeName)
-		eventBroadcaster := record.NewBroadcaster()
-		eventBroadcaster.StartStructuredLogging(3)
-		eventBroadcaster.StartRecordingToSink(&clientcorev1.EventSinkImpl{Interface: pe.client.CoreV1().Events(pod.Namespace)})
-		r := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "sigs.k8s.io.descheduler"})
-		r.Event(pod, v1.EventTypeNormal, "Descheduled", fmt.Sprintf("pod evicted by sigs.k8s.io/descheduler%s", opts.Reason))
+		reason := opts.Reason
+		if len(reason) == 0 {
+			reason = strategy
+			if len(reason) == 0 {
+				reason = "NotSet"
+			}
+		}
+		pe.eventRecorder.Eventf(pod, nil, v1.EventTypeNormal, reason, "Descheduled", "pod evicted by sigs.k8s.io/descheduler")
 	}
 	return true
 }

--- a/pkg/descheduler/strategies/duplicates_test.go
+++ b/pkg/descheduler/strategies/duplicates_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -313,6 +314,8 @@ func TestFindDuplicatePods(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"v1",
@@ -321,6 +324,7 @@ func TestFindDuplicatePods(t *testing.T) {
 				nil,
 				testCase.nodes,
 				false,
+				eventRecorder,
 			)
 
 			nodeFit := false
@@ -751,6 +755,8 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -759,6 +765,7 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 				nil,
 				testCase.nodes,
 				false,
+				eventRecorder,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/failedpods_test.go
+++ b/pkg/descheduler/strategies/failedpods_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -268,6 +269,8 @@ func TestRemoveFailedPods(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -276,6 +279,7 @@ func TestRemoveFailedPods(t *testing.T) {
 				nil,
 				tc.nodes,
 				false,
+				eventRecorder,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/node_affinity_test.go
+++ b/pkg/descheduler/strategies/node_affinity_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -215,6 +216,8 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -223,6 +226,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventRecorder,
 			)
 
 			nodeFit := false

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -500,6 +501,8 @@ func TestHighNodeUtilization(t *testing.T) {
 			//	return true, nil, fmt.Errorf("Wrong node: %v", getAction.GetName())
 			//})
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"v1",
@@ -508,6 +511,7 @@ func TestHighNodeUtilization(t *testing.T) {
 				nil,
 				testCase.nodes,
 				false,
+				eventRecorder,
 			)
 
 			strategy := api.DeschedulerStrategy{
@@ -712,6 +716,8 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"policy/v1",
@@ -720,6 +726,7 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 				nil,
 				item.nodes,
 				false,
+				eventRecorder,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/lownodeutilization_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -765,6 +766,8 @@ func TestLowNodeUtilization(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -773,6 +776,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				nil,
 				test.nodes,
 				false,
+				eventRecorder,
 			)
 
 			strategy := api.DeschedulerStrategy{
@@ -1086,6 +1090,8 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -1094,6 +1100,7 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				nil,
 				item.nodes,
 				false,
+				eventRecorder,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/pod_antiaffinity_test.go
+++ b/pkg/descheduler/strategies/pod_antiaffinity_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -211,6 +212,8 @@ func TestPodAntiAffinity(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -219,6 +222,7 @@ func TestPodAntiAffinity(t *testing.T) {
 				test.maxNoOfPodsToEvictPerNamespace,
 				test.nodes,
 				false,
+				eventRecorder,
 			)
 			strategy := api.DeschedulerStrategy{
 				Params: &api.StrategyParameters{

--- a/pkg/descheduler/strategies/pod_lifetime_test.go
+++ b/pkg/descheduler/strategies/pod_lifetime_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -389,6 +390,8 @@ func TestPodLifeTime(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -397,6 +400,7 @@ func TestPodLifeTime(t *testing.T) {
 				tc.maxPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventRecorder,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/toomanyrestarts_test.go
+++ b/pkg/descheduler/strategies/toomanyrestarts_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -243,6 +244,8 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -251,6 +254,7 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventRecorder,
 			)
 
 			evictorFilter := evictions.NewEvictorFilter(

--- a/pkg/descheduler/strategies/topologyspreadconstraint_test.go
+++ b/pkg/descheduler/strategies/topologyspreadconstraint_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -1215,6 +1216,8 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				return false, nil, nil // fallback to the default reactor
 			})
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				"v1",
@@ -1223,6 +1226,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				nil,
 				tc.nodes,
 				false,
+				eventRecorder,
 			)
 
 			nodeFit := false

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/events"
 
 	"sigs.k8s.io/descheduler/pkg/apis/componentconfig"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -349,6 +350,8 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
 				policyv1.SchemeGroupVersion.String(),
@@ -357,6 +360,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				tc.maxNoOfPodsToEvictPerNamespace,
 				tc.nodes,
 				false,
+				eventRecorder,
 			)
 
 			handle := &frameworkfake.HandleImpl{

--- a/pkg/utils/events.go
+++ b/pkg/utils/events.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"context"
+
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/events"
+)
+
+func GetRecorderAndBroadcaster(ctx context.Context, clientset clientset.Interface) (events.EventBroadcasterAdapter, events.EventRecorder) {
+	eventBroadcaster := events.NewEventBroadcasterAdapter(clientset)
+	eventBroadcaster.StartRecordingToSink(ctx.Done())
+	eventRecorder := eventBroadcaster.NewRecorder("sigs.k8s.io.descheduler")
+	return eventBroadcaster, eventRecorder
+}

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/pointer"
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -138,6 +139,9 @@ func TestRemoveDuplicates(t *testing.T) {
 			if err != nil || len(evictionPolicyGroupVersion) == 0 {
 				t.Fatalf("Error creating eviction policy group %v", err)
 			}
+
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				clientSet,
 				evictionPolicyGroupVersion,
@@ -146,6 +150,7 @@ func TestRemoveDuplicates(t *testing.T) {
 				nil,
 				nodes,
 				false,
+				eventRecorder,
 			)
 
 			t.Log("Running DeschedulerStrategy strategy")

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/pointer"
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -131,6 +132,9 @@ func TestTooManyRestarts(t *testing.T) {
 			if err != nil || len(evictionPolicyGroupVersion) == 0 {
 				t.Fatalf("Error creating eviction policy group: %v", err)
 			}
+
+			eventRecorder := &events.FakeRecorder{}
+
 			podEvictor := evictions.NewPodEvictor(
 				clientSet,
 				evictionPolicyGroupVersion,
@@ -139,6 +143,7 @@ func TestTooManyRestarts(t *testing.T) {
 				nil,
 				nodes,
 				false,
+				eventRecorder,
 			)
 
 			// Run RemovePodsHavingTooManyRestarts strategy


### PR DESCRIPTION
Fixes #884 

I was trying something around #887 but that did not do it. There I just mistakenly removed `StartRecordingToSink` which when reintroduced would cause the leak again. So you can just ignore that. (just mentioning to document attempts)

Shutting down eventBroadcaster seems to do the trick. If we look back to the [pprof top report for in use objects](https://github.com/kubernetes-sigs/descheduler/issues/884#issuecomment-1180547263) we see that we have something getting accumulated in k8s.io/apimachinery/pkg/watch.(*Broadcaster).Watch. I am guessing every time we call StartRecordingToSink that is when we start accumulating it.

Shutting down the eventBroadcaster right after we publish the event seems to stop this accumulation and it also seems to not affect the publication of the event itself (I kept monitoring some evicted pods in terminating state to be sure):

```
Events:
  Type    Reason          Age   From                     Message
  ----    ------          ----  ----                     -------
  Normal  Scheduled       2m    default-scheduler        Successfully assigned default/nginx-deployment-85d945584d-zvcps to ip-10-0-177-50.ec2.internal
  Normal  AddedInterface  116s  multus                   Add eth0 [10.130.2.231/23] from openshift-sdn
  Normal  Pulled          115s  kubelet                  Container image "k8s.gcr.io/pause:3.1" already present on machine
  Normal  Created         111s  kubelet                  Created container nginx
  Normal  Started         111s  kubelet                  Started container nginx
  Normal  Descheduled     29s   sigs.k8s.io.descheduler  pod evicted by sigs.k8s.io/descheduler
```


Here is new graph of memory consumption:

![image](https://user-images.githubusercontent.com/2432275/180248830-e73a74ce-3614-4554-9153-452caea084f2.png)
