### PR TITLE
helm: ability to override command and args. set args inline

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -66,15 +66,11 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command:
-                - "/bin/descheduler"
+                {{- toYaml .Values.command | nindent 16 }}
               args:
-                - "--policy-config-file"
-                - "/policy-dir/policy.yaml"
+                - --policy-config-file: "/policy-dir/policy.yaml"
                 {{- range $key, $value := .Values.cmdOptions }}
-                - {{ printf "--%s" $key | quote }}
-                {{- if $value }}
-                - {{ $value | quote }}
-                {{- end }}
+                - {{ printf "--%s" $key }}{{ if $value }}={{ $value }}{{ end }}
                 {{- end }}
               livenessProbe:
                 {{- toYaml .Values.livenessProbe | nindent 16 }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -44,17 +44,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - "/bin/descheduler"
+            {{- toYaml .Values.command | nindent 12 }}
           args:
-            - "--policy-config-file"
-            - "/policy-dir/policy.yaml"
-            - "--descheduling-interval"
-            - {{ required "deschedulingInterval required for running as Deployment" .Values.deschedulingInterval }}
+            - --policy-config-file=/policy-dir/policy.yaml
+            - --descheduling-interval={{ required "deschedulingInterval required for running as Deployment" .Values.deschedulingInterval }}
             {{- range $key, $value := .Values.cmdOptions }}
-            - {{ printf "--%s" $key | quote }}
-            {{- if $value }}
-            - {{ $value | quote }}
-            {{- end }}
+            - {{ printf "--%s" $key }}{{ if $value }}={{ $value }}{{ end }}
             {{- end }}
             {{- include "descheduler.leaderElection" . | nindent 12 }}
           ports:

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -67,6 +67,9 @@ leaderElection: {}
 #  resourceName: "descheduler"
 #  resourceNamescape: "kube-system"
 
+command:
+- "/bin/descheduler"
+
 cmdOptions:
   v: 3
 


### PR DESCRIPTION
1. ability to override comand and args from helm value. for example we pipe certain commands and as a result, we're using kustomize to patch it since helm doesn't provide the cmd/args values
2. set args inline to make booleans work.
  `$key=$value` as opposed to:
  ```
  - --key
  - value
  ```
  
  Currently this is failing for me:
  ```
  - --dry-run
  - false # this is an issue
  ```
  
  but this works:
  ```
  - --dry-run=false
  ```