### PR TITLE
parallelize docker build for each arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ push: image
 	$(CONTAINER_ENGINE) tag $(IMAGE) $(IMAGE_GCLOUD)
 	$(CONTAINER_ENGINE) push $(IMAGE_GCLOUD)
 
-push-all: image.amd64 image.arm image.arm64
+push-images:
 	gcloud auth configure-docker
 	for arch in $(ARCHS); do \
 		$(CONTAINER_ENGINE) tag $(IMAGE)-$${arch} $(IMAGE_GCLOUD)-$${arch} ;\
@@ -95,6 +95,8 @@ push-all: image.amd64 image.arm image.arm64
 		DOCKER_CLI_EXPERIMENTAL=enabled $(CONTAINER_ENGINE) manifest annotate --arch $${arch} $(IMAGE_GCLOUD) $(IMAGE_GCLOUD)-$${arch} ;\
 	done
 	DOCKER_CLI_EXPERIMENTAL=enabled $(CONTAINER_ENGINE) manifest push $(IMAGE_GCLOUD) ;\
+
+push-all: image.amd64 image.arm image.arm64 push-images
 
 clean:
 	rm -rf _output

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,14 +7,53 @@ timeout: 1500s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
+    id: image-amd64
     entrypoint: make
     env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
     - VERSION=$_GIT_TAG
     - BASE_REF=$_PULL_BASE_REF
     args:
-    - push-all
+    - image.amd64
+    waitFor: ['-']  # run in parallel
+
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
+    id: image-arm
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - image.arm
+    waitFor: ['-']
+
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
+    id: image-arm64
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - image.arm64
+    waitFor: ['-']
+
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20221007-ad65926f6b'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    - VERSION=$_GIT_TAG
+    - BASE_REF=$_PULL_BASE_REF
+    args:
+    - push-images
+    waitFor:
+    - image-amd64
+    - image-arm
+    - image-arm64
+
+
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution


### PR DESCRIPTION
Builds have been timing out since we run them sequentially [here](https://github.com/kubernetes-sigs/descheduler/blob/9f6afd4d2526cc31e1486d25e2f1ecd1d7476de5/Makefile#L89)

Sample failed build: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-descheduler-push-images/1602480325080911872