### PR TITLE
Allow a setting option `ttlSecondsAfterFinished` for job

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -57,6 +57,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `startingDeadlineSeconds`           | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                |
 | `successfulJobsHistoryLimit`        | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `nil`                                |
 | `failedJobsHistoryLimit`            | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `nil`                                |
+| `ttlSecondsAfterFinished`           | If set, configure `ttlSecondsAfterFinished` for the _descheduler_ job                                                 | `nil`                                |
 | `deschedulingInterval`              | If using kind:Deployment, sets time between consecutive descheduler executions.                                       | `5m`                                 |
 | `replicas`                          | The replica count for Deployment                                                                                      | `1`                                  |
 | `leaderElection`                    | The options for high availability when running replicated components                                                  | _see values.yaml_                    |

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -55,8 +55,8 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `cronJobApiVersion`                 | CronJob API Group Version                                                                                             | `"batch/v1"`                         |
 | `schedule`                          | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                      |
 | `startingDeadlineSeconds`           | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                |
-| `successfulJobsHistoryLimit`        | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `nil`                                |
-| `failedJobsHistoryLimit`            | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `nil`                                |
+| `successfulJobsHistoryLimit`        | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `3`                                  |
+| `failedJobsHistoryLimit`            | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `1`                                  |
 | `ttlSecondsAfterFinished`           | If set, configure `ttlSecondsAfterFinished` for the _descheduler_ job                                                 | `nil`                                |
 | `deschedulingInterval`              | If using kind:Deployment, sets time between consecutive descheduler executions.                                       | `5m`                                 |
 | `replicas`                          | The replica count for Deployment                                                                                      | `1`                                  |

--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -43,46 +43,46 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the _descheduler_ chart and their default values.
 
-| Parameter                           | Description                                                                                                           | Default                              |
-|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------|
-| `kind`                              | Use as CronJob or Deployment                                                                                          | `CronJob`                            |
+| Parameter                           | Description                                                                                                           | Default                                   |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `kind`                              | Use as CronJob or Deployment                                                                                          | `CronJob`                                 |
 | `image.repository`                  | Docker repository to use                                                                                              | `registry.k8s.io/descheduler/descheduler` |
