### PR TITLE
nodefit: use info log level when pod doesn't fit

### DIFF
--- a/pkg/framework/plugins/defaultevictor/defaultevictor.go
+++ b/pkg/framework/plugins/defaultevictor/defaultevictor.go
@@ -160,7 +160,7 @@ func (d *DefaultEvictor) PreEvictionFilter(pod *v1.Pod) bool {
 			return false
 		}
 		if !nodeutil.PodFitsAnyOtherNode(d.handle.GetPodsAssignedToNodeFunc(), pod, nodes) {
-			klog.ErrorS(err, "pod does not fit on any other node because of nodeSelector(s), Taint(s), or nodes marked as unschedulable", "pod", klog.KObj(pod))
+			klog.InfoS("pod does not fit on any other node because of nodeSelector(s), Taint(s), or nodes marked as unschedulable", "pod", klog.KObj(pod))
 			return false
 		}
 		return true


### PR DESCRIPTION
Pods that don't pass the nodeFit condition currently log an unsuppressable error message to logs. This changes the log level to info as it's a normal operating condition.