### PR TITLE
bump golangci for go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ARCHS = amd64 arm arm64
 
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitbranch=${BRANCH} -X ${LDFLAG_LOCATION}.gitsha1=${SHA1}"
 
-GOLANGCI_VERSION := v1.49.0
+GOLANGCI_VERSION := v1.52.1
 HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint 2> /dev/null)
 
 GOFUMPT_VERSION := v0.4.0


### PR DESCRIPTION
golangci causes oom/execution-error when ran with go 1.20 (fixed in 1.52.0)

https://github.com/golangci/golangci-lint/issues/3538