### PR TITLE
Switch to registry.k8s.io

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -46,7 +46,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | Parameter                           | Description                                                                                                           | Default                              |
 |-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | `kind`                              | Use as CronJob or Deployment                                                                                          | `CronJob`                            |
-| `image.repository`                  | Docker repository to use                                                                                              | `k8s.gcr.io/descheduler/descheduler` |
+| `image.repository`                  | Docker repository to use                                                                                              | `registry.k8s.io/descheduler/descheduler` |
 | `image.tag`                         | Docker tag to use                                                                                                     | `v[chart appVersion]`                |
 | `image.pullPolicy`                  | Docker image pull policy                                                                                              | `IfNotPresent`                       |
 | `imagePullSecrets`                  | Docker repository secrets                                                                                             | `[]`                                 |

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -6,7 +6,7 @@
 kind: CronJob
 
 image:
-  repository: k8s.gcr.io/descheduler/descheduler
+  repository: registry.k8s.io/descheduler/descheduler
   # Overrides the image tag whose default is the chart version
   tag: ""
   pullPolicy: IfNotPresent

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2,26 +2,27 @@
 
 Starting with descheduler release v0.10.0 container images are available in the official k8s container registry.
 
-Descheduler Version | Container Image                            | Architectures           |
-------------------- |--------------------------------------------|-------------------------|
-v0.25.0             | k8s.gcr.io/descheduler/descheduler:v0.25.0 | AMD64<br>ARM64<br>ARMv7 |
-v0.24.1             | k8s.gcr.io/descheduler/descheduler:v0.24.1 | AMD64<br>ARM64<br>ARMv7 |
-v0.24.0             | k8s.gcr.io/descheduler/descheduler:v0.24.0 | AMD64<br>ARM64<br>ARMv7 |
-v0.23.1             | k8s.gcr.io/descheduler/descheduler:v0.23.1 | AMD64<br>ARM64<br>ARMv7 |
-v0.22.0             | k8s.gcr.io/descheduler/descheduler:v0.22.0 | AMD64<br>ARM64<br>ARMv7 |
-v0.21.0             | k8s.gcr.io/descheduler/descheduler:v0.21.0 | AMD64<br>ARM64<br>ARMv7 |
-v0.20.0             | k8s.gcr.io/descheduler/descheduler:v0.20.0 | AMD64<br>ARM64          |
-v0.19.0             | k8s.gcr.io/descheduler/descheduler:v0.19.0 | AMD64                   |
-v0.18.0             | k8s.gcr.io/descheduler/descheduler:v0.18.0 | AMD64                   |
-v0.10.0             | k8s.gcr.io/descheduler/descheduler:v0.10.0 | AMD64                   |
+Descheduler Version | Container Image                                 | Architectures           |
+------------------- |-------------------------------------------------|-------------------------|
+v0.25.1             | registry.k8s.io/descheduler/descheduler:v0.25.1 | AMD64<br>ARM64<br>ARMv7 |
+v0.25.0             | registry.k8s.io/descheduler/descheduler:v0.25.0 | AMD64<br>ARM64<br>ARMv7 |
+v0.24.1             | registry.k8s.io/descheduler/descheduler:v0.24.1 | AMD64<br>ARM64<br>ARMv7 |
+v0.24.0             | registry.k8s.io/descheduler/descheduler:v0.24.0 | AMD64<br>ARM64<br>ARMv7 |
+v0.23.1             | registry.k8s.io/descheduler/descheduler:v0.23.1 | AMD64<br>ARM64<br>ARMv7 |
+v0.22.0             | registry.k8s.io/descheduler/descheduler:v0.22.0 | AMD64<br>ARM64<br>ARMv7 |
+v0.21.0             | registry.k8s.io/descheduler/descheduler:v0.21.0 | AMD64<br>ARM64<br>ARMv7 |
+v0.20.0             | registry.k8s.io/descheduler/descheduler:v0.20.0 | AMD64<br>ARM64          |
+v0.19.0             | registry.k8s.io/descheduler/descheduler:v0.19.0 | AMD64                   |
+v0.18.0             | registry.k8s.io/descheduler/descheduler:v0.18.0 | AMD64                   |
+v0.10.0             | registry.k8s.io/descheduler/descheduler:v0.10.0 | AMD64                   |
 
 Note that multi-arch container images cannot be pulled by [kind](https://kind.sigs.k8s.io) from a registry. Therefore
 starting with descheduler release v0.20.0 use the below process to download the official descheduler
 image into a kind cluster.
 ```
 kind create cluster
-docker pull k8s.gcr.io/descheduler/descheduler:v0.20.0
-kind load docker-image k8s.gcr.io/descheduler/descheduler:v0.20.0
+docker pull registry.k8s.io/descheduler/descheduler:v0.20.0
+kind load docker-image registry.k8s.io/descheduler/descheduler:v0.20.0
 ```
 
 ## Policy Configuration Examples

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
-            image: k8s.gcr.io/descheduler/descheduler:v0.25.0
+            image: registry.k8s.io/descheduler/descheduler:v0.25.1
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: descheduler-sa
       containers:
         - name: descheduler
-          image: k8s.gcr.io/descheduler/descheduler:v0.25.0
+          image: registry.k8s.io/descheduler/descheduler:v0.25.1
           imagePullPolicy: IfNotPresent
           command:
             - "/bin/descheduler"

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
-          image: k8s.gcr.io/descheduler/descheduler:v0.25.0
+          image: registry.k8s.io/descheduler/descheduler:v0.25.1
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume


### PR DESCRIPTION
This updates references from `k8s.gcr.io` to `registry.k8s.io`. More info at https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)