### PR TITLE
.gitattribute to not pollute PRs or stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Always check-out / check-in files with LF line endings.
+* text=auto eol=lf
+
+go.sum merge=union
+**/zz_generated.*.go linguist-generated=true
+vendor/** linguist-vendored


### PR DESCRIPTION
Per: https://github.com/github-linguist/linguist/blob/master/docs/overrides.md

Also see: https://github.com/kubernetes/kubernetes/blob/master/.gitattributes

### Summary

<!------------------------------------------------------------------------------------------------------------------------------------------->
 | Git attribute                                  | Defined in            | Effect on file                                                  |
 |:-----------------------------------------------|:----------------------|:----------------------------------------------------------------|
 | `linguist-detectable`                          | [`languages.yml`]     | Included in stats, even if language's type is `data` or `prose` |
 | `linguist-documentation`                       | [`documentation.yml`] | Excluded from stats                                             |
 | `linguist-generated`                           | [`generated.rb`]      | Excluded from stats, hidden in diffs                            |
 | `linguist-language`=<var><ins>name</ins></var> | [`languages.yml`]     | Highlighted and classified as <var><ins>name</ins></var>        |
 | `linguist-vendored`                            | [`vendor.yml`]        | Excluded from stats                                             |
<!------------------------------------------------------------------------------------------------------------------------------------------->