### PR TITLE
Update helm chart rolebinding to use events.k8s.io

### DIFF
--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 rules:
-- apiGroups: [""]
+- apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "update"]
 - apiGroups: [""]


### PR DESCRIPTION
Patch PR: https://github.com/kubernetes-sigs/descheduler/pull/989
ref #986 #959