### PR TITLE
Adding descheduler policy API Version option in helm templates

### DIFF
--- a/charts/descheduler/templates/configmap.yaml
+++ b/charts/descheduler/templates/configmap.yaml
@@ -7,6 +7,6 @@ metadata:
     {{- include "descheduler.labels" . | nindent 4 }}
 data:
   policy.yaml: |
-    apiVersion: "descheduler/v1alpha1"
+    apiVersion: "{{ .Values.deschedulerPolicyAPIVersion }}"
     kind: "DeschedulerPolicy"
 {{ toYaml .Values.deschedulerPolicy | trim | indent 4 }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -60,6 +60,9 @@ leaderElection: {}
 cmdOptions:
   v: 3
 
+#It is recommended to use the latest Policy API version
+deschedulerPolicyAPIVersion: "descheduler/v1alpha2"
+
 deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"
   # maxNoOfPodsToEvictPerNode: 10

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -60,7 +60,7 @@ leaderElection: {}
 cmdOptions:
   v: 3
 
-#It is recommended to use the latest Policy API version
+# Recommended to use the latest Policy API version supported by the Descheduler app version
 deschedulerPolicyAPIVersion: "descheduler/v1alpha2"
 
 deschedulerPolicy:

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -61,7 +61,7 @@ cmdOptions:
   v: 3
 
 # Recommended to use the latest Policy API version supported by the Descheduler app version
-deschedulerPolicyAPIVersion: "descheduler/v1alpha2"
+deschedulerPolicyAPIVersion: "descheduler/v1alpha1"
 
 deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"


### PR DESCRIPTION
This PR adds the option to specify descheduler policy API version. Currently the version is hardcoded in helm template/manifest and points to deprecated v1alpha1.

This PR fixes the issue: https://github.com/kubernetes-sigs/descheduler/issues/1069