### PR TITLE
Implement preferredDuringSchedulingIgnoredDuringExecution for RemovePodsViolatingNodeAffinity

### DIFF
--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -215,7 +215,7 @@ func TestPodFitsCurrentNode(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
-			actual := PodFitsCurrentNode(getPodsAssignedToNode, tc.pod, tc.node)
+			actual := PodFitsCurrentNode(getPodsAssignedToNode, tc.pod, tc.node, false)
 			if actual != tc.success {
 				t.Errorf("Test %#v failed", tc.description)
 			}
@@ -745,7 +745,7 @@ func TestPodFitsAnyOtherNode(t *testing.T) {
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
-			actual := PodFitsAnyOtherNode(getPodsAssignedToNode, tc.pod, tc.nodes)
+			actual := PodFitsAnyOtherNode(getPodsAssignedToNode, tc.pod, tc.nodes, false)
 			if actual != tc.success {
 				t.Errorf("Test %#v failed", tc.description)
 			}
@@ -804,7 +804,7 @@ func TestNodeFit(t *testing.T) {
 
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
-			if errs := NodeFit(getPodsAssignedToNode, tc.pod, tc.node); (len(errs) == 0 && tc.err != nil) || errs[0].Error() != tc.err.Error() {
+			if errs := NodeFit(getPodsAssignedToNode, tc.pod, tc.node, false); (len(errs) == 0 && tc.err != nil) || errs[0].Error() != tc.err.Error() {
 				t.Errorf("Test %#v failed, got %v, expect %v", tc.description, errs, tc.err)
 			}
 		})

--- a/pkg/framework/plugins/defaultevictor/defaultevictor.go
+++ b/pkg/framework/plugins/defaultevictor/defaultevictor.go
@@ -159,7 +159,7 @@ func (d *DefaultEvictor) PreEvictionFilter(pod *v1.Pod) bool {
 			klog.ErrorS(fmt.Errorf("Pod fails the following checks"), "pod", klog.KObj(pod))
 			return false
 		}
-		if !nodeutil.PodFitsAnyOtherNode(d.handle.GetPodsAssignedToNodeFunc(), pod, nodes) {
+		if !nodeutil.PodFitsAnyOtherNode(d.handle.GetPodsAssignedToNodeFunc(), pod, nodes, false) {
 			klog.ErrorS(fmt.Errorf("pod does not fit on any other node because of nodeSelector(s), Taint(s), or nodes marked as unschedulable"), "pod", klog.KObj(pod))
 			return false
 		}

--- a/pkg/framework/plugins/removeduplicates/removeduplicates.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates.go
@@ -254,7 +254,7 @@ func getTargetNodes(podNodes map[string][]*v1.Pod, nodes []*v1.Node) []*v1.Node 
 			}) {
 				continue
 			}
-			if match, err := utils.PodMatchNodeSelector(pod, node); err == nil && !match {
+			if match, err := utils.PodMatchNodeSelector(pod, node, false); err == nil && !match {
 				continue
 			}
 			matchingNodes[node.Name] = node

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -340,7 +340,7 @@ func balanceDomains(
 			// This is because the chosen pods aren't sorted, but immovable pods still count as "evicted" toward the PTS algorithm.
 			// So, a better selection heuristic could improve performance.
 
-			if !node.PodFitsAnyOtherNode(getPodsAssignedToNode, aboveToEvict[k], nodesBelowIdealAvg) {
+			if !node.PodFitsAnyOtherNode(getPodsAssignedToNode, aboveToEvict[k], nodesBelowIdealAvg, false) {
 				klog.V(2).InfoS("ignoring pod for eviction as it does not fit on any other node", "pod", klog.KObj(aboveToEvict[k]))
 				continue
 			}


### PR DESCRIPTION
The descheduler can now evict pods that violate a "preferred..." node affinity. When it detects pods with this violation, it checks if they fit in some other node and they don't violate this affinity in the new node.

In the current implementation, setting
preferredDuringSchedulingIgnoredDuringExecution evicts also pods that violate requiredDuringSchedulingIgnoredDuringExecution.