### PR TITLE
fix: display ownerKey in the logs correctly

### DIFF
--- a/pkg/framework/plugins/removeduplicates/removeduplicates.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates.go
@@ -57,6 +57,10 @@ type podOwner struct {
 	imagesHash            string
 }
 
+func (po podOwner) String() string {
+	return fmt.Sprintf("%s/%s/%s/%s", po.namespace, po.kind, po.name, po.imagesHash)
+}
+
 // New builds plugin from its arguments while passing a handle
 func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	removeDuplicatesArgs, ok := args.(*RemoveDuplicatesArgs)


### PR DESCRIPTION
Logs from `RemoveDuplicates` plugin do not display `ownerKey` correctly. Here's an example:
```
"Average occurrence per node" node="<redacted>" ownerKey={} avg=5"
```

The PR adds an implementation of `Stringer` interface for `podOwner` struct. Example of logs after the change:

```
"Average occurrence per node" node="<redacted>" ownerKey="loki/StatefulSet/loki-write/docker.io/grafana/loki:2.8.2" avg=6
```