### PR TITLE
Use dl.k8s.io instead of kubernetes-release bucket

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -26,7 +26,7 @@ if [ -n "$KIND_E2E" ]; then
     # If we did not set SKIP_INSTALL
     if [ -z "$SKIP_INSTALL" ]; then
         K8S_VERSION=${KUBERNETES_VERSION:-v1.27.0}
-        curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
+        curl -Lo kubectl https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
         wget https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-linux-amd64
         chmod +x kind-linux-amd64
         mv kind-linux-amd64 kind


### PR DESCRIPTION
This PR replace references of https://storage.googleapis.com/kubernetes-release with https://dl.k8s.io 
https://github.com/kubernetes/k8s.io/issues/2396