### PR TITLE
Pod security context fix for Openshift

### DIFF
--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -38,6 +38,8 @@ import (
 )
 
 func TestRemoveDuplicates(t *testing.T) {
+	runAsUser := true
+	ape := false
 	ctx := context.Background()
 
 	clientSet, sharedInformerFactory, _, getPodsAssignedToNode, stopCh := initializeClient(t)
@@ -74,11 +76,25 @@ func TestRemoveDuplicates(t *testing.T) {
 					Labels: map[string]string{"app": "test-duplicate", "name": "test-duplicatePods"},
 				},
 				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+                                          RunAsNonRoot: &runAsUser,
+                                          SeccompProfile: &v1.SeccompProfile{
+                                            Type: v1.SeccompProfileTypeRuntimeDefault,
+                                          },
+                                        },
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+                                                 AllowPrivilegeEscalation: &ape,
+                                                 Capabilities: &v1.Capabilities{
+                                                   Drop: []v1.Capability{
+                                                       "ALL",
+                                                   },
+                                                 },
+                                               },
 					}},
 				},
 			},

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -38,7 +38,7 @@ import (
 )
 
 func TestRemoveDuplicates(t *testing.T) {
-	runAsUser := true
+	runAsUser := false
 	ape := false
 	ctx := context.Background()
 
@@ -77,24 +77,24 @@ func TestRemoveDuplicates(t *testing.T) {
 				},
 				Spec: v1.PodSpec{
 					SecurityContext: &v1.PodSecurityContext{
-                                          RunAsNonRoot: &runAsUser,
-                                          SeccompProfile: &v1.SeccompProfile{
-                                            Type: v1.SeccompProfileTypeRuntimeDefault,
-                                          },
-                                        },
+						RunAsNonRoot: &runAsUser,
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
 						SecurityContext: &v1.SecurityContext{
-                                                 AllowPrivilegeEscalation: &ape,
-                                                 Capabilities: &v1.Capabilities{
-                                                   Drop: []v1.Capability{
-                                                       "ALL",
-                                                   },
-                                                 },
-                                               },
+							AllowPrivilegeEscalation: &ape,
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{
+									"ALL",
+								},
+							},
+						},
 					}},
 				},
 			},

--- a/test/e2e/e2e_leaderelection_test.go
+++ b/test/e2e/e2e_leaderelection_test.go
@@ -147,6 +147,8 @@ func TestLeaderElection(t *testing.T) {
 }
 
 func createDeployment(ctx context.Context, clientSet clientset.Interface, namespace string, replicas int32, t *testing.T) (*appsv1.Deployment, error) {
+	runAsUser := true
+	ape := false
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "leaderelection",
@@ -163,11 +165,25 @@ func createDeployment(ctx context.Context, clientSet clientset.Interface, namesp
 					Labels: map[string]string{"test": "leaderelection", "name": "test-leaderelection"},
 				},
 				Spec: v1.PodSpec{
+                                        SecurityContext: &v1.PodSecurityContext{
+                                          RunAsNonRoot: &runAsUser,
+                                          SeccompProfile: &v1.SeccompProfile{
+                                            Type: v1.SeccompProfileTypeRuntimeDefault,
+                                          },
+                                        },
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+                                                  AllowPrivilegeEscalation: &ape,
+                                                  Capabilities: &v1.Capabilities{
+                                                    Drop: []v1.Capability{
+                                                        "ALL",
+                                                    },
+                                                  },
+                                                },
 					}},
 				},
 			},

