### PR TITLE
Fix wired behavior during code generating

### DIFF
--- a/hack/lib/generator-help.sh
+++ b/hack/lib/generator-help.sh
@@ -5,8 +5,7 @@
 #   2. find all the files containing specific tags in contents;
 #   3. extract related dirs;
 #   4. remove duplicated paths;
-#   5. replace . with ${PRJ_PREFIX}
-#   6. merge all dirs in array with delimiter ,;
+#   5. merge all dirs in array with delimiter ,;
 #
 # Example:
 #   find_dirs_containing_comment_tags("+k8s:")
@@ -15,11 +14,10 @@
 function find_dirs_containing_comment_tags() {
    array=()
    while IFS='' read -r line; do array+=("$line"); done < <( \
-     find . -type f -name \*.go -not -path "./vendor/*" -print0  \
+     find . -type f -name \*.go -not -path "./vendor/*" -not -path "./_tmp/*" -print0  \
      | xargs -0 grep --color=never -l "$@" \
      | xargs -n1 dirname \
      | LC_ALL=C sort -u \
-     | sed "s|.|${PRJ_PREFIX}|" \
      )
 
    IFS=",";


### PR DESCRIPTION
- exclude files & folders under _tmp folder during code-generator;
- remove redundant path replacement to keep the consistent logic with verify-xx.sh;