### PR TITLE
set helm-extra-set-args as inline command arg

### DIFF
--- a/.github/ci/ct.yaml
+++ b/.github/ci/ct.yaml
@@ -2,5 +2,4 @@ chart-dirs:
   - charts
 helm-extra-args: "--timeout=5m"
 check-version-increment: false
-helm-extra-set-args: "--set=kind=Deployment"
 target-branch: master

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -8,10 +8,12 @@ on:
     paths:
       - 'charts/**'
       - '.github/workflows/helm.yaml'
+      - '.github/ci/ct.yaml'
   pull_request:
     paths:
       - 'charts/**'
       - '.github/workflows/helm.yaml'
+      - '.github/ci/ct.yaml'
 
 jobs:
   lint-and-test:
@@ -57,7 +59,7 @@ jobs:
 
       # helm-extra-set-args only available after ct 3.6.0
       - name: Run chart-testing (install)
-        run: ct install --config=.github/ci/ct.yaml
+        run: ct install --config=.github/ci/ct.yaml --helm-extra-set-args='--set=kind=Deployment'
 
       - name: E2E after chart install
         env:


### PR DESCRIPTION
Based on the docs, it seems that `helm-extra-set-args` is only available as [an inline arg](https://github.com/helm/chart-testing/blob/main/doc/ct_install.md#options) but not as a [config](https://github.com/helm/chart-testing/blob/main/pkg/config/config.go#L44).

Closes #949 