### PR TITLE
fix default value assignment of EvictLocalStoragePods

### DIFF
--- a/pkg/framework/plugins/defaultevictor/defaults.go
+++ b/pkg/framework/plugins/defaultevictor/defaults.go
@@ -28,7 +28,7 @@ func SetDefaults_DefaultEvictorArgs(obj *DefaultEvictorArgs) {
 		obj.NodeSelector = ""
 	}
 	if !obj.EvictLocalStoragePods {
-		obj.EvictSystemCriticalPods = false
+		obj.EvictLocalStoragePods = false
 	}
 	if !obj.EvictSystemCriticalPods {
 		obj.EvictSystemCriticalPods = false


### PR DESCRIPTION
Patching 0.26 (0.26.1)
https://github.com/kubernetes-sigs/descheduler/pull/1104#issuecomment-1493447747