### PR TITLE
remove TODO comments for cronjob v1beta1 support

### DIFF
--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -28,7 +28,7 @@ fullnameOverride: ""
 # labels that'll be applied to all resources
 commonLabels: {}
 
-cronJobApiVersion: "batch/v1"  # Use "batch/v1beta1" for k8s version < 1.21.0. TODO(@7i) remove with 1.23 release
+cronJobApiVersion: "batch/v1"
 schedule: "*/2 * * * *"
 suspend: false
 # startingDeadlineSeconds: 200

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: batch/v1  # for k8s version < 1.21.0, use batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: descheduler-cronjob


### PR DESCRIPTION
- Descheduler promises 3 version skew
- The batch/v1beta1 API version of CronJob will no longer be served in v1.25.