### PR TITLE
[release-1.25] Update helm chart rolebinding to use events.k8s.io

### DIFF
--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: descheduler
-version: 0.25.1
+version: 0.25.2
 appVersion: 0.25.1
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:

--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 rules:
-- apiGroups: [""]
+- apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "update"]
 - apiGroups: [""]


### PR DESCRIPTION
This will publish a new helm chart when it merges
Fixes https://github.com/kubernetes-sigs/descheduler/issues/986
Fixes #959