### PR TITLE
FakeClientset: bump watch channel size

### DIFF
--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/watch"
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/mux"
 	restclient "k8s.io/client-go/rest"
@@ -111,6 +112,9 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 }
 
 func Run(ctx context.Context, rs *options.DeschedulerServer) error {
+	// increase the fake watch channel so the dry-run mode can be run
+	// over a cluster with thousands of pods
+	watch.DefaultChanSize = 100000
 	return descheduler.Run(ctx, rs)
 }
 


### PR DESCRIPTION
Huge clusters with thousands of pods can quickly exceed the default watch channel size of the fake clientset. Causing the channel to panic with "channel full".