### PR TITLE
feat: change DeschedulerVersion and GitVersion labels

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -43,7 +43,7 @@ var (
 			Subsystem:      DeschedulerSubsystem,
 			Name:           "build_info",
 			Help:           "Build info about descheduler, including Go version, Descheduler version, Git SHA, Git branch",
-			ConstLabels:    map[string]string{"GoVersion": version.Get().GoVersion, "DeschedulerVersion": version.Get().GitVersion, "GitBranch": version.Get().GitBranch, "GitSha1": version.Get().GitSha1},
+			ConstLabels:    map[string]string{"GoVersion": version.Get().GoVersion, "AppVersion": version.Get().Major + "." + version.Get().Minor, "DeschedulerVersion": version.Get().GitVersion, "GitBranch": version.Get().GitBranch, "GitSha1": version.Get().GitSha1},
 			StabilityLevel: metrics.ALPHA,
 		},
 	)


### PR DESCRIPTION
This commit changes build_info metric labels
- AppVersion label will show major+minor version for example 0.24.1

It will be seen like this
```bash
# HELP descheduler_build_info [ALPHA] Build info about descheduler, including Go version, Descheduler version, Git SHA, Git branch
# TYPE descheduler_build_info gauge
descheduler_build_info{AppVersion="0.24.1",GitBranch="metric-label-fix",GitSha1="0317be1b7672c511f5e2e53acaea1dd5cb74fd77",DeschedulerVersion="v20220909-v0.24.1-188-g0317be1b7",GoVersion="go1.19"} 0
```

Signed-off-by: eminaktas <eminaktas34@gmail.com>