### PR TITLE
NodeFit: do not check whether node fitsRequest when a pod is already assigned to the node

### DIFF
--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -119,9 +119,11 @@ func NodeFit(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, node *v
 		errors = append(errors, fmt.Errorf("pod does not tolerate taints on the node"))
 	}
 	// Check if the pod can fit on a node based off it's requests
-	ok, reqErrors := fitsRequest(nodeIndexer, pod, node)
-	if !ok {
-		errors = append(errors, reqErrors...)
+	if pod.Spec.NodeName == "" || pod.Spec.NodeName != node.Name {
+		ok, reqErrors := fitsRequest(nodeIndexer, pod, node)
+		if !ok {
+			errors = append(errors, reqErrors...)
+		}
 	}
 	// Check if node is schedulable
 	if IsNodeUnschedulable(node) {


### PR DESCRIPTION
SSIA

Fixes: https://github.com/kubernetes-sigs/descheduler/issues/873