### PR TITLE
fix:eviction groupversion not support v1beta1

### DIFF
--- a/pkg/descheduler/evictions/utils/utils.go
+++ b/pkg/descheduler/evictions/utils/utils.go
@@ -23,6 +23,7 @@ import (
 const (
 	EvictionKind        = "Eviction"
 	EvictionSubresource = "pods/eviction"
+	EvictionVersionv1   = "v1"
 )
 
 // SupportEviction uses Discovery API to find out if the server support eviction subresource


### PR DESCRIPTION
question:
when running descheduler in k8s cluster(1.19), we can see some error logs, like this:
```bash
I0222 02:55:05.474234 7 removeduplicates.go:203] "Average occurrence per node" node="stark12.add.bjyt.qihoo.net" ownerKey={namespace:kstone kind:TApp name:test131-etcd imagesHash:quay.io/coreos/etcd:v3.4.13} avg=1

E0222 02:55:05.475172 7 evictions.go:143] "Error evicting pod" err="Eviction in version \"v1\" cannot be handled as a Eviction: no kind \"Eviction\" is registered for version \"policy/v1\" in scheme \"k8s.io/kubernetes/pkg/api/legacyscheme/scheme.go:30\"" pod="kstone/test131-etcd-2" reason=""

I0222 02:55:05.475215 7 descheduler.go:424] "Number of evicted pods" totalEvicted=0
```
and in this scenario, we can found :
![截屏2023-02-22 18 45 28](https://user-images.githubusercontent.com/32814765/220598882-21d67b40-a0f6-4d26-bf78-bdcc9305aa4c.png)

the reason for this is that version 1.19 of k8s does not support the eviction resource whose groupversion is v1 