### PR TITLE
feat: Implement preferredDuringSchedulingIgnoredDuringExecution for RemovePodsViolatingNodeAffinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,10 @@ profiles:
 This strategy makes sure all pods violating
 [node affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#node-affinity)
 are eventually removed from nodes. Node affinity rules allow a pod to specify
-`requiredDuringSchedulingIgnoredDuringExecution` type, which tells the scheduler
+`requiredDuringSchedulingIgnoredDuringExecution` and/or
+`preferredDuringSchedulingIgnoredDuringExecution`.
+
+The `requiredDuringSchedulingIgnoredDuringExecution` type tells the scheduler
 to respect node affinity when scheduling the pod but kubelet to ignore
 in case node changes over time and no longer respects the affinity.
 When enabled, the strategy serves as a temporary implementation
@@ -448,6 +451,14 @@ affinity rule `requiredDuringSchedulingIgnoredDuringExecution` at the time
 of scheduling. Over time nodeA stops to satisfy the rule. When the strategy gets
 executed and there is another node available that satisfies the node affinity rule,
 podA gets evicted from nodeA.
+
+The `preferredDuringSchedulingIgnoredDuringExecution` type tells the scheduler
+to respect node affinity when scheduling if that's possible. If not, the pod
+gets scheduled anyway. It may happen that, over time, the state of the cluster
+changes and now the pod can be scheduled on a node that actually fits its
+preferred node affinity. When enabled, the strategy serves as a temporary
+implementation of `preferredDuringSchedulingPreferredDuringExecution`, so the
+pod will be evicted if it can be scheduled on a "better" node.
 
 **Parameters:**
 

--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -289,3 +289,37 @@ func IsBasicResource(name v1.ResourceName) bool {
 		return false
 	}
 }
+
+// Returns the weight that the pod gives to a node by analyzing the
+// soft node affinity of that pod
+// (nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution)
+func PodNodeAffinityWeight(pod *v1.Pod, node *v1.Node) int32 {
+	totalWeight, err := utils.PodNodeAffinityWeight(pod, node)
+	if err != nil {
+		return 0
+	}
+	return totalWeight
+}
+
+// Returns the best weight (maximum one) that the pod gives to the
+// best node by analyzing the soft node affinity of that pod
+// (nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution)
+func BestPodNodeAffinityWeight(pod *v1.Pod, nodes []*v1.Node) int32 {
+	var bestWeight int32 = 0
+	for _, node := range nodes {
+		weight := PodNodeAffinityWeight(pod, node)
+		if weight > bestWeight {
+			bestWeight = weight
+		}
+	}
+	return bestWeight
+}
+
+// PodMatchNodeSelector checks if a pod node selector matches the node label.
+func PodMatchNodeSelector(pod *v1.Pod, node *v1.Node) bool {
+	matches, err := utils.PodMatchNodeSelector(pod, node)
+	if err != nil {
+		return false
+	}
+	return matches
+}

--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -290,24 +290,24 @@ func IsBasicResource(name v1.ResourceName) bool {
 	}
 }
 
-// Returns the weight that the pod gives to a node by analyzing the
-// soft node affinity of that pod
+// GetNodeWeightGivenPodPreferredAffinity returns the weight
+// that the pod gives to a node by analyzing the soft node affinity of that pod
 // (nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution)
