### PR TITLE
📖 Fix broken kustomize reference in the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The descheduler helm chart is also listed on the [artifact hub](https://artifact
 ### Install Using Kustomize
 
 You can use kustomize to install descheduler.
-See the [resources | Kustomize](https://kubectl.docs.kubernetes.io/references/kustomize/resource/) for detailed instructions.
+See the [resources | Kustomize](https://kubectl.docs.kubernetes.io/references/kustomize/cmd/build/) for detailed instructions.
 
 Run As A Job
 ```


### PR DESCRIPTION
While exploring the repo, found out the link to kustomize is broken and perhaps it was referencing to "kustomize build" page since it is where descheduler installation instructions are about that makes use of it. 

Additional note: it might be beneficial to automate broken link checking in the repo by adding GA for markdown link checks. One example could be: https://github.com/gaurav-nelson/github-action-markdown-link-check