### PR TITLE
feat: add RemovePodsHavingTooManyRestarts to values.yaml

### DIFF
--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -67,6 +67,12 @@ deschedulerPolicy:
   strategies:
     RemoveDuplicates:
       enabled: true
+    RemovePodsHavingTooManyRestarts:
+      enabled: true
+      params:
+        podsHavingTooManyRestarts:
+          podRestartThreshold: 100
+          includingInitContainers: true
     RemovePodsViolatingNodeTaints:
       enabled: true
     RemovePodsViolatingNodeAffinity:


### PR DESCRIPTION
This does the following:
1. Enables RemovePodsHavingTooManyRestarts when using Helm by default (it is not currently)
2. Adds RemovePodsHavingTooManyRestarts to the values.yaml for clearer configs