### PR TITLE
add restricted security policy to e2e test pods

### DIFF
--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/pointer"
+	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	eutils "sigs.k8s.io/descheduler/pkg/descheduler/evictions/utils"
 )
@@ -74,11 +75,27 @@ func TestRemoveDuplicates(t *testing.T) {
 					Labels: map[string]string{"app": "test-duplicate", "name": "test-duplicatePods"},
 				},
 				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsNonRoot: utilpointer.Bool(true),
+						RunAsUser:    utilpointer.Int64(1000),
+						RunAsGroup:   utilpointer.Int64(1000),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: utilpointer.Bool(false),
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{
+									"ALL",
+								},
+							},
+						},
 					}},
 				},
 			},

--- a/test/e2e/e2e_leaderelection_test.go
+++ b/test/e2e/e2e_leaderelection_test.go
@@ -32,6 +32,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 
+	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/descheduler"
 )
@@ -163,11 +164,27 @@ func createDeployment(ctx context.Context, clientSet clientset.Interface, namesp
 					Labels: map[string]string{"test": "leaderelection", "name": "test-leaderelection"},
 				},
 				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsNonRoot: utilpointer.Bool(true),
+						RunAsUser:    utilpointer.Int64(1000),
+						RunAsGroup:   utilpointer.Int64(1000),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
 						Image:           "kubernetes/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: utilpointer.Bool(false),
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{
+									"ALL",
+								},
+							},
+						},
 					}},
 				},
 			},

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -38,6 +38,7 @@ import (
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/pointer"
+	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/api"
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
@@ -57,6 +58,14 @@ import (
 
 func MakePodSpec(priorityClassName string, gracePeriod *int64) v1.PodSpec {
 	return v1.PodSpec{
+		SecurityContext: &v1.PodSecurityContext{
+			RunAsNonRoot: utilpointer.Bool(true),
+			RunAsUser:    utilpointer.Int64(1000),
+			RunAsGroup:   utilpointer.Int64(1000),
+			SeccompProfile: &v1.SeccompProfile{
+				Type: v1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
 		Containers: []v1.Container{{
 			Name:            "pause",
 			ImagePullPolicy: "Never",
@@ -70,6 +79,14 @@ func MakePodSpec(priorityClassName string, gracePeriod *int64) v1.PodSpec {
 				Requests: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("100m"),
 					v1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			},
+			SecurityContext: &v1.SecurityContext{
+				AllowPrivilegeEscalation: utilpointer.Bool(false),
+				Capabilities: &v1.Capabilities{
+					Drop: []v1.Capability{
+						"ALL",
+					},
 				},
 			},
 		}},
@@ -303,6 +320,14 @@ func TestLowNodeUtilization(t *testing.T) {
 				Labels:    map[string]string{"test": "node-utilization", "name": "test-rc-node-utilization"},
 			},
 			Spec: v1.PodSpec{
+				SecurityContext: &v1.PodSecurityContext{
+					RunAsNonRoot: utilpointer.Bool(true),
+					RunAsUser:    utilpointer.Int64(1000),
+					RunAsGroup:   utilpointer.Int64(1000),
+					SeccompProfile: &v1.SeccompProfile{
+						Type: v1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Containers: []v1.Container{{
 					Name:            "pause",
 					ImagePullPolicy: "Never",
@@ -1287,6 +1312,14 @@ func createBalancedPodForNodes(
 				Labels:    balancePodLabel,
 			},
 			Spec: v1.PodSpec{
+				SecurityContext: &v1.PodSecurityContext{
+					RunAsNonRoot: utilpointer.Bool(true),
+					RunAsUser:    utilpointer.Int64(1000),
+					RunAsGroup:   utilpointer.Int64(1000),
+					SeccompProfile: &v1.SeccompProfile{
+						Type: v1.SeccompProfileTypeRuntimeDefault,
+					},
+				},
 				Affinity: &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/pointer"
 
+	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	eutils "sigs.k8s.io/descheduler/pkg/descheduler/evictions/utils"
 	"sigs.k8s.io/descheduler/pkg/framework"
@@ -75,6 +76,14 @@ func TestTooManyRestarts(t *testing.T) {
 					Labels: map[string]string{"test": "restart-pod", "name": "test-toomanyrestarts"},
 				},
 				Spec: v1.PodSpec{
+					SecurityContext: &v1.PodSecurityContext{
+						RunAsNonRoot: utilpointer.Bool(true),
+						RunAsUser:    utilpointer.Int64(1000),
+						RunAsGroup:   utilpointer.Int64(1000),
+						SeccompProfile: &v1.SeccompProfile{
+							Type: v1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
@@ -82,6 +91,14 @@ func TestTooManyRestarts(t *testing.T) {
 						Command:         []string{"/bin/sh"},
 						Args:            []string{"-c", "sleep 1s && exit 1"},
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
+						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: utilpointer.Bool(false),
+							Capabilities: &v1.Capabilities{
+								Drop: []v1.Capability{
+									"ALL",
+								},
+							},
+						},
 					}},
 				},
 			},


### PR DESCRIPTION
While running e2e tests on k8s v1.24+, the test logs are filled with privileged security context warning messages. Also some of the tests are failing because pods can't be started with privileged security context. This PR will add restricted context to the e2e pods.