### PR TITLE
Update verify scripts to use the generation scripts directly

### DIFF
--- a/hack/verify-conversions.sh
+++ b/hack/verify-conversions.sh
@@ -16,12 +16,7 @@ git archive --format=tar --prefix=descheduler/ "$(git write-tree)" | (cd "${_des
 _deschedulertmp="${_deschedulertmp}/descheduler"
 
 pushd "${_deschedulertmp}" > /dev/null 2>&1
-go build -o "${OS_OUTPUT_BINPATH}/conversion-gen" "k8s.io/code-generator/cmd/conversion-gen"
-
-${OS_OUTPUT_BINPATH}/conversion-gen \
-		--go-header-file "hack/boilerplate/boilerplate.go.txt" \
-		--input-dirs "./pkg/apis/componentconfig/v1alpha1,./pkg/api/v1alpha1" \
-		--output-file-base zz_generated.conversion
+./hack/update-generated-conversions.sh
 popd > /dev/null 2>&1
 
 pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1

--- a/hack/verify-deep-copies.sh
+++ b/hack/verify-deep-copies.sh
@@ -16,12 +16,7 @@ git archive --format=tar --prefix=descheduler/ "$(git write-tree)" | (cd "${_des
 _deschedulertmp="${_deschedulertmp}/descheduler"
 
 pushd "${_deschedulertmp}" > /dev/null 2>&1
-go build -o "${OS_OUTPUT_BINPATH}/deepcopy-gen" "k8s.io/code-generator/cmd/deepcopy-gen"
-
-${OS_OUTPUT_BINPATH}/deepcopy-gen \
-                --go-header-file "hack/boilerplate/boilerplate.go.txt" \
-                --input-dirs "./pkg/apis/componentconfig,./pkg/apis/componentconfig/v1alpha1,./pkg/api,./pkg/api/v1alpha1,./pkg/framework/plugins/defaultevictor/" \
-                --output-file-base zz_generated.deepcopy
+./hack/update-generated-deep-copies.sh
 popd > /dev/null 2>&1
 
 pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1

--- a/hack/verify-defaulters.sh
+++ b/hack/verify-defaulters.sh
@@ -15,13 +15,7 @@ git archive --format=tar --prefix=descheduler/ "$(git write-tree)" | (cd "${_des
 _deschedulertmp="${_deschedulertmp}/descheduler"
 
 pushd "${_deschedulertmp}" > /dev/null 2>&1
-go build -o "${OS_OUTPUT_BINPATH}/defaulter-gen" "k8s.io/code-generator/cmd/defaulter-gen"
-
-${OS_OUTPUT_BINPATH}/defaulter-gen \
-            --go-header-file "hack/boilerplate/boilerplate.go.txt" \
-            --input-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api/v1alpha1" \
-            --extra-peer-dirs "${PRJ_PREFIX}/pkg/apis/componentconfig/v1alpha1,${PRJ_PREFIX}/pkg/api/v1alpha1" \
-            --output-file-base zz_generated.defaults
+./hack/update-generated-defaulters.sh
 popd > /dev/null 2>&1
 
 pushd "${DESCHEDULER_ROOT}" > /dev/null 2>&1


### PR DESCRIPTION
In https://github.com/kubernetes-sigs/descheduler/pull/958 we are noticing odd behavior with the `verify` tools for our generator scripts, specifically conversions. CI is [failing to verify the conversion-gen](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_descheduler/958/pull-descheduler-verify-master/1580431724137943040) saying there are changes missing. But, running these generators on some local environments (and containers) produces no diff, while other environments do produce the generated output that the tests are expecting.

https://github.com/kubernetes-sigs/descheduler/pull/954/commits/96c03a3f97b6440c1622a9e09606785fdbb4de87 and https://github.com/kubernetes-sigs/descheduler/pull/954/commits/2b1746cda8883c199329510ac021b1c6badf4984 update the generator scripts (deepcopies, conversion, and defaulters) to dynamically parse which files to run on using the function [`find_dirs_containing_comment_tags`](https://github.com/kubernetes-sigs/descheduler/blob/2b1746cda8883c199329510ac021b1c6badf4984/hack/lib/generator-help.sh#L15). But, it didn't update the verify scripts to parse similarly (they are still hardcoded).

Updating the verify scripts to call the generators directly is a good idea to keep our generators and changes in line. Doing so fixed the verify failures (at least for me locally). But, I don't know if this is actually fixing it, or if there is a bug in the new generator command with `find_dirs_containing_comment_tags` and this is just copying the bug over to the verify scripts as well. 

What looks suspicious to me is [this line](https://github.com/kubernetes-sigs/descheduler/blob/2b1746cda8883c199329510ac021b1c6badf4984/hack/lib/generator-help.sh#L22) which replaces `.` in the path names with `${PRJ_PREFIX}`. So on my local for example, the output of this function for conversion-gen is:
```
sigs.k8s.io/descheduler/pkg/api/v1alpha1,sigs.k8s.io/descheduler/pkg/apis/componentconfig/v1alpha1
```
as opposed to
```
./pkg/api/v1alpha1,./pkg/apis/componentconfig/v1alpha1
```

This stands out because `verify-conversions.sh` specifically [currently has the latter](https://github.com/kubernetes-sigs/descheduler/pull/982/files#diff-7318ba5bb4b500e18e147fd0db7ccb39d26c47690dd9ac70ba5d4bb7e6fcc917L23) as its input dirs. But, the generator is using the *former* as its input dirs.

The fact that this shows up differently on different environments makes me think it may be an issue with how `PRJ_PREFIX` is parsed. Maybe similar to https://github.com/kubernetes-sigs/descheduler/issues/313. Marking this WIP for now to continue work on it

See also a similar weird output from the deepcopy script in https://github.com/kubernetes-sigs/descheduler/pull/976#issuecomment-1272207052