### PR TITLE
Split CMD into ENTRYPOINT and CMD for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,6 @@ USER 1000
 
 COPY --from=0 /go/src/sigs.k8s.io/descheduler/_output/bin/descheduler /bin/descheduler
 
-CMD ["/bin/descheduler", "--help"]
+ENTRYPOINT ["/bin/descheduler"]
+CMD ["--help"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,3 @@ COPY --from=0 /go/src/sigs.k8s.io/descheduler/_output/bin/descheduler /bin/desch
 
 ENTRYPOINT ["/bin/descheduler"]
 CMD ["--help"]
-

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,4 +19,5 @@ USER 1000
 
 COPY _output/bin/descheduler /bin/descheduler
 
-CMD ["/bin/descheduler", "--help"]
+ENTRYPOINT ["/bin/descheduler"]
+CMD ["--help"]

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -62,8 +62,6 @@ spec:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              command:
-                - "/bin/descheduler"
               args:
                 - "--policy-config-file"
                 - "/policy-dir/policy.yaml"

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -43,8 +43,6 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - "/bin/descheduler"
           args:
             - "--policy-config-file"
             - "/policy-dir/policy.yaml"

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -20,8 +20,6 @@ spec:
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume
-            command:
-              - "/bin/descheduler"
             args:
               - "--policy-config-file"
               - "/policy-dir/policy.yaml"

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -21,8 +21,6 @@ spec:
         - name: descheduler
           image: k8s.gcr.io/descheduler/descheduler:v0.25.0
           imagePullPolicy: IfNotPresent
-          command:
-            - "/bin/descheduler"
           args:
             - "--policy-config-file"
             - "/policy-dir/policy.yaml"

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -18,8 +18,6 @@ spec:
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume
-          command:
-            - "/bin/descheduler"
           args:
             - "--policy-config-file"
             - "/policy-dir/policy.yaml"


### PR DESCRIPTION
--help is now an CMD which means explicitly providing a command override in kubernetes is no longer required. You can now simply provide the necessary arguments

With this change it's now possible to simply override the --help argument by providing explicit arguments instead.
Therefore explicitly using `command` in kubernetes resources is no longer required.

It might make seem like a trivial change, but this way it fits way better in my deployment automation and I'd appreciate if you could merge this.
