### PR TITLE
chart: sync deschedulerPolicy with base configmap

### DIFF
--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -74,55 +74,33 @@ cmdOptions:
   v: 3
 
 # Recommended to use the latest Policy API version supported by the Descheduler app version
-deschedulerPolicyAPIVersion: "descheduler/v1alpha1"
+deschedulerPolicyAPIVersion: "descheduler/v1alpha2"
 
 deschedulerPolicy:
-  # nodeSelector: "key1=value1,key2=value2"
-  # maxNoOfPodsToEvictPerNode: 10
-  # maxNoOfPodsToEvictPerNamespace: 10
-  # ignorePvcPods: true
-  # evictLocalStoragePods: true
-  # tracing:
-  #   collectorEndpoint: otel-collector.observability.svc.cluster.local:4317
-  #   transportCert: ""
-  #   serviceName: ""
-  #   serviceNamespace: ""
-  #   sampleRate: 1.0
-  #   fallbackToNoOpProviderOnError: true
-  strategies:
-    RemoveDuplicates:
-      enabled: true
-    RemovePodsHavingTooManyRestarts:
-      enabled: true
-      params:
-        podsHavingTooManyRestarts:
-          podRestartThreshold: 100
-          includingInitContainers: true
-    RemovePodsViolatingNodeTaints:
-      enabled: true
-    RemovePodsViolatingNodeAffinity:
-      enabled: true
-      params:
-        nodeAffinityType:
-        - requiredDuringSchedulingIgnoredDuringExecution
-    RemovePodsViolatingInterPodAntiAffinity:
-      enabled: true
-    RemovePodsViolatingTopologySpreadConstraint:
-      enabled: true
-      params:
-        includeSoftConstraints: false
-    LowNodeUtilization:
-      enabled: true
-      params:
-        nodeResourceUtilizationThresholds:
-          thresholds:
-            cpu: 20
-            memory: 20
-            pods: 20
-          targetThresholds:
-            cpu: 50
-            memory: 50
-            pods: 50
+  profiles:
+    - name: ProfileName
+      pluginConfig:
+        - name: "DefaultEvictor"
+        - name: "RemovePodsViolatingInterPodAntiAffinity"
+        - name: "RemoveDuplicates"
+        - name: "LowNodeUtilization"
+          args:
+            thresholds:
+              "cpu" : 20
+              "memory": 20
+              "pods": 20
+            targetThresholds:
+              "cpu" : 50
+              "memory": 50
+              "pods": 50
+      plugins:
+        balance:
+          enabled:
+            - "LowNodeUtilization"
+            - "RemoveDuplicates"
+        deschedule:
+          enabled:
+            - "RemovePodsViolatingInterPodAntiAffinity"
 
 priorityClassName: system-cluster-critical
 


### PR DESCRIPTION
Switches descheduler policy version to descheduler/v1alpha2 and syncs with the kubernetes/base/configmap.yaml default values