### PR TITLE
remove e2e tests from helm github action

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -60,10 +60,3 @@ jobs:
       # helm-extra-set-args only available after ct 3.6.0
       - name: Run chart-testing (install)
         run: ct install --config=.github/ci/ct.yaml --helm-extra-set-args='--set=kind=Deployment'
-
-      - name: E2E after chart install
-        env:
-          KUBERNETES_VERSION: "v1.26.0"
-          KIND_E2E: true
-          SKIP_INSTALL: true
-        run: make test-e2e


### PR DESCRIPTION
Rationale:
1. e2e tests are not executed against a Descheduler install. If anything, we could end up with a race condition between a Descheduler run and the e2e tests. For example, notice [here](https://github.com/kubernetes-sigs/descheduler/blob/master/test/e2e/e2e_leaderelection_test.go#L105) that the test runs Descheduler itself.
2. We already run e2e tests against 3 Kubernetes Versions