### PR TITLE
fix: descheduler_loop_duration_seconds has wrong value

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -112,8 +112,9 @@ func (d *descheduler) runDeschedulerLoop(ctx context.Context, nodes []*v1.Node) 
 	var span trace.Span
 	ctx, span = tracing.Tracer().Start(ctx, "runDeschedulerLoop")
 	defer span.End()
-	loopStartDuration := time.Now()
-	defer metrics.DeschedulerLoopDuration.With(map[string]string{}).Observe(time.Since(loopStartDuration).Seconds())
+	defer func(loopStartDuration time.Time) {
+		metrics.DeschedulerLoopDuration.With(map[string]string{}).Observe(time.Since(loopStartDuration).Seconds())
+	}(time.Now())
 
 	// if len is still <= 1 error out
 	if len(nodes) <= 1 {


### PR DESCRIPTION
see golang/go#60048

I learned this change from https://github.com/golang/tools/blob/9abb02c1b5524bf655a0985bc101496a6b53ff71/internal/gocommand/invoke.go#L265, thanks to author https://github.com/heschi 🙏