-| `image.tag`                         | Docker tag to use                                                                                                     | `v[chart appVersion]`                |
-| `image.pullPolicy`                  | Docker image pull policy                                                                                              | `IfNotPresent`                       |
-| `imagePullSecrets`                  | Docker repository secrets                                                                                             | `[]`                                 |
-| `nameOverride`                      | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                 |
-| `fullnameOverride`                  | String to fully override `descheduler.fullname` template                                                              | `""`                                 |
-| `cronJobApiVersion`                 | CronJob API Group Version                                                                                             | `"batch/v1"`                         |
-| `schedule`                          | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                      |
-| `startingDeadlineSeconds`           | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                |
-| `successfulJobsHistoryLimit`        | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `3`                                  |
-| `failedJobsHistoryLimit`            | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `1`                                  |
-| `ttlSecondsAfterFinished`           | If set, configure `ttlSecondsAfterFinished` for the _descheduler_ job                                                 | `nil`                                |
-| `deschedulingInterval`              | If using kind:Deployment, sets time between consecutive descheduler executions.                                       | `5m`                                 |
-| `replicas`                          | The replica count for Deployment                                                                                      | `1`                                  |
-| `leaderElection`                    | The options for high availability when running replicated components                                                  | _see values.yaml_                    |
-| `cmdOptions`                        | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                    |
-| `deschedulerPolicy.strategies`      | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                    |
-| `priorityClassName`                 | The name of the priority class to add to pods                                                                         | `system-cluster-critical`            |
-| `rbac.create`                       | If `true`, create & use RBAC resources                                                                                | `true`                               |
-| `resources`                         | Descheduler container CPU and memory requests/limits                                                                  | _see values.yaml_                    |
-| `serviceAccount.create`             | If `true`, create a service account for the cron job                                                                  | `true`                               |
-| `serviceAccount.name`               | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                |
-| `serviceAccount.annotations`        | Specifies custom annotations for the serviceAccount                                                                   | `{}`                                 |
-| `podAnnotations`                    | Annotations to add to the descheduler Pods                                                                            | `{}`                                 |
-| `podLabels`                         | Labels to add to the descheduler Pods                                                                                 | `{}`                                 |
-| `nodeSelector`                      | Node selectors to run the descheduler cronjob/deployment on specific nodes                                            | `nil`                                |
-| `service.enabled`                   | If `true`, create a service for deployment                                                                            | `false`                              |
-| `serviceMonitor.enabled`            | If `true`, create a ServiceMonitor for deployment                                                                     | `false`                              |
-| `serviceMonitor.namespace`          | The namespace where Prometheus expects to find service monitors                                                       | `nil`                                |
-| `serviceMonitor.interval`           | The scrape interval. If not set, the Prometheus default scrape interval is used                                       | `nil`                                |
-| `serviceMonitor.honorLabels`        | Keeps the scraped data's labels when labels are on collisions with target labels.                                     | `true`                               |
-| `serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping                                                                         | `true`                               |
-| `serviceMonitor.serverName`         | Name of the server to use when validating TLS certificate                                                             | `nil`                                |
-| `serviceMonitor.metricRelabelings`  | MetricRelabelConfigs to apply to samples after scraping, but before ingestion                                         | `[]`                                 |
-| `serviceMonitor.relabelings`        | RelabelConfigs to apply to samples before scraping                                                                    | `[]`                                 |
-| `affinity`                          | Node affinity to run the descheduler cronjob/deployment on specific nodes                                             | `nil`                                |
-| `tolerations`                       | tolerations to run the descheduler cronjob/deployment on specific nodes                                               | `nil`                                |
-| `suspend`                           | Set spec.suspend in descheduler cronjob                                                                               | `false`                              |
-| `commonLabels`                      | Labels to apply to all resources                                                                                      | `{}`                                 |
-| `livenessProbe`                     | Liveness probe configuration for the descheduler container                                                            | _see values.yaml_                    |
+| `image.tag`                         | Docker tag to use                                                                                                     | `v[chart appVersion]`                     |
+| `image.pullPolicy`                  | Docker image pull policy                                                                                              | `IfNotPresent`                            |
+| `imagePullSecrets`                  | Docker repository secrets                                                                                             | `[]`                                      |
+| `nameOverride`                      | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                      |
+| `fullnameOverride`                  | String to fully override `descheduler.fullname` template                                                              | `""`                                      |
+| `cronJobApiVersion`                 | CronJob API Group Version                                                                                             | `"batch/v1"`                              |
+| `schedule`                          | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                           |
+| `startingDeadlineSeconds`           | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                     |
+| `successfulJobsHistoryLimit`        | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `3`                                       |
+| `failedJobsHistoryLimit`            | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `1`                                       |
+| `ttlSecondsAfterFinished`           | If set, configure `ttlSecondsAfterFinished` for the _descheduler_ job                                                 | `nil`                                     |
+| `deschedulingInterval`              | If using kind:Deployment, sets time between consecutive descheduler executions.                                       | `5m`                                      |
+| `replicas`                          | The replica count for Deployment                                                                                      | `1`                                       |
+| `leaderElection`                    | The options for high availability when running replicated components                                                  | _see values.yaml_                         |
+| `cmdOptions`                        | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                         |
+| `deschedulerPolicy.strategies`      | The _descheduler_ strategies to apply                                                                                 | _see values.yaml_                         |
+| `priorityClassName`                 | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                 |
+| `rbac.create`                       | If `true`, create & use RBAC resources                                                                                | `true`                                    |
+| `resources`                         | Descheduler container CPU and memory requests/limits                                                                  | _see values.yaml_                         |
+| `serviceAccount.create`             | If `true`, create a service account for the cron job                                                                  | `true`                                    |
+| `serviceAccount.name`               | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                     |
+| `serviceAccount.annotations`        | Specifies custom annotations for the serviceAccount                                                                   | `{}`                                      |
+| `podAnnotations`                    | Annotations to add to the descheduler Pods                                                                            | `{}`                                      |
+| `podLabels`                         | Labels to add to the descheduler Pods                                                                                 | `{}`                                      |
+| `nodeSelector`                      | Node selectors to run the descheduler cronjob/deployment on specific nodes                                            | `nil`                                     |
+| `service.enabled`                   | If `true`, create a service for deployment                                                                            | `false`                                   |
+| `serviceMonitor.enabled`            | If `true`, create a ServiceMonitor for deployment                                                                     | `false`                                   |
+| `serviceMonitor.namespace`          | The namespace where Prometheus expects to find service monitors                                                       | `nil`                                     |
+| `serviceMonitor.interval`           | The scrape interval. If not set, the Prometheus default scrape interval is used                                       | `nil`                                     |
+| `serviceMonitor.honorLabels`        | Keeps the scraped data's labels when labels are on collisions with target labels.                                     | `true`                                    |
+| `serviceMonitor.insecureSkipVerify` | Skip TLS certificate validation when scraping                                                                         | `true`                                    |
+| `serviceMonitor.serverName`         | Name of the server to use when validating TLS certificate                                                             | `nil`                                     |
+| `serviceMonitor.metricRelabelings`  | MetricRelabelConfigs to apply to samples after scraping, but before ingestion                                         | `[]`                                      |
+| `serviceMonitor.relabelings`        | RelabelConfigs to apply to samples before scraping                                                                    | `[]`                                      |
+| `affinity`                          | Node affinity to run the descheduler cronjob/deployment on specific nodes                                             | `nil`                                     |
+| `tolerations`                       | tolerations to run the descheduler cronjob/deployment on specific nodes                                               | `nil`                                     |
+| `suspend`                           | Set spec.suspend in descheduler cronjob                                                                               | `false`                                   |
+| `commonLabels`                      | Labels to apply to all resources                                                                                      | `{}`                                      |
+| `livenessProbe`                     | Liveness probe configuration for the descheduler container                                                            | _see values.yaml_                         |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -23,6 +23,9 @@ spec:
   {{- end }}
   jobTemplate:
     spec:
+      {{- if .Values.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         metadata:
           name: {{ template "descheduler.fullname" . }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -34,6 +34,7 @@ suspend: false
 # startingDeadlineSeconds: 200
 # successfulJobsHistoryLimit: 1
 # failedJobsHistoryLimit: 1
+# ttlSecondsAfterFinished 600
 
 # Required when running as a Deployment
 deschedulingInterval: 5m

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -32,7 +32,7 @@ cronJobApiVersion: "batch/v1"
 schedule: "*/2 * * * *"
 suspend: false
 # startingDeadlineSeconds: 200
-# successfulJobsHistoryLimit: 1
+# successfulJobsHistoryLimit: 3
 # failedJobsHistoryLimit: 1
 # ttlSecondsAfterFinished 600
 


### PR DESCRIPTION
Allow end users to optionally set the descheduler CronJob `.spec.jobTemplate.spec.ttlSecondsAfterFinished` using helm chart.

ref: https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically

and correct & fmt `README.md` because  `successfulJobsHistoryLimit, failedJobsHistoryLimit` have [the default values](https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#jobs-history-limits).