### PR TITLE
helm: bump chart to v0.28.0

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy: 
       matrix:
         k8s-version: ["v1.28.0"]
-        descheduler-version: ["v0.27.1"]
+        descheduler-version: ["v0.28.0"]
         descheduler-api: ["v1alpha1", "v1alpha2"]
         manifest: ["deployment"]
     runs-on: ubuntu-latest

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: descheduler
-version: 0.27.1
-appVersion: 0.27.1
+version: 0.28.0
+appVersion: 0.28.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:
 - kubernetes


### PR DESCRIPTION
rebased on top of #1224 

pre-requisites:
- cut release-1.28 branch
- cut v0.28.0 tag and publish image


closes #1196 