### PR TITLE
correct JSON log format

### DIFF
--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apiserver/pkg/server/mux"
 	restclient "k8s.io/client-go/rest"
 	registry "k8s.io/component-base/logs/api/v1"
+	jsonLog "k8s.io/component-base/logs/json"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
@@ -62,13 +63,18 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 				return
 			}
 			var factory registry.LogFormatFactory
+
+			if s.Logging.Format == "json" {
+				factory = jsonLog.Factory{}
+			}
+
 			if factory == nil {
 				klog.ClearLogger()
 			} else {
 				log, logrFlush := factory.Create(registry.LoggingConfiguration{
-					Format: s.Logging.Format,
+					Format:    s.Logging.Format,
+					Verbosity: s.Logging.Verbosity,
 				})
-
 				defer logrFlush()
 				klog.SetLogger(log)
 			}


### PR DESCRIPTION
today I upgraded to `0.25.2` version and noticed that the `json` format is not working
after a quick scan of the code I noticed that `factory` is always `nil`.

some related problems #991 and #965 

I'm sure there is a much more elegant solution to this problem.