### PR TITLE
[1.26] update pause image from 'kubernetes/pause' to 'registry.k8s.io/pause'

### DIFF
--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -86,7 +86,7 @@ func TestRemoveDuplicates(t *testing.T) {
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
-						Image:           "kubernetes/pause",
+						Image:           "registry.k8s.io/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
 						SecurityContext: &v1.SecurityContext{
 							AllowPrivilegeEscalation: utilpointer.Bool(false),

--- a/test/e2e/e2e_leaderelection_test.go
+++ b/test/e2e/e2e_leaderelection_test.go
@@ -176,7 +176,7 @@ func createDeployment(ctx context.Context, clientSet clientset.Interface, namesp
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
-						Image:           "kubernetes/pause",
+						Image:           "registry.k8s.io/pause",
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},
 						SecurityContext: &v1.SecurityContext{
 							AllowPrivilegeEscalation: utilpointer.Bool(false),

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -69,7 +69,7 @@ func MakePodSpec(priorityClassName string, gracePeriod *int64) v1.PodSpec {
 		Containers: []v1.Container{{
 			Name:            "pause",
 			ImagePullPolicy: "Never",
-			Image:           "kubernetes/pause",
+			Image:           "registry.k8s.io/pause",
 			Ports:           []v1.ContainerPort{{ContainerPort: 80}},
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -330,7 +330,7 @@ func TestLowNodeUtilization(t *testing.T) {
 				Containers: []v1.Container{{
 					Name:            "pause",
 					ImagePullPolicy: "Never",
-					Image:           "kubernetes/pause",
+					Image:           "registry.k8s.io/pause",
 					Ports:           []v1.ContainerPort{{ContainerPort: 80}},
 					Resources: v1.ResourceRequirements{
 						Limits: v1.ResourceList{
@@ -1335,7 +1335,7 @@ func createBalancedPodForNodes(
 				Containers: []v1.Container{
 					{
 						Name:  "pause",
-						Image: "kubernetes/pause",
+						Image: "registry.k8s.io/pause",
 						Resources: v1.ResourceRequirements{
 							Limits:   needCreateResource,
 							Requests: needCreateResource,

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -87,7 +87,7 @@ func TestTooManyRestarts(t *testing.T) {
 					Containers: []v1.Container{{
 						Name:            "pause",
 						ImagePullPolicy: "Always",
-						Image:           "kubernetes/pause",
+						Image:           "registry.k8s.io/pause",
 						Command:         []string{"/bin/sh"},
 						Args:            []string{"-c", "sleep 1s && exit 1"},
 						Ports:           []v1.ContainerPort{{ContainerPort: 80}},

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -33,8 +33,8 @@ if [ -n "$KIND_E2E" ]; then
         export PATH=$PATH:$PWD
         kind create cluster --image kindest/node:${K8S_VERSION} --config=./hack/kind_config.yaml
     fi
-    ${CONTAINER_ENGINE:-docker} pull kubernetes/pause
-    kind load docker-image kubernetes/pause
+    ${CONTAINER_ENGINE:-docker} pull registry.k8s.io/pause
+    kind load docker-image registry.k8s.io/pause
     kind get kubeconfig > /tmp/admin.conf
     export KUBECONFIG="/tmp/admin.conf"
     mkdir -p ~/gopath/src/sigs.k8s.io/


### PR DESCRIPTION
Backporting https://github.com/kubernetes-sigs/descheduler/pull/1166 to 1.26