### PR TITLE
Fix wrong command on contributor-guide.md

### DIFF
--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -53,7 +53,7 @@ make build-helm
 To check linting of your changes in the helm chart locally you can run:
 
 ```
-make lint-helm
+make lint-chart
 ```
 
 ## Test helm changes locally with kind and ct


### PR DESCRIPTION

Change `make lint-helm` to `make lint-chart`. 