### PR TITLE
fix plugin arg conversion when using multiple profiles with same plugin

### DIFF
--- a/pkg/api/v1alpha2/conversion.go
+++ b/pkg/api/v1alpha2/conversion.go
@@ -88,7 +88,7 @@ func convertToInternalPluginConfigArgs(out *api.DeschedulerPolicy) error {
 func Convert_v1alpha2_PluginConfig_To_api_PluginConfig(in *PluginConfig, out *api.PluginConfig, s conversion.Scope) error {
 	out.Name = in.Name
 	if _, ok := pluginregistry.PluginRegistry[in.Name]; ok {
-		out.Args = pluginregistry.PluginRegistry[in.Name].PluginArgInstance
+		out.Args = pluginregistry.PluginRegistry[in.Name].PluginArgInstance.DeepCopyObject()
 		if in.Args.Raw != nil {
 			_, _, err := Codecs.UniversalDecoder().Decode(in.Args.Raw, nil, out.Args)
 			if err != nil {

--- a/pkg/descheduler/policyconfig.go
+++ b/pkg/descheduler/policyconfig.go
@@ -137,11 +137,6 @@ func validateDeschedulerConfiguration(in api.DeschedulerPolicy, registry pluginr
 	for _, profile := range in.Profiles {
 		for _, pluginConfig := range profile.PluginConfigs {
 			if _, ok := registry[pluginConfig.Name]; ok {
-				if _, ok := registry[pluginConfig.Name]; !ok {
-					errorsInProfiles = fmt.Errorf("%w: %s", errorsInProfiles, fmt.Sprintf("in profile %s: plugin %s in pluginConfig not registered", profile.Name, pluginConfig.Name))
-					continue
-				}
-
 				pluginUtilities := registry[pluginConfig.Name]
 				if pluginUtilities.PluginArgValidator == nil {
 					continue
@@ -154,6 +149,9 @@ func validateDeschedulerConfiguration(in api.DeschedulerPolicy, registry pluginr
 						errorsInProfiles = fmt.Errorf("%w: %s", errorsInProfiles, fmt.Sprintf("in profile %s: %s", profile.Name, err.Error()))
 					}
 				}
+			} else {
+				errorsInProfiles = fmt.Errorf("%w: %s", errorsInProfiles, fmt.Sprintf("in profile %s: plugin %s in pluginConfig not registered", profile.Name, pluginConfig.Name))
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
If you have multiple profiles and reuse the plugin, the values stump over each other because we were reusing the same `PluginArgInstance`.

closes #1142 