### PR TITLE
metrics: enable loop duration and strategy duration metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -48,9 +48,29 @@ var (
 		},
 	)
 
+	DeschedulerLoopDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      DeschedulerSubsystem,
+			Name:           "descheduler_loop_duration_seconds",
+			Help:           "Time taken to complete a strategy descheduling operation",
+			StabilityLevel: metrics.ALPHA,
+			Buckets:        []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500},
+		}, []string{})
+
+	DeschedulerStrategyDuration = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Subsystem:      DeschedulerSubsystem,
+			Name:           "descheduler_strategy_duration_seconds",
+			Help:           "Time taken to complete Each strategy of the descheduling operation",
+			StabilityLevel: metrics.ALPHA,
+			Buckets:        []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100},
+		}, []string{"strategy", "profile"})
+
 	metricsList = []metrics.Registerable{
 		PodsEvicted,
 		buildInfo,
+		DeschedulerLoopDuration,
+		DeschedulerStrategyDuration,
 	}
 )
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -52,7 +52,7 @@ var (
 		&metrics.HistogramOpts{
 			Subsystem:      DeschedulerSubsystem,
 			Name:           "descheduler_loop_duration_seconds",
-			Help:           "Time taken to complete a strategy descheduling operation",
+			Help:           "Time taken to complete a full descheduling cycle",
 			StabilityLevel: metrics.ALPHA,
 			Buckets:        []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500},
 		}, []string{})


### PR DESCRIPTION
This PR enables collection of metrics around the following

1. Amount of time taken for each loop of descheduler operation
2. Amount of time taken for each strategy operation to complete

This represents the values mentioned above as a Histogram with measurements tracked as a factor of seconds in time unit.

Closes #1037 