### PR TITLE
doc: fix a markdown's style on user-guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -159,6 +159,7 @@ strategies:
 ```
 
 ### Autoheal Node Problems
+
 Descheduler's `RemovePodsViolatingNodeTaints` strategy can be combined with
 [Node Problem Detector](https://github.com/kubernetes/node-problem-detector/) and
 [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) to automatically remove
@@ -167,6 +168,7 @@ There is a feature called TaintNodeByCondition of the node controller that takes
 The Descheduler will then deschedule workloads from those Nodes. Finally, if the descheduled Node's resource
 allocation falls below the Cluster Autoscaler's scale down threshold, the Node will become a scale down candidate
 and can be removed by Cluster Autoscaler. These three components form an autohealing cycle for Node problems.
+
 ---
 **NOTE**
 


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/descheduler/blob/master/docs/user-guide.md#deschedulers-removepodsviolatingnodetaints-strategy-can-be-combined-withnode-problem-detector-andcluster-autoscaler-to-automatically-removenodes-which-have-problems-node-problem-detector-can-detect-specific-node-problems-and-report-them-to-the-api-serverthere-is-a-feature-called-taintnodebycondition-of-the-node-controller-that-takes-some-conditions-and-turns-them-into-taints-currently-this-only-works-for-the-default-node-conditions-pidpressure-memorypressure-diskpressure-ready-and-some-cloud-provider-specific-conditionsthe-descheduler-will-then-deschedule-workloads-from-those-nodes-finally-if-the-descheduled-nodes-resourceallocation-falls-below-the-cluster-autoscalers-scale-down-threshold-the-node-will-become-a-scale-down-candidateand-can-be-removed-by-cluster-autoscaler-these-three-components-form-an-autohealing-cycle-for-node-problems.

Now, it seems be broken. This PR just fixes that.