--- a/test/e2e/e2e_leaderelection_test.go
+++ b/test/e2e/e2e_leaderelection_test.go
@@ -147,7 +147,7 @@ func TestLeaderElection(t *testing.T) {
 }
 
 func createDeployment(ctx context.Context, clientSet clientset.Interface, namespace string, replicas int32, t *testing.T) (*appsv1.Deployment, error) {
-	runAsUser := true
+	runAsUser := false
 	ape := false
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -165,25 +165,25 @@ func createDeployment(ctx context.Context, clientSet clientset.Interface, namesp
 					Labels: map[string]string{"test": "leaderelection", "name": "test-leaderelection"},
 				},
 				Spec: v1.PodSpec{
-                                        SecurityContext: &v1.PodSecurityContext{
-                                          RunAsNonRoot: &runAsUser,
-                                          SeccompProfile: &v1.SeccompProfile{
-                                            Type: v1.SeccompProfileTypeRuntimeDefault,
-                                          },
-                                        },
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsNonRoot: &runAsUser,
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
 						SecurityContext: &v1.SecurityContext{
-                                                  AllowPrivilegeEscalation: &ape,
-                                                  Capabilities: &v1.Capabilities{
-                                                    Drop: []v1.Capability{
-                                                        "ALL",
-                                                    },
-                                                  },
-                                                },
+							AllowPrivilegeEscalation: &ape,
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{
+									"ALL",
+								},
+							},
+						},
 					}},
 				},
 			},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -56,7 +56,15 @@ import (
 )
 
 func MakePodSpec(priorityClassName string, gracePeriod *int64) v1.PodSpec {
+	runAsUser := true
+	ape := false
 	return v1.PodSpec{
+		SecurityContext: &v1.PodSecurityContext{
+                  RunAsNonRoot: &runAsUser,
+                  SeccompProfile: &v1.SeccompProfile{
+                    Type: v1.SeccompProfileTypeRuntimeDefault,
+                    },
+                },
 		Containers: []v1.Container{{
 			Name:            "pause",
 			ImagePullPolicy: "Never",
@@ -72,6 +80,14 @@ func MakePodSpec(priorityClassName string, gracePeriod *int64) v1.PodSpec {
 					v1.ResourceMemory: resource.MustParse("100Mi"),
 				},
 			},
+			SecurityContext: &v1.SecurityContext{
+                          AllowPrivilegeEscalation: &ape,
+                          Capabilities: &v1.Capabilities{
+                            Drop: []v1.Capability{
+                              "ALL",
+                            },
+                          },
+                        },
 		}},
 		PriorityClassName:             priorityClassName,
 		TerminationGracePeriodSeconds: gracePeriod,
@@ -296,6 +312,7 @@ func TestLowNodeUtilization(t *testing.T) {
 
 	t.Log("Creating pods all bound to a single node")
 	for i := 0; i < 4; i++ {
+		runAsUser := true
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("lnu-pod-%v", i),
@@ -303,6 +320,12 @@ func TestLowNodeUtilization(t *testing.T) {
 				Labels:    map[string]string{"test": "node-utilization", "name": "test-rc-node-utilization"},
 			},
 			Spec: v1.PodSpec{
+				SecurityContext: &v1.PodSecurityContext{
+                                  RunAsNonRoot: &runAsUser,
+                                  SeccompProfile: &v1.SeccompProfile{
+                                    Type: v1.SeccompProfileTypeRuntimeDefault,
+                                  },
+                                },
 				Containers: []v1.Container{{
 					Name:            "pause",
 					ImagePullPolicy: "Never",
@@ -1287,6 +1310,12 @@ func createBalancedPodForNodes(
 				Labels:    balancePodLabel,
 			},
 			Spec: v1.PodSpec{
+				SecurityContext: &v1.PodSecurityContext{
+                                  RunAsNonRoot: &runAsUser,
+                                  SeccompProfile: &v1.SeccompProfile{
+                                    Type: v1.SeccompProfileTypeRuntimeDefault,
+                                  },
+                                },
 				Affinity: &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 func TestTooManyRestarts(t *testing.T) {
-	runAsUser := true
+	runAsUser := false
 	ape := false
 	ctx := context.Background()
 
@@ -78,11 +78,11 @@ func TestTooManyRestarts(t *testing.T) {
 				},
 				Spec: v1.PodSpec{
 					SecurityContext: &v1.PodSecurityContext{
-                                          RunAsNonRoot: &runAsUser,
-                                          SeccompProfile: &v1.SeccompProfile{
-                                            Type: v1.SeccompProfileTypeRuntimeDefault,
-                                          },
-                                        },
+						RunAsNonRoot: &runAsUser,
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
@@ -91,13 +91,13 @@ func TestTooManyRestarts(t *testing.T) {
 						Args:            []string{"-c", "sleep 1s && exit 1"},
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
 						SecurityContext: &v1.SecurityContext{
-                                                  AllowPrivilegeEscalation: &ape,
-                                                  Capabilities: &v1.Capabilities{
-                                                    Drop: []v1.Capability{
-                                                        "ALL",
-                                                    },
-                                                  },
-                                                },
+							AllowPrivilegeEscalation: &ape,
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{
+									"ALL",
+								},
+							},
+						},
 					}},
 				},
 			},

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -40,6 +40,8 @@ import (
 )
 
 func TestTooManyRestarts(t *testing.T) {
+	runAsUser := true
+	ape := false
 	ctx := context.Background()
 
 	clientSet, sharedInformerFactory, _, getPodsAssignedToNode, stopCh := initializeClient(t)
@@ -75,6 +77,12 @@ func TestTooManyRestarts(t *testing.T) {
 					Labels: map[string]string{"test": "restart-pod", "name": "test-toomanyrestarts"},
 				},
 				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+                                          RunAsNonRoot: &runAsUser,
+                                          SeccompProfile: &v1.SeccompProfile{
+                                            Type: v1.SeccompProfileTypeRuntimeDefault,
+                                          },
+                                        },
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
@@ -82,6 +90,14 @@ func TestTooManyRestarts(t *testing.T) {
 						Command:         []string{"/bin/sh"},
 						Args:            []string{"-c", "sleep 1s && exit 1"},
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+                                                  AllowPrivilegeEscalation: &ape,
+                                                  Capabilities: &v1.Capabilities{
+                                                    Drop: []v1.Capability{
+                                                        "ALL",
+                                                    },
+                                                  },
+                                                },
 					}},
 				},
 			},


### PR DESCRIPTION
Related to the Downstreamed descheduler and openshift specific requirements. But adding Security contexts here would not hurt, and avoids conflicts for us when downstreaming changes there: https://github.com/openshift/descheduler/pull/80