### PR TITLE
HighNodeUtilization: support node rebalance when high utilized nodes empty

### DIFF
--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization.go
@@ -29,7 +29,47 @@ import (
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
+	"sigs.k8s.io/descheduler/pkg/utils"
 )
+
+// balanceNodes balance nodes from low utilized nodes to high utilized nodes. A corner case: All nodes are underutilized
+func balanceNodes(sourceNodes, destinationNodes []NodeInfo) ([]NodeInfo, []NodeInfo) {
+	if len(sourceNodes) == 0 || len(destinationNodes) > 0 {
+		return sourceNodes, destinationNodes
+	}
+	numOfBalanced := 0
+	partition := int(float64(len(sourceNodes)) * 0.5)
+	src := make([]NodeInfo, 0, partition)
+	dst := destinationNodes
+	hasImportantPods := func(node *NodeInfo) bool {
+		for _, pod := range node.allPods {
+			if utils.IsMirrorPod(pod) {
+				return true
+			}
+			if utils.IsPodWithPVC(pod) {
+				return true
+			}
+			if utils.IsCriticalPriorityPod(pod) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, node := range sourceNodes {
+		if nodeutil.IsNodeUnschedulable(node.node) {
+			src = append(src, node)
+			continue
+		}
+
+		if numOfBalanced < partition && !hasImportantPods(&node) {
+			numOfBalanced++
+			dst = append(dst, node)
+		} else {
+			src = append(src, node)
+		}
+	}
+	return src, dst
+}
 
 // HighNodeUtilization evicts pods from under utilized nodes so that scheduler can schedule according to its strategy.
 // Note that CPU/Memory requests are used to calculate nodes' utilization and not the actual resource usage.
@@ -82,6 +122,9 @@ func HighNodeUtilization(ctx context.Context, client clientset.Interface, strate
 	if len(sourceNodes) == 0 {
 		klog.V(1).InfoS("No node is underutilized, nothing to do here, you might tune your thresholds further")
 		return
+	}
+	if len(highNodes) == 0 {
+		sourceNodes, highNodes = balanceNodes(sourceNodes, highNodes)
 	}
 	if len(sourceNodes) <= strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes {
 		klog.V(1).InfoS("Number of nodes underutilized is less or equal than NumberOfNodes, nothing to do here", "underutilizedNodes", len(sourceNodes), "numberOfNodes", strategy.Params.NodeResourceUtilizationThresholds.NumberOfNodes)

--- a/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
+++ b/pkg/descheduler/strategies/nodeutilization/highnodeutilization_test.go
@@ -121,6 +121,7 @@ func TestHighNodeUtilization(t *testing.T) {
 				test.BuildTestPod("p6", 400, 0, n3NodeName, test.SetRSOwnerRef),
 				test.BuildTestPod("p7", 400, 0, n3NodeName, test.SetRSOwnerRef),
 				test.BuildTestPod("p8", 400, 0, n3NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p9", 400, 0, n3NodeName, test.SetRSOwnerRef),
 			},
 			expectedPodsEvicted: 0,
 		},
@@ -136,15 +137,14 @@ func TestHighNodeUtilization(t *testing.T) {
 				test.BuildTestNode(n3NodeName, 4000, 3000, 10, test.SetNodeUnschedulable),
 			},
 			pods: []*v1.Pod{
-				// These can't be evicted.
 				test.BuildTestPod("p1", 400, 0, n1NodeName, test.SetRSOwnerRef),
-				// These can't be evicted.
 				test.BuildTestPod("p2", 400, 0, n2NodeName, test.SetRSOwnerRef),
+				// These can't be evicted.
 				test.BuildTestPod("p3", 400, 0, n3NodeName, test.SetRSOwnerRef),
 				test.BuildTestPod("p4", 400, 0, n3NodeName, test.SetRSOwnerRef),
 				test.BuildTestPod("p5", 400, 0, n3NodeName, test.SetRSOwnerRef),
 			},
-			expectedPodsEvicted: 0,
+			expectedPodsEvicted: 1,
 		},
 		{
 			name: "without priorities",
@@ -428,6 +428,25 @@ func TestHighNodeUtilization(t *testing.T) {
 				}),
 			},
 			expectedPodsEvicted: 0,
+		},
+		{
+			name: "All nodes are low utilized",
+			thresholds: api.ResourceThresholds{
+				v1.ResourceCPU: 30,
+			},
+			nodes: []*v1.Node{
+				test.BuildTestNode(n1NodeName, 4000, 3000, 10, nil),
+				test.BuildTestNode(n2NodeName, 4000, 3000, 10, nil),
+				test.BuildTestNode(n3NodeName, 4000, 3000, 10, nil),
+			},
+			pods: []*v1.Pod{
+				// node was balanced to high nodes. These won't be evicted.
+				test.BuildTestPod("p1", 400, 0, n1NodeName, test.SetRSOwnerRef),
+				// low nodes
+				test.BuildTestPod("p2", 400, 0, n2NodeName, test.SetRSOwnerRef),
+				test.BuildTestPod("p3", 400, 0, n3NodeName, test.SetRSOwnerRef),
+			},
+			expectedPodsEvicted: 2,
 		},
 	}
 


### PR DESCRIPTION
background: I'm using descscheduler highnodeutilization mode in production to improve machine utilization and reduce unnecessary waste. Highnodeutilization is to set a threshold, divide the nodes into two, and migrate the pods on the nodes with low utilization to the nodes with high utilization. However, there are some issue in this mode. When all nodes have low utilization, and the highnodeutilization mode will not work. However, the pods on the node with low utilization can be migrated to the node with low utilization to achieve the effect.