### PR TITLE
Bump golangci lint timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ lint:
 ifndef HAS_GOLANGCI
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./_output/bin ${GOLANGCI_VERSION}
 endif
-	./_output/bin/golangci-lint run
+	./_output/bin/golangci-lint run --timeout 10m
 
 fmt:
 ifndef HAS_GOFUMPT


### PR DESCRIPTION
/hold
for debugging purposes only

Debugging https://github.com/kubernetes-sigs/descheduler/pull/1174