### PR TITLE
helm: update cronjob args argument to avoid unmarshal error

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -68,7 +68,7 @@ spec:
               command:
                 {{- toYaml .Values.command | nindent 16 }}
               args:
-                - --policy-config-file: "/policy-dir/policy.yaml"
+                - --policy-config-file=/policy-dir/policy.yaml
                 {{- range $key, $value := .Values.cmdOptions }}
                 - {{ printf "--%s" $key }}{{ if $value }}={{ $value }}{{ end }}
                 {{- end }}


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/descheduler/issues/1226

Make it match both the deployment parallel

https://github.com/kubernetes-sigs/descheduler/blob/33e9a52385394a3f4b2cb55bdf717fe52f1a852f/charts/descheduler/templates/cronjob.yaml#L71

As well as the documented arg

https://github.com/kubernetes-sigs/descheduler/blob/master/docs/user-guide.md#balance-cluster-by-pod-age