### PR TITLE
[1.26] bump go version to 1.19.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.19.3
+FROM golang:1.19.13
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .


### PR DESCRIPTION
I note there are a few backports already on the 1.26 branch... could a tag be made to generate a v0.26.2 image? I would follow up with the following PR for Helm / Docs changes.

(also happy to do corresponding bumps for 1.27?)