### PR TITLE
helm: ability to specify `dnsConfig`

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -51,6 +51,9 @@ spec:
           affinity:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.dnsConfig }}
+          dnsConfig: {{ .Values.dnsConfig }}
+          {{- end }}
           {{- with .Values.tolerations }}
           tolerations:
             {{- toYaml . | nindent 12 }}

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -52,7 +52,8 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.dnsConfig }}
-          dnsConfig: {{ .Values.dnsConfig }}
+          dnsConfig:
+            {{- .Values.dnsConfig | toYaml | nindent 12 }}
           {{- end }}
           {{- with .Values.tolerations }}
           tolerations:

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -32,7 +32,8 @@ spec:
         {{- end }}
     spec:
       {{- if .Values.dnsConfig }}
-      dnsConfig: {{ .Values.dnsConfig }}
+      dnsConfig:
+        {{- .Values.dnsConfig | toYaml | nindent 8 }}
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         {{- .Values.podAnnotations | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.dnsConfig }}
+      dnsConfig: {{ .Values.dnsConfig }}
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -172,6 +172,8 @@ podAnnotations: {}
 
 podLabels: {}
 
+dnsConfig: {}
+
 livenessProbe:
   failureThreshold: 3
   httpGet:


### PR DESCRIPTION
Changes:
- add ability to specify dnsConfig in helm chart for Deployment and CronJob resources

This allows specifying dnsConfig block like mentioned in the [kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config)

One example of what's in use at @myfitnesspal is 
```yaml
      dnsConfig:
        options:
        - name: ndots
          value: "2"
        - name: single-request-reopen
        - name: use-vc
```

screenshot of how the dns configuration is rendered on the cronjob resource
![image](https://github.com/kubernetes-sigs/descheduler/assets/4290846/b050cce9-8e60-4bd7-b9b8-acfd0d1901ac)
