### PR TITLE
Allow namespace filter to use regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,8 @@ The following strategies accept a `namespaces` parameter which allows to specify
 * `RemovePodsViolatingTopologySpreadConstraint`
 * `RemoveFailedPods`
 
+The list of including, excluding namespaces are treated as string patterns and compiled into regular expressions.
+It adds `^` and `$` at the beginning and end of each pattern to ensure matching the entire string.
 
 The following strategies accept a `evictableNamespaces` parameter which allows to specify a list of excluding namespaces:
 * `LowNodeUtilization` and `HighNodeUtilization` (Only filtered right before eviction)
@@ -722,13 +724,14 @@ profiles:
           include:
           - "namespace1"
           - "namespace2"
+          - "namespace1\d"
     plugins:
       deschedule:
         enabled:
           - "PodLifeTime"
 ```
 
-In the example `PodLifeTime` gets executed only over `namespace1` and `namespace2`.
+In the example `PodLifeTime` gets executed only over `namespace1`, `namespace2` and namespaces matched with `^namespace1\d$` pattern.
 The similar holds for `exclude` field:
 
 ```yaml
@@ -744,13 +747,14 @@ profiles:
           exclude:
           - "namespace1"
           - "namespace2"
+          - "namespace1\d"
     plugins:
       deschedule:
         enabled:
           - "PodLifeTime"
 ```
 
-The strategy gets executed over all namespaces but `namespace1` and `namespace2`.
+The strategy gets executed over all namespaces but `namespace1`, `namespace2` and namespaces matched with `^namespace1\d$` pattern.
 
 It's not allowed to compute `include` with `exclude` field.
 

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -67,8 +67,10 @@ type DeschedulerStrategy struct {
 	Params *StrategyParameters `json:"params,omitempty"`
 }
 
-// Namespaces carries a list of included/excluded namespaces
-// for which a given strategy is applicable.
+// Namespaces carries a list of included/excluded namespaces for which a given
+// strategy is applicable. They are string patterns and compiled into regular
+// expressions. It adds "^" and "$" at the beginning and end of each pattern to
+// ensure matching the entire string.
 type Namespaces struct {
 	Include []string `json:"include"`
 	Exclude []string `json:"exclude"`

--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	"sigs.k8s.io/descheduler/pkg/descheduler/node"
@@ -282,9 +281,9 @@ func evictPods(
 	podEvictor frameworktypes.Evictor,
 	continueEviction continueEvictionCond,
 ) {
-	var excludedNamespaces sets.Set[string]
+	var excludedNamespaces []string
 	if evictableNamespaces != nil {
-		excludedNamespaces = sets.New(evictableNamespaces.Exclude...)
+		excludedNamespaces = evictableNamespaces.Exclude
 	}
 
 	if continueEviction(nodeInfo, totalAvailableUsage) {

--- a/pkg/framework/plugins/podlifetime/pod_lifetime.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime.go
@@ -49,10 +49,10 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("want args to be of type PodLifeTimeArgs, got %T", args)
 	}
 
-	var includedNamespaces, excludedNamespaces sets.Set[string]
+	var includedNamespaces, excludedNamespaces []string
 	if podLifeTimeArgs.Namespaces != nil {
-		includedNamespaces = sets.New(podLifeTimeArgs.Namespaces.Include...)
-		excludedNamespaces = sets.New(podLifeTimeArgs.Namespaces.Exclude...)
+		includedNamespaces = podLifeTimeArgs.Namespaces.Include
+		excludedNamespaces = podLifeTimeArgs.Namespaces.Exclude
 	}
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter

--- a/pkg/framework/plugins/removeduplicates/removeduplicates.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates.go
@@ -64,10 +64,10 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("want args to be of type RemoveDuplicatesArgs, got %T", args)
 	}
 
-	var includedNamespaces, excludedNamespaces sets.Set[string]
+	var includedNamespaces, excludedNamespaces []string
 	if removeDuplicatesArgs.Namespaces != nil {
-		includedNamespaces = sets.New(removeDuplicatesArgs.Namespaces.Include...)
-		excludedNamespaces = sets.New(removeDuplicatesArgs.Namespaces.Exclude...)
+		includedNamespaces = removeDuplicatesArgs.Namespaces.Include
+		excludedNamespaces = removeDuplicatesArgs.Namespaces.Exclude
 	}
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter

--- a/pkg/framework/plugins/removefailedpods/failedpods.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods.go
@@ -50,10 +50,10 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("want args to be of type RemoveFailedPodsArgs, got %T", args)
 	}
 
-	var includedNamespaces, excludedNamespaces sets.Set[string]
+	var includedNamespaces, excludedNamespaces []string
 	if failedPodsArgs.Namespaces != nil {
-		includedNamespaces = sets.New(failedPodsArgs.Namespaces.Include...)
-		excludedNamespaces = sets.New(failedPodsArgs.Namespaces.Exclude...)
+		includedNamespaces = failedPodsArgs.Namespaces.Include
+		excludedNamespaces = failedPodsArgs.Namespaces.Exclude
 	}
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
@@ -50,10 +50,10 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("want args to be of type RemovePodsHavingTooManyRestartsArgs, got %T", args)
 	}
 
-	var includedNamespaces, excludedNamespaces sets.Set[string]
+	var includedNamespaces, excludedNamespaces []string
 	if tooManyRestartsArgs.Namespaces != nil {
-		includedNamespaces = sets.New(tooManyRestartsArgs.Namespaces.Include...)
-		excludedNamespaces = sets.New(tooManyRestartsArgs.Namespaces.Exclude...)
+		includedNamespaces = tooManyRestartsArgs.Namespaces.Include
+		excludedNamespaces = tooManyRestartsArgs.Namespaces.Exclude
 	}
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
@@ -50,10 +49,10 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("want args to be of type RemovePodsViolatingInterPodAntiAffinityArgs, got %T", args)
 	}
 
-	var includedNamespaces, excludedNamespaces sets.Set[string]
+	var includedNamespaces, excludedNamespaces []string
 	if interPodAntiAffinityArgs.Namespaces != nil {
-		includedNamespaces = sets.New(interPodAntiAffinityArgs.Namespaces.Include...)
-		excludedNamespaces = sets.New(interPodAntiAffinityArgs.Namespaces.Exclude...)
+		includedNamespaces = interPodAntiAffinityArgs.Namespaces.Include
+		excludedNamespaces = interPodAntiAffinityArgs.Namespaces.Exclude
 	}
 
 	podFilter, err := podutil.NewOptions().

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -46,10 +45,10 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("want args to be of type RemovePodsViolatingNodeAffinityArgs, got %T", args)
 	}
 
-	var includedNamespaces, excludedNamespaces sets.Set[string]
+	var includedNamespaces, excludedNamespaces []string
 	if nodeAffinityArgs.Namespaces != nil {
-		includedNamespaces = sets.New(nodeAffinityArgs.Namespaces.Include...)
-		excludedNamespaces = sets.New(nodeAffinityArgs.Namespaces.Exclude...)
+		includedNamespaces = nodeAffinityArgs.Namespaces.Include
+		excludedNamespaces = nodeAffinityArgs.Namespaces.Exclude
 	}
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -50,10 +50,10 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("want args to be of type RemovePodsViolatingNodeTaintsArgs, got %T", args)
 	}
 
-	var includedNamespaces, excludedNamespaces sets.Set[string]
+	var includedNamespaces, excludedNamespaces []string
 	if nodeTaintsArgs.Namespaces != nil {
-		includedNamespaces = sets.New(nodeTaintsArgs.Namespaces.Include...)
-		excludedNamespaces = sets.New(nodeTaintsArgs.Namespaces.Exclude...)
+		includedNamespaces = nodeTaintsArgs.Namespaces.Include
+		excludedNamespaces = nodeTaintsArgs.Namespaces.Exclude
 	}
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter


### PR DESCRIPTION
This PR allow namespace filter to use regular expressions.

The current namespace filter does not support cases where namespaces are dynamically created. In #901, namespace selector was proposed, but in my use case, regular expressions are sufficient.