### PR TITLE
Add json tags to internal api fields

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -1,0 +1,38 @@
+name: manifests
+
+on:
+  pull_request:
+
+jobs:
+  deploy:
+    strategy: 
+      matrix:
+        k8s-version: ["v1.26.0"]
+        descheduler-version: ["v0.26.1"]
+        descheduler-api: ["v1alpha1", "v1alpha2"]
+        manifest: ["deployment"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.5.0
+        with:
+          node_image: kindest/node:${{ matrix.k8s-version }}
+          kubectl_version: ${{ matrix.k8s-version }}
+          config: test/kind-config.yaml
+      - name: Build image
+        run: |
+          VERSION="dev" make dev-image
+          docker tag descheduler:dev registry.k8s.io/descheduler/descheduler:${{ matrix.descheduler-version }}
+      - name: Kind load image
+        run: |
+          kind load docker-image registry.k8s.io/descheduler/descheduler:${{ matrix.descheduler-version }} --name chart-testing
+      - name: Create k8s manifests
+        run: |
+          kubectl create -f kubernetes/base/rbac.yaml
+          kubectl create -f test/manifests/${{ matrix.descheduler-api }}/configmap.yaml
+          kubectl create -f kubernetes/${{ matrix.manifest }}/${{ matrix.manifest }}.yaml
+      - name: Wait for ready condition
+        run: |
+          kubectl wait --for=condition=Available --timeout=60s ${{ matrix.manifest }} descheduler -n kube-system

--- a/kubernetes/base/configmap.yaml
+++ b/kubernetes/base/configmap.yaml
@@ -6,23 +6,26 @@ metadata:
   namespace: kube-system
 data:
   policy.yaml: |
-    apiVersion: "descheduler/v1alpha1"
+    apiVersion: "descheduler/v1alpha2"
     kind: "DeschedulerPolicy"
-    strategies:
-      "RemoveDuplicates":
-         enabled: true
-      "RemovePodsViolatingInterPodAntiAffinity":
-         enabled: true
-      "LowNodeUtilization":
-         enabled: true
-         params:
-           nodeResourceUtilizationThresholds:
-             thresholds:
-               "cpu" : 20
-               "memory": 20
-               "pods": 20
-             targetThresholds:
-               "cpu" : 50
-               "memory": 50
-               "pods": 50
-
+    profiles:
+      - name: ProfileName
+        pluginConfig:
+        - name: "DefaultEvictor"
+        - name: "RemovePodsViolatingInterPodAntiAffinity"
+        - name: "LowNodeUtilization"
+          args:
+            thresholds:
+              "cpu" : 20
+              "memory": 20
+              "pods": 20
+            targetThresholds:
+              "cpu" : 50
+              "memory": 50
+              "pods": 50
+        plugins:
+          balance:
+            enabled:
+              - "LowNodeUtilization"
+              - "RemovePodsViolatingInterPodAntiAffinity"
+              - "RemoveDuplicates

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -43,8 +43,8 @@ type DeschedulerPolicy struct {
 // Namespaces carries a list of included/excluded namespaces
 // for which a given strategy is applicable
 type Namespaces struct {
-	Include []string
-	Exclude []string
+	Include []string `json:"include"`
+	Exclude []string `json:"exclude"`
 }
 
 type (
@@ -53,8 +53,8 @@ type (
 )
 
 type PriorityThreshold struct {
-	Value *int32
-	Name  string
+	Value *int32 `json:"value"`
+	Name  string `json:"name"`
 }
 
 type DeschedulerProfile struct {

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/test/manifests/v1alpha1/configmap.yaml
+++ b/test/manifests/v1alpha1/configmap.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: descheduler-policy-configmap
+  namespace: kube-system
+data:
+  policy.yaml: |
+    apiVersion: "descheduler/v1alpha1"
+    kind: "DeschedulerPolicy"
+    strategies:
+      "RemoveDuplicates":
+         enabled: true
+      "RemovePodsViolatingInterPodAntiAffinity":
+         enabled: true
+      "LowNodeUtilization":
+         enabled: true
+         params:
+           nodeResourceUtilizationThresholds:
+             thresholds:
+               "cpu" : 20
+               "memory": 20
+               "pods": 20
+             targetThresholds:
+               "cpu" : 50
+               "memory": 50
+               "pods": 50

--- a/test/manifests/v1alpha2/configmap.yaml
+++ b/test/manifests/v1alpha2/configmap.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: descheduler-policy-configmap
+  namespace: kube-system
+data:
+  policy.yaml: |
+    apiVersion: "descheduler/v1alpha2"
+    kind: "DeschedulerPolicy"
+    profiles:
+      - name: ProfileName
+        pluginConfig:
+        - name: "DefaultEvictor"
+          args:
+            priorityThreshold:
+              value: 10000
+        - name: "PodLifeTime"
+          args:
+            maxPodLifeTimeSeconds: 86400
+            namespaces:
+              include:
+              - "namespace1"
+              - "namespace2"
+        plugins:
+          deschedule:
+            enabled:
+              - "PodLifeTime"
+


### PR DESCRIPTION
Fixes #1121 

Plugin arg objects refer to the internal API type for some settings, but those types don't have json tags which causes an error trying to decode the config. This adds json tags to those types and sets up a new github workflow for testing that the descheduler is deployed in a kind cluster and starts running successfully.

As a follow up, we should expand the test suite to cover all possible plugin configurations (ie, a big config file that uses every setting possible) for both v1alpha1 and v1alpha2.

We also might want to just copy these internal types to the v1alpha2 package and use those, if possible.