-func PodNodeAffinityWeight(pod *v1.Pod, node *v1.Node) int32 {
-	totalWeight, err := utils.PodNodeAffinityWeight(pod, node)
+func GetNodeWeightGivenPodPreferredAffinity(pod *v1.Pod, node *v1.Node) int32 {
+	totalWeight, err := utils.GetNodeWeightGivenPodPreferredAffinity(pod, node)
 	if err != nil {
 		return 0
 	}
 	return totalWeight
 }
 
-// Returns the best weight (maximum one) that the pod gives to the
-// best node by analyzing the soft node affinity of that pod
-// (nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution)
-func BestPodNodeAffinityWeight(pod *v1.Pod, nodes []*v1.Node) int32 {
+// GetBestNodeWeightGivenPodPreferredAffinity returns the best weight
+// (maximum one) that the pod gives to the best node by analyzing the soft node affinity
+// of that pod (nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution)
+func GetBestNodeWeightGivenPodPreferredAffinity(pod *v1.Pod, nodes []*v1.Node) int32 {
 	var bestWeight int32 = 0
 	for _, node := range nodes {
-		weight := PodNodeAffinityWeight(pod, node)
+		weight := GetNodeWeightGivenPodPreferredAffinity(pod, node)
 		if weight > bestWeight {
 			bestWeight = weight
 		}

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -875,7 +875,7 @@ func TestBestPodNodeAffinityWeight(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
-			bestWeight := BestPodNodeAffinityWeight(tc.pod, tc.nodes)
+			bestWeight := GetBestNodeWeightGivenPodPreferredAffinity(tc.pod, tc.nodes)
 			if bestWeight != tc.expectedWeight {
 				t.Errorf("Test %#v failed", tc.description)
 			}

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -811,6 +811,78 @@ func TestNodeFit(t *testing.T) {
 	}
 }
 
+func TestBestPodNodeAffinityWeight(t *testing.T) {
+	defaultPod := test.BuildTestPod("p1", 0, 0, "node1", func(p *v1.Pod) {
+		p.Spec.Affinity = &v1.Affinity{
+			NodeAffinity: &v1.NodeAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+					{
+						Weight: 10,
+						Preference: v1.NodeSelectorTerm{
+							MatchExpressions: []v1.NodeSelectorRequirement{
+								{
+									Key:      "key1",
+									Operator: "In",
+									Values:   []string{"value1"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	tests := []struct {
+		description    string
+		pod            *v1.Pod
+		nodes          []*v1.Node
+		expectedWeight int32
+	}{
+		{
+			description: "No node matches the preferred affinity",
+			pod:         defaultPod,
+			nodes: []*v1.Node{
+				test.BuildTestNode("node2", 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						"key2": "value2",
+					}
+				}),
+				test.BuildTestNode("node3", 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						"key3": "value3",
+					}
+				}),
+			},
+			expectedWeight: 0,
+		},
+		{
+			description: "A single node matches the preferred affinity",
+			pod:         defaultPod,
+			nodes: []*v1.Node{
+				test.BuildTestNode("node1", 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						"key1": "value1",
+					}
+				}),
+				test.BuildTestNode("node2", 64000, 128*1000*1000*1000, 200, func(node *v1.Node) {
+					node.ObjectMeta.Labels = map[string]string{
+						"key2": "value2",
+					}
+				}),
+			},
+			expectedWeight: 10,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			bestWeight := BestPodNodeAffinityWeight(tc.pod, tc.nodes)
+			if bestWeight != tc.expectedWeight {
+				t.Errorf("Test %#v failed", tc.description)
+			}
+		})
+	}
+}
+
 // createResourceList builds a small resource list of core resources
 func createResourceList(cpu, memory, ephemeralStorage int64) v1.ResourceList {
 	resourceList := make(map[v1.ResourceName]resource.Quantity)

--- a/pkg/utils/pod.go
+++ b/pkg/utils/pod.go
@@ -213,3 +213,28 @@ func PodToleratesTaints(pod *v1.Pod, taintsOfNodes map[string][]v1.Taint) bool {
 	}
 	return false
 }
+
+// PodHasNodeAffinity returns true if the pod has a node affinity of type
+// `nodeAffinityType` defined. The nodeAffinityType param can take this two values:
+// "requiredDuringSchedulingIgnoredDuringExecution" or "requiredDuringSchedulingIgnoredDuringExecution"
+func PodHasNodeAffinity(pod *v1.Pod, nodeAffinityType NodeAffinityType) bool {
+	if pod.Spec.Affinity == nil {
+		return false
+	}
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		return false
+	}
+	if nodeAffinityType == RequiredDuringSchedulingIgnoredDuringExecution {
+		return pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil
+	} else if nodeAffinityType == PreferredDuringSchedulingIgnoredDuringExecution {
+		return len(pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution) > 0
+	}
+	return false
+}
+
+type NodeAffinityType string
+
+const (
+	RequiredDuringSchedulingIgnoredDuringExecution  NodeAffinityType = "requiredDuringSchedulingIgnoredDuringExecution"
+	PreferredDuringSchedulingIgnoredDuringExecution NodeAffinityType = "preferredDuringSchedulingIgnoredDuringExecution"
+)

--- a/pkg/utils/predicates.go
+++ b/pkg/utils/predicates.go
@@ -279,10 +279,8 @@ func TolerationsEqual(t1, t2 []v1.Toleration) bool {
 // Returns the weight that the pod gives to a node by analyzing the
 // soft node affinity of that pod
 // (nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution)
-func PodNodeAffinityWeight(pod *v1.Pod, node *v1.Node) (int32, error) {
-	if pod.Spec.Affinity == nil ||
-		pod.Spec.Affinity.NodeAffinity == nil ||
-		len(pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution) == 0 {
+func GetNodeWeightGivenPodPreferredAffinity(pod *v1.Pod, node *v1.Node) (int32, error) {
+	if !PodHasNodeAffinity(pod, PreferredDuringSchedulingIgnoredDuringExecution) {
 		return 0, nil
 	}
 	// Iterate over each PreferredSchedulingTerm and check if it matches with the current node labels.

--- a/pkg/utils/predicates_test.go
+++ b/pkg/utils/predicates_test.go
@@ -1031,7 +1031,7 @@ func TestPodNodeAffinityWeight(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			pod := v1.Pod{}
 			pod.Spec.Affinity = test.affinity
-			totalWeight, err := PodNodeAffinityWeight(&pod, &defaultNode)
+			totalWeight, err := GetNodeWeightGivenPodPreferredAffinity(&pod, &defaultNode)
 			if err != nil {
 				t.Error("Found non nil error")
 			}

--- a/pkg/utils/predicates_test.go
+++ b/pkg/utils/predicates_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestUniqueSortTolerations(t *testing.T) {
@@ -934,6 +935,108 @@ func TestNodeSelectorTermsEqual(t *testing.T) {
 			equal := NodeSelectorsEqual(&test.leftSelector, &test.rightSelector)
 			if equal != test.equal {
 				t.Errorf("NodeSelectorsEqual expected to be %v, got %v", test.equal, equal)
+			}
+		})
+	}
+}
+
+func createNodeSelectorTerm(key, value string) v1.NodeSelectorTerm {
+	return v1.NodeSelectorTerm{
+		MatchExpressions: []v1.NodeSelectorRequirement{
+			{
+				Key:      key,
+				Operator: "In",
+				Values:   []string{value},
+			},
+		},
+	}
+}
+
+func TestPodNodeAffinityWeight(t *testing.T) {
+	defaultNode := v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+				"key3": "value3",
+			},
+		},
+	}
+	tests := []struct {
+		name           string
+		affinity       *v1.Affinity
+		expectedWeight int32
+	}{
+		{
+			name:           "No affinity",
+			affinity:       nil,
+			expectedWeight: 0,
+		},
+		{
+			name:           "No node affinity",
+			affinity:       &v1.Affinity{},
+			expectedWeight: 0,
+		},
+		{
+			name: "Empty preferred node affinity, but matching required node affinity",
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							createNodeSelectorTerm("key1", "value1"),
+						},
+					},
+				},
+			},
+			expectedWeight: 0,
+		},
+		{
+			name: "Matching single key in preferred node affinity",
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+						{
+							Weight:     10,
+							Preference: createNodeSelectorTerm("key1", "value1"),
+						},
+						{
+							Weight:     5,
+							Preference: createNodeSelectorTerm("key1", "valueX"),
+						},
+					},
+				},
+			},
+			expectedWeight: 10,
+		},
+		{
+			name: "Matching two keys in preferred node affinity",
+			affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+						{
+							Weight:     10,
+							Preference: createNodeSelectorTerm("key1", "value1"),
+						},
+						{
+							Weight:     5,
+							Preference: createNodeSelectorTerm("key2", "value2"),
+						},
+					},
+				},
+			},
+			expectedWeight: 15,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := v1.Pod{}
+			pod.Spec.Affinity = test.affinity
+			totalWeight, err := PodNodeAffinityWeight(&pod, &defaultNode)
+			if err != nil {
+				t.Error("Found non nil error")
+			}
+			if totalWeight != test.expectedWeight {
+				t.Errorf("Expected total weight is %v but actual total weight is %v", test.expectedWeight, totalWeight)
 			}
 		})
 	}


### PR DESCRIPTION
Now, the descheduler can detect and evict pods that are not optimally allocated according to the "preferred..." node affinity. It only evicts a pod if it can be scheduled on a node that scores higher in terms of preferred node affinity than the current one.

This can be activated by enabling the RemovePodsViolatingNodeAffinity plugin and passing "preferredDuringSchedulingIgnoredDuringExecution" in the args.

For example, imagine we have a pod that prefers nodes with label "key1: value1" with a weight of 10. If this pod is scheduled on a node that doesn't have "key1: value1" as label but there's another node that has this label and where this pod can potentially run, then the descheduler will evict the pod.

Another effect of this commit is that the
RemovePodsViolatingNodeAffinity plugin will not remove pods that don't fit in the current node but for other reasons than violating the node affinity. Before that, enabling this plugin could cause evictions on pods that were running on tainted nodes without the necessary tolerations.

This commit also fixes the wording of some tests from node_affinity_test.go and some parameters and expectations of these tests, which were wrong.