### PR TITLE
Make the logged nodeutilization percentages human-readable

### DIFF
--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -164,7 +164,7 @@ func resourceThreshold(nodeCapacity v1.ResourceList, resourceName v1.ResourceNam
 	return resource.NewQuantity(resourceCapacityFraction(resourceCapacityQuantity.Value()), defaultFormat)
 }
 
-func roundTo2Digits(percentage float64) float64 {
+func roundTo2Decimals(percentage float64) float64 {
 	return math.Round(percentage*100) / 100
 }
 
@@ -179,7 +179,7 @@ func resourceUsagePercentages(nodeUsage NodeUsage) map[v1.ResourceName]float64 {
 		cap := nodeCapacity[resourceName]
 		if !cap.IsZero() {
 			resourceUsagePercentage[resourceName] = 100 * float64(resourceUsage.MilliValue()) / float64(cap.MilliValue())
-			resourceUsagePercentage[resourceName] = roundTo2Digits(resourceUsagePercentage[resourceName])
+			resourceUsagePercentage[resourceName] = roundTo2Decimals(resourceUsagePercentage[resourceName])
 		}
 	}
 

--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -18,6 +18,7 @@ package nodeutilization
 
 import (
 	"context"
+	"math"
 	"sort"
 
 	"sigs.k8s.io/descheduler/pkg/api"
@@ -163,6 +164,10 @@ func resourceThreshold(nodeCapacity v1.ResourceList, resourceName v1.ResourceNam
 	return resource.NewQuantity(resourceCapacityFraction(resourceCapacityQuantity.Value()), defaultFormat)
 }
 
+func roundTo2Digits(percentage float64) float64 {
+	return math.Round(percentage*100) / 100
+}
+
 func resourceUsagePercentages(nodeUsage NodeUsage) map[v1.ResourceName]float64 {
 	nodeCapacity := nodeUsage.node.Status.Capacity
 	if len(nodeUsage.node.Status.Allocatable) > 0 {
@@ -174,6 +179,7 @@ func resourceUsagePercentages(nodeUsage NodeUsage) map[v1.ResourceName]float64 {
 		cap := nodeCapacity[resourceName]
 		if !cap.IsZero() {
 			resourceUsagePercentage[resourceName] = 100 * float64(resourceUsage.MilliValue()) / float64(cap.MilliValue())
+			resourceUsagePercentage[resourceName] = roundTo2Digits(resourceUsagePercentage[resourceName])
 		}
 	}
 


### PR DESCRIPTION
A cleaner looking log.

Original:

> I1121 15:44:10.570746   47691 nodeutilization.go:198] "Node is underutilized" node="k8s-playground-control-plane" usage={"cpu":"950m","memory":"290Mi","pods":"9"} usagePercentage={"cpu":9.5,"memory":3.696861352760446,"pods":8.181818181818182}

vs.

> I1121 16:37:29.266709   60211 nodeutilization.go:204] "Node is underutilized" node="kind-control-plane" usage={"cpu":"950m","memory":"290Mi","pods":"9"} usagePercentage={"cpu":9.5,"memory":3.7,"pods":8.18}