### PR TITLE
add PreEvictionFilter extension to DefaultEvictor Plugin

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -181,6 +181,11 @@ func (ei *evictorImpl) Filter(pod *v1.Pod) bool {
 	return ei.evictorFilter.Filter(pod)
 }
 
+// PreEvictionFilter checks if pod can be evicted right before eviction
+func (ei *evictorImpl) PreEvictionFilter(pod *v1.Pod) bool {
+	return ei.evictorFilter.PreEvictionFilter(pod)
+}
+
 // Evict evicts a pod (no pre-check performed)
 func (ei *evictorImpl) Evict(ctx context.Context, pod *v1.Pod, opts evictions.EvictOptions) bool {
 	return ei.podEvictor.EvictPod(ctx, pod, opts)

--- a/pkg/framework/fake/fake.go
+++ b/pkg/framework/fake/fake.go
@@ -37,6 +37,9 @@ func (hi *HandleImpl) Evictor() framework.Evictor {
 func (hi *HandleImpl) Filter(pod *v1.Pod) bool {
 	return hi.EvictorFilterImpl.Filter(pod)
 }
+func (hi *HandleImpl) PreEvictionFilter(pod *v1.Pod) bool {
+	return hi.EvictorFilterImpl.PreEvictionFilter(pod)
+}
 func (hi *HandleImpl) Evict(ctx context.Context, pod *v1.Pod, opts evictions.EvictOptions) bool {
 	return hi.PodEvictorImpl.EvictPod(ctx, pod, opts)
 }

--- a/pkg/framework/plugins/podlifetime/pod_lifetime.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime.go
@@ -56,8 +56,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		excludedNamespaces = sets.NewString(podLifeTimeArgs.Namespaces.Exclude...)
 	}
 
+	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
 	podFilter, err := podutil.NewOptions().
-		WithFilter(handle.Evictor().Filter).
+		WithFilter(podutil.WrapFilterFuncs(handle.Evictor().Filter, handle.Evictor().PreEvictionFilter)).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		WithLabelSelector(podLifeTimeArgs.LabelSelector).

--- a/pkg/framework/plugins/removeduplicates/removeduplicates.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates.go
@@ -71,8 +71,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		excludedNamespaces = sets.NewString(removeDuplicatesArgs.Namespaces.Exclude...)
 	}
 
+	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
 	podFilter, err := podutil.NewOptions().
-		WithFilter(handle.Evictor().Filter).
+		WithFilter(podutil.WrapFilterFuncs(handle.Evictor().Filter, handle.Evictor().PreEvictionFilter)).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		BuildFilterFunc()

--- a/pkg/framework/plugins/removefailedpods/failedpods.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods.go
@@ -57,8 +57,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		excludedNamespaces = sets.NewString(failedPodsArgs.Namespaces.Exclude...)
 	}
 
+	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
 	podFilter, err := podutil.NewOptions().
-		WithFilter(handle.Evictor().Filter).
+		WithFilter(podutil.WrapFilterFuncs(handle.Evictor().Filter, handle.Evictor().PreEvictionFilter)).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		WithLabelSelector(failedPodsArgs.LabelSelector).

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
@@ -57,8 +57,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		excludedNamespaces = sets.NewString(tooManyRestartsArgs.Namespaces.Exclude...)
 	}
 
+	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
 	podFilter, err := podutil.NewOptions().
-		WithFilter(handle.Evictor().Filter).
+		WithFilter(podutil.WrapFilterFuncs(handle.Evictor().Filter, handle.Evictor().PreEvictionFilter)).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		WithLabelSelector(tooManyRestartsArgs.LabelSelector).

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -92,7 +92,7 @@ loop:
 		podutil.SortPodsBasedOnPriorityLowToHigh(pods)
 		totalPods := len(pods)
 		for i := 0; i < totalPods; i++ {
-			if checkPodsWithAntiAffinityExist(pods[i], pods) && d.handle.Evictor().Filter(pods[i]) {
+			if checkPodsWithAntiAffinityExist(pods[i], pods) && d.handle.Evictor().Filter(pods[i]) && d.handle.Evictor().PreEvictionFilter(pods[i]) {
 				if d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{}) {
 					// Since the current pod is evicted all other pods which have anti-affinity with this
 					// pod need not be evicted.

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
@@ -54,8 +54,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		excludedNamespaces = sets.NewString(nodeAffinityArgs.Namespaces.Exclude...)
 	}
 
+	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
 	podFilter, err := podutil.NewOptions().
-		WithFilter(handle.Evictor().Filter).
+		WithFilter(podutil.WrapFilterFuncs(handle.Evictor().Filter, handle.Evictor().PreEvictionFilter)).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		WithLabelSelector(nodeAffinityArgs.LabelSelector).

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -57,8 +57,9 @@ func New(args runtime.Object, handle framework.Handle) (framework.Plugin, error)
 		excludedNamespaces = sets.NewString(nodeTaintsArgs.Namespaces.Exclude...)
 	}
 
+	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
 	podFilter, err := podutil.NewOptions().
-		WithFilter(handle.Evictor().Filter).
+		WithFilter(podutil.WrapFilterFuncs(handle.Evictor().Filter, handle.Evictor().PreEvictionFilter)).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		WithLabelSelector(nodeTaintsArgs.LabelSelector).

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -215,7 +215,10 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) Balance(ctx context.Contex
 		if !d.podFilter(pod) {
 			continue
 		}
-		d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{})
+
+		if d.handle.Evictor().PreEvictionFilter(pod) {
+			d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{})
+		}
 		if d.handle.Evictor().NodeLimitExceeded(nodeMap[pod.Spec.NodeName]) {
 			nodeLimitExceeded[pod.Spec.NodeName] = true
 		}

--- a/pkg/framework/types.go
+++ b/pkg/framework/types.go
@@ -43,6 +43,8 @@ type Handle interface {
 type Evictor interface {
 	// Filter checks if a pod can be evicted
 	Filter(*v1.Pod) bool
+	// PreEvictionFilter checks if pod can be evicted right before eviction
+	PreEvictionFilter(*v1.Pod) bool
 	// Evict evicts a pod (no pre-check performed)
 	Evict(context.Context, *v1.Pod, evictions.EvictOptions) bool
 	// NodeLimitExceeded checks if the number of evictions for a node was exceeded
@@ -78,4 +80,5 @@ type BalancePlugin interface {
 type EvictorPlugin interface {
 	Plugin
 	Filter(pod *v1.Pod) bool
+	PreEvictionFilter(pod *v1.Pod) bool
 }


### PR DESCRIPTION
As per https://github.com/kubernetes-sigs/descheduler/issues/640#issuecomment-1248167067 I am just moving nodefit check to the preEvictionFilter extension point of the DefaultEvictor plugin. Follow ups would include those other options of that issue (and namespace selectors, etc).

Let me know if the evocation of the extension point shouldn't be done in the way that I did.

Also related to https://github.com/kubernetes-sigs/descheduler/issues/924, https://github.com/kubernetes-sigs/descheduler/issues/753#issuecomment-1227422028, 