### PR TITLE
helm: support of `timeZone` for CronJob

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `cronJobApiVersion`                 | CronJob API Group Version                                                                                             | `"batch/v1"`                              |
 | `schedule`                          | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                           |
 | `startingDeadlineSeconds`           | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                     |
+| `timeZone`                          | configure `timeZone` for CronJob                                                                                      | `nil`                                     |
 | `successfulJobsHistoryLimit`        | If set, configure `successfulJobsHistoryLimit` for the _descheduler_ job                                              | `3`                                       |
 | `failedJobsHistoryLimit`            | If set, configure `failedJobsHistoryLimit` for the _descheduler_ job                                                  | `1`                                       |
 | `ttlSecondsAfterFinished`           | If set, configure `ttlSecondsAfterFinished` for the _descheduler_ job                                                 | `nil`                                     |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if .Values.failedJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
   {{- end }}
+  {{- if .Values.timeZone }}
+  timeZone: {{ .Values.timeZone }}
+  {{- end }}
   jobTemplate:
     spec:
       {{- if .Values.ttlSecondsAfterFinished }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -45,6 +45,7 @@ suspend: false
 # successfulJobsHistoryLimit: 3
 # failedJobsHistoryLimit: 1
 # ttlSecondsAfterFinished 600
+# timeZone: Etc/UTC
 
 # Required when running as a Deployment
 deschedulingInterval: 5m


### PR DESCRIPTION
closes #1243 

Stable in 1.27 - field is optional
https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones


Test:
```
helm template deschduler ./descheduler -f ./descheduler/values.yaml --set timeZone=Etc/UTC

...
# Source: descheduler/templates/cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: deschduler-descheduler
  namespace: default
  labels:
    app.kubernetes.io/name: descheduler
    helm.sh/chart: descheduler-0.28.0
    app.kubernetes.io/instance: deschduler
    app.kubernetes.io/version: "0.28.0"
    app.kubernetes.io/managed-by: Helm
spec:
  schedule: "*/2 * * * *"
  concurrencyPolicy: "Forbid"
  timeZone: Etc/UTC
  jobTemplate:
    spec:
...
```