### PR TITLE
add resource match for removeduplicates

### DIFF
--- a/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
@@ -72,6 +72,7 @@ func TestFindDuplicatePods(t *testing.T) {
 		}
 	})
 	node6 := test.BuildTestNode("n6", 200, 200, 10, nil)
+	node7 := test.BuildTestNode("n7", 2000, 3000, 10, nil)
 
 	p1 := test.BuildTestPod("p1", 100, 0, node1.Name, nil)
 	p1.Namespace = "dev"
@@ -186,6 +187,14 @@ func TestFindDuplicatePods(t *testing.T) {
 		"datacenter": "west",
 	}
 
+	// no enough resource to evict duplicate pods
+	p21 := test.BuildTestPod("p21", 1700, 0, node1.Name, nil)
+	p22 := test.BuildTestPod("p22", 1700, 0, node2.Name, nil)
+	p23 := test.BuildTestPod("p23", 600, 0, node7.Name, nil)
+	p24 := test.BuildTestPod("p24", 600, 0, node7.Name, nil)
+	p23.ObjectMeta.OwnerReferences = ownerRef3
+	p24.ObjectMeta.OwnerReferences = ownerRef3
+
 	testCases := []struct {
 		description             string
 		pods                    []*v1.Pod
@@ -283,6 +292,12 @@ func TestFindDuplicatePods(t *testing.T) {
 			nodes:                   []*v1.Node{node1, node6},
 			expectedEvictedPodCount: 1,
 			nodefit:                 true,
+		},
+		{
+			description:             "no enough resource to evict duplicate pods",
+			pods:                    []*v1.Pod{p21, p22, p23, p24},
+			nodes:                   []*v1.Node{node1, node2, node7},
+			expectedEvictedPodCount: 0,
 		},
 	}
 


