### PR TITLE
Increase cloud build timeout to 1 hour

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 # See https://cloud.google.com/cloud-build/docs/build-config
 
 # this must be specified in seconds. If omitted, defaults to 600s (10 mins)
-timeout: 1800s
+timeout: 3600s
 # this prevents errors if you don't use both _GIT_TAG and _PULL_BASE_REF,
 # or any new substitutions added in the future.
 options:


### PR DESCRIPTION
Doing this as a last resort until we can sort out parallel builds as asked in https://github.com/kubernetes/test-infra/issues/28258, hoping this will unblock our release