### PR TITLE
Add go1.20 to hack/verify-gofmt.sh

### DIFF
--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -23,7 +23,7 @@ DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 GO_VERSION=($(go version))
 
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.17|go1.18|go1.19') ]]; then
+if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.18|go1.19|go1.20') ]]; then
   echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
   exit 1
 fi


### PR DESCRIPTION
Likely causing CI failures like https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_descheduler/1105/pull-descheduler-verify-master/1642849390601179136 after bumping our CI to 1.20 in https://github.com/kubernetes/test-infra/pull/29200