### PR DESCRIPTION
getTargetNodes function lacks match resource and that will lead to repeat evicting and re-creating in the same node in every 5min.  PodFitsCurrentNode function can satisfy all matching requirements.
```
I0217 07:43:47.299670       1 removeduplicates.go:103] "Processing node" node="kind-worker3"
I0217 07:43:47.299792       1 removeduplicates.go:103] "Processing node" node="kind-worker2"
I0217 07:43:47.299841       1 removeduplicates.go:103] "Processing node" node="kind-worker"
I0217 07:43:47.299878       1 removeduplicates.go:103] "Processing node" node="kind-control-plane"
I0217 07:43:47.300010       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-tnbgt"
I0217 07:43:47.300086       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-z5rzh"
I0217 07:43:47.300106       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-2hnbx"
I0217 07:43:47.300142       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-c4tt4"
I0217 07:43:47.300162       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-dpfsv"
I0217 07:43:47.300183       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-hcnwt"
I0217 07:43:47.300205       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-nnnk7"
I0217 07:43:47.300217       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-82wbl"
I0217 07:43:47.300232       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-m6fr2"
I0217 07:43:47.300341       1 removeduplicates.go:194] "Adjusting feasible nodes" owner={namespace:default kind:ReplicaSet name:d4-5888544785 imagesHash:nginx:latest} from=4 to=4
I0217 07:43:47.300441       1 removeduplicates.go:203] "Average occurrence per node" node="kind-control-plane" ownerKey={namespace:default kind:ReplicaSet name:d4-5888544785 imagesHash:nginx:latest} avg=3
I0217 07:43:47.322858       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-2hnbx" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:43:47.357189       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-c4tt4" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:43:47.426423       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-dpfsv" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:43:47.475805       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-hcnwt" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:43:47.554166       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-nnnk7" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:43:47.632808       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-82wbl" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:43:47.680516       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-m6fr2" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:43:47.680590       1 descheduler.go:408] "Number of evicted pods" totalEvicted=7
I0217 07:48:47.298827       1 descheduler.go:309] Building a pod evictor
I0217 07:48:47.298982       1 pod_antiaffinity.go:83] "Processing node" node="kind-worker3"
I0217 07:48:47.299120       1 pod_antiaffinity.go:83] "Processing node" node="kind-worker2"
I0217 07:48:47.299277       1 pod_antiaffinity.go:83] "Processing node" node="kind-worker"
I0217 07:48:47.299339       1 pod_antiaffinity.go:83] "Processing node" node="kind-control-plane"
I0217 07:48:47.299976       1 nodeutilization.go:201] "Node is overutilized" node="kind-worker3" usage=map[cpu:7900m memory:426Mi pods:4] usagePercentage=map[cpu:98.75 memory:2.7007255525348275 pods:3.6363636363636362]
I0217 07:48:47.300219       1 nodeutilization.go:201] "Node is overutilized" node="kind-worker2" usage=map[cpu:7900m memory:170Mi pods:3] usagePercentage=map[cpu:98.75 memory:1.0777543284763398 pods:2.727272727272727]
I0217 07:48:47.300244       1 nodeutilization.go:201] "Node is overutilized" node="kind-worker" usage=map[cpu:7900m memory:170Mi pods:3] usagePercentage=map[cpu:98.75 memory:1.0777543284763398 pods:2.727272727272727]
I0217 07:48:47.300263       1 nodeutilization.go:204] "Node is appropriately utilized" node="kind-control-plane" usage=map[cpu:2950m memory:390Mi pods:19] usagePercentage=map[cpu:36.875 memory:2.472495224151603 pods:17.272727272727273]
I0217 07:48:47.300278       1 lownodeutilization.go:134] "Criteria for a node under utilization" CPU=20 Mem=20 Pods=20
I0217 07:48:47.300285       1 lownodeutilization.go:135] "Number of underutilized nodes" totalNumber=0
I0217 07:48:47.300293       1 lownodeutilization.go:148] "Criteria for a node above target utilization" CPU=50 Mem=50 Pods=50
I0217 07:48:47.300299       1 lownodeutilization.go:149] "Number of overutilized nodes" totalNumber=3
I0217 07:48:47.300309       1 lownodeutilization.go:152] "No node is underutilized, nothing to do here, you might tune your thresholds further"
I0217 07:48:47.300450       1 removeduplicates.go:103] "Processing node" node="kind-worker3"
I0217 07:48:47.300537       1 removeduplicates.go:103] "Processing node" node="kind-worker2"
I0217 07:48:47.300612       1 removeduplicates.go:103] "Processing node" node="kind-worker"
I0217 07:48:47.300687       1 removeduplicates.go:103] "Processing node" node="kind-control-plane"
I0217 07:48:47.300815       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-wl4nd"
I0217 07:48:47.300893       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-cx9kf"
I0217 07:48:47.300923       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-z5rzh"
I0217 07:48:47.300938       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-chzmq"
I0217 07:48:47.300961       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-mkh8p"
I0217 07:48:47.300975       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-r88dm"
I0217 07:48:47.300983       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-tnbgt"
I0217 07:48:47.301001       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-cghkw"
I0217 07:48:47.301028       1 removeduplicates.go:162] "Duplicate found" pod="default/d4-5888544785-ctlm4"
I0217 07:48:47.301116       1 removeduplicates.go:194] "Adjusting feasible nodes" owner={namespace:default kind:ReplicaSet name:d4-5888544785 imagesHash:nginx:latest} from=4 to=4
I0217 07:48:47.301149       1 removeduplicates.go:203] "Average occurrence per node" node="kind-control-plane" ownerKey={namespace:default kind:ReplicaSet name:d4-5888544785 imagesHash:nginx:latest} avg=3
I0217 07:48:47.331042       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-z5rzh" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:48:47.359293       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-chzmq" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:48:47.404424       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-mkh8p" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:48:47.435109       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-r88dm" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:48:47.503553       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-tnbgt" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:48:47.552920       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-cghkw" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:48:47.600072       1 evictions.go:162] "Evicted pod" pod="default/d4-5888544785-ctlm4" reason="" strategy="RemoveDuplicates" node="kind-control-plane"
I0217 07:48:47.600174       1 descheduler.go:408] "Number of evicted pods" totalEvicted=7
```