### PR TITLE
RemovePodsViolatingInterPodAntiAffinity: sort to evict newer pods

### DIFF
--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -231,7 +231,18 @@ func IsGuaranteedPod(pod *v1.Pod) bool {
 // If pods have same priorities, they will be sorted by QoS in the following order:
 // BestEffort, Burstable, Guaranteed
 func SortPodsBasedOnPriorityLowToHigh(pods []*v1.Pod) {
-	sort.Slice(pods, func(i, j int) bool {
+	sort.Slice(pods, lessFuncByPriority(pods))
+}
+
+// StableSortPodsBasedOnPriorityLowToHigh sorts pods stably based on their priorities from low to high.
+// If pods have same priorities, they will be sorted by QoS in the following order:
+// BestEffort, Burstable, Guaranteed
+func StableSortPodsBasedOnPriorityLowToHigh(pods []*v1.Pod) {
+	sort.SliceStable(pods, lessFuncByPriority(pods))
+}
+
+func lessFuncByPriority(pods []*v1.Pod) func(i, j int) bool {
+	return func(i, j int) bool {
 		if pods[i].Spec.Priority == nil && pods[j].Spec.Priority != nil {
 			return true
 		}
@@ -248,12 +259,19 @@ func SortPodsBasedOnPriorityLowToHigh(pods []*v1.Pod) {
 			return false
 		}
 		return *pods[i].Spec.Priority < *pods[j].Spec.Priority
-	})
+	}
 }
 
 // SortPodsBasedOnAge sorts Pods from oldest to most recent in place
 func SortPodsBasedOnAge(pods []*v1.Pod) {
 	sort.Slice(pods, func(i, j int) bool {
 		return pods[i].CreationTimestamp.Before(&pods[j].CreationTimestamp)
+	})
+}
+
+// ReverseSortPodsBasedOnAge sorts Pods from most recent to oldest in place
+func ReverseSortPodsBasedOnAge(pods []*v1.Pod) {
+	sort.Slice(pods, func(i, j int) bool {
+		return !pods[i].CreationTimestamp.Before(&pods[j].CreationTimestamp)
 	})
 }

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -19,6 +19,7 @@ package removepodsviolatinginterpodantiaffinity
 import (
 	"context"
 	"fmt"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
Background: To maintain system stability, when deleting or evicting multiple pods with the same conditions (such as priority), newer pods are generally preferred. For instance, when scaling in a Deployment resource, newer pods are deleted.
I'm not sure the above condition, but this pull request based on it. If this is wrong, please point it.

The "RemovePodsViolatingInterPodAntiAffinity" plugin presently considers only pod priority and QoS tier. This pull request enables the plugin to select the newest pod from pods violating inter pod anti-affinity.

Implementation detail that I want to be reviewed:
- Create a new function "**Stable**SortPodsBasedOnPriorityLowToHigh", that is stable version of "SortPodsBasedOnPriorityLowToHigh", to avoid changing current behavior of other plugins.
- Remove "each node processing" behavior to accurately prioritize pods based on their age. I believe that this modification will have a minimal impact on the plugin.
