### PR TITLE
fix: json logging

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -87,7 +87,6 @@ func newDefaultComponentConfig() (*componentconfig.DeschedulerConfiguration, err
 
 // AddFlags adds flags for a specific SchedulerServer to the specified FlagSet
 func (rs *DeschedulerServer) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&rs.Logging.Format, "logging-format", "text", `Sets the log format. Permitted formats: "text", "json". Non-default formats don't honor these flags: --add-dir-header, --alsologtostderr, --log-backtrace-at, --log_dir, --log_file, --log_file_max_size, --logtostderr, --skip-headers, --skip-log-headers, --stderrthreshold, --log-flush-frequency.\nNon-default choices are currently alpha and subject to change without warning.`)
 	fs.DurationVar(&rs.DeschedulingInterval, "descheduling-interval", rs.DeschedulingInterval, "Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.")
 	fs.StringVar(&rs.ClientConnection.Kubeconfig, "kubeconfig", rs.ClientConnection.Kubeconfig, "File with kube configuration. Deprecated, use client-connection-kubeconfig instead.")
 	fs.StringVar(&rs.ClientConnection.Kubeconfig, "client-connection-kubeconfig", rs.ClientConnection.Kubeconfig, "File path to kube configuration for interacting with kubernetes apiserver.")

--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -20,7 +20,6 @@ package app
 import (
 	"context"
 	"io"
-	"os"
 	"os/signal"
 	"syscall"
 
@@ -32,12 +31,14 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	apiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/mux"
 	restclient "k8s.io/client-go/rest"
-	registry "k8s.io/component-base/logs/api/v1"
-	jsonLog "k8s.io/component-base/logs/json"
+	"k8s.io/component-base/featuregate"
+	"k8s.io/component-base/logs"
+	logsapi "k8s.io/component-base/logs/api/v1"
 	_ "k8s.io/component-base/logs/json/register"
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
@@ -50,40 +51,34 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 		klog.ErrorS(err, "unable to initialize server")
 	}
 
+	featureGate := featuregate.NewFeatureGate()
+	logConfig := logsapi.NewLoggingConfiguration()
+
 	cmd := &cobra.Command{
 		Use:   "descheduler",
 		Short: "descheduler",
-		Long:  `The descheduler evicts pods which may be bound to less desired nodes`,
-		Run: func(cmd *cobra.Command, args []string) {
-			// s.Logs.Config.Format = s.Logging.Format
-
-			// LoopbackClientConfig is a config for a privileged loopback connection
-			var LoopbackClientConfig *restclient.Config
-			var SecureServing *apiserver.SecureServingInfo
-			if err := s.SecureServing.ApplyTo(&SecureServing, &LoopbackClientConfig); err != nil {
+		Long:  "The descheduler evicts pods which may be bound to less desired nodes",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			logs.InitLogs()
+			if logsapi.ValidateAndApply(logConfig, featureGate); err != nil {
+				return err
+			}
+			descheduler.SetupPlugins()
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// loopbackClientConfig is a config for a privileged loopback connection
+			var loopbackClientConfig *restclient.Config
+			var secureServing *apiserver.SecureServingInfo
+			if err := s.SecureServing.ApplyTo(&secureServing, &loopbackClientConfig); err != nil {
 				klog.ErrorS(err, "failed to apply secure server configuration")
-				return
+				return err
 			}
 
-			SecureServing.DisableHTTP2 = !s.EnableHTTP2
-
-			var factory registry.LogFormatFactory
-			if s.Logging.Format == "json" {
-				factory = jsonLog.Factory{}
-			}
-
-			if factory == nil {
-				klog.ClearLogger()
-			} else {
-				log, loggerControl := factory.Create(registry.LoggingConfiguration{
-					Format:    s.Logging.Format,
-					Verbosity: s.Logging.Verbosity,
-				}, registry.LoggingOptions{})
-				defer loggerControl.Flush()
-				klog.SetLogger(log)
-			}
+			secureServing.DisableHTTP2 = !s.EnableHTTP2
 
 			ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			defer done()
 
 			pathRecorderMux := mux.NewPathRecorderMux("descheduler")
 			if !s.DisableMetrics {
@@ -92,25 +87,30 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 
 			healthz.InstallHandler(pathRecorderMux, healthz.NamedCheck("Descheduler", healthz.PingHealthz.Check))
 
-			stoppedCh, _, err := SecureServing.Serve(pathRecorderMux, 0, ctx.Done())
+			stoppedCh, _, err := secureServing.Serve(pathRecorderMux, 0, ctx.Done())
 			if err != nil {
 				klog.Fatalf("failed to start secure server: %v", err)
-				return
+				return err
 			}
 
-			err = Run(ctx, s)
-			if err != nil {
+			if err = Run(ctx, s); err != nil {
 				klog.ErrorS(err, "descheduler server")
+				return err
 			}
 
-			done()
 			// wait for metrics server to close
 			<-stoppedCh
+
+			return nil
 		},
 	}
 	cmd.SetOut(out)
 	flags := cmd.Flags()
 	s.AddFlags(flags)
+
+	runtime.Must(logsapi.AddFeatureGates(featureGate))
+	logsapi.AddFlags(logConfig, flags)
+
 	return cmd
 }
 
@@ -124,9 +124,4 @@ func Run(ctx context.Context, rs *options.DeschedulerServer) error {
 	// over a cluster with thousands of pods
 	watch.DefaultChanSize = 100000
 	return descheduler.Run(ctx, rs)
-}
-
-func SetupLogs() {
-	klog.SetOutput(os.Stdout)
-	klog.InitFlags(nil)
 }

--- a/cmd/descheduler/descheduler.go
+++ b/cmd/descheduler/descheduler.go
@@ -21,13 +21,7 @@ import (
 
 	"k8s.io/component-base/cli"
 	"sigs.k8s.io/descheduler/cmd/descheduler/app"
-	"sigs.k8s.io/descheduler/pkg/descheduler"
 )
-
-func init() {
-	app.SetupLogs()
-	descheduler.SetupPlugins()
-}
 
 func main() {
 	out := os.Stdout

--- a/docs/cli/descheduler.md
+++ b/docs/cli/descheduler.md
@@ -32,7 +32,10 @@ descheduler [flags]
       --leader-elect-resource-name string        The name of resource object that is used for locking during leader election. (default "descheduler")
       --leader-elect-resource-namespace string   The namespace of resource object that is used for locking during leader election. (default "kube-system")
       --leader-elect-retry-period duration       The duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled. (default 26s)
-      --logging-format string                    Sets the log format. Permitted formats: "text", "json". Non-default formats don't honor these flags: --add-dir-header, --alsologtostderr, --log-backtrace-at, --log_dir, --log_file, --log_file_max_size, --logtostderr, --skip-headers, --skip-log-headers, --stderrthreshold, --log-flush-frequency.\nNon-default choices are currently alpha and subject to change without warning. (default "text")
+      --log-flush-frequency duration             Maximum number of seconds between log flushes (default 5s)
+      --log-json-info-buffer-size quantity       [Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.
+      --log-json-split-stream                    [Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.
+      --logging-format string                    Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". (default "text")
       --otel-collector-endpoint string           Set this flag to the OpenTelemetry Collector Service Address
       --otel-fallback-no-op-on-error             Fallback to NoOp Tracer in case of error
       --otel-sample-rate float                   Sample rate to collect the Traces (default 1)
@@ -50,6 +53,8 @@ descheduler [flags]
       --tls-min-version string                   Minimum TLS version supported. Possible values: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13
       --tls-private-key-file string              File containing the default x509 private key matching --tls-cert-file.
       --tls-sni-cert-key namedCertKey            A pair of x509 certificate and private key file paths, optionally suffixed with a list of domain patterns which are fully qualified domain names, possibly with prefixed wildcard segments. The domain patterns also allow IP addresses, but IPs should only be used if the apiserver has visibility to the IP address requested by a client. If no domain patterns are provided, the names of the certificate are extracted. Non-wildcard matches trump over wildcard matches, explicit domain patterns trump over extracted names. For multiple key/certificate pairs, use the --tls-sni-cert-key multiple times. Examples: "example.crt,example.key" or "foo.crt,foo.key:*.foo.com,foo.com". (default [])
+  -v, --v Level                                  number for the log level verbosity
+      --vmodule pattern=N,...                    comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
 ```
 
 ### SEE ALSO

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -21,7 +21,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
-	registry "k8s.io/component-base/logs/api/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -60,10 +59,6 @@ type DeschedulerConfiguration struct {
 
 	// LeaderElection starts Deployment using leader election loop
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration
-
-	// Logging specifies the options of logging.
-	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/api/v1/options.go) for more information.
-	Logging registry.LoggingConfiguration
 
 	// ClientConnection specifies the kubeconfig file and client connection settings to use when communicating with the apiserver.
 	// Refer to [ClientConnection](https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/componentconfig#ClientConnectionConfiguration) for more information.

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -21,7 +21,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
-	registry "k8s.io/component-base/logs/api/v1"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -60,10 +59,6 @@ type DeschedulerConfiguration struct {
 
 	// LeaderElection starts Deployment using leader election loop
 	LeaderElection componentbaseconfig.LeaderElectionConfiguration `json:"leaderElection,omitempty"`
-
-	// Logging specifies the options of logging.
-	// Refer to [Logs Options](https://github.com/kubernetes/component-base/blob/master/logs/api/v1/options.go) for more information.
-	Logging registry.LoggingConfiguration `json:"logging,omitempty"`
 
 	// ClientConnection specifies the kubeconfig file and client connection settings to use when communicating with the apiserver.
 	// Refer to [ClientConnection](https://pkg.go.dev/k8s.io/kubernetes/pkg/apis/componentconfig#ClientConnectionConfiguration) for more information.

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -72,7 +72,6 @@ func autoConvert_v1alpha1_DeschedulerConfiguration_To_componentconfig_Deschedule
 		return err
 	}
 	out.LeaderElection = in.LeaderElection
-	out.Logging = in.Logging
 	out.ClientConnection = in.ClientConnection
 	return nil
 }
@@ -95,7 +94,6 @@ func autoConvert_componentconfig_DeschedulerConfiguration_To_v1alpha1_Deschedule
 		return err
 	}
 	out.LeaderElection = in.LeaderElection
-	out.Logging = in.Logging
 	out.ClientConnection = in.ClientConnection
 	return nil
 }

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -31,7 +31,6 @@ func (in *DeschedulerConfiguration) DeepCopyInto(out *DeschedulerConfiguration) 
 	out.TypeMeta = in.TypeMeta
 	out.Tracing = in.Tracing
 	out.LeaderElection = in.LeaderElection
-	in.Logging.DeepCopyInto(&out.Logging)
 	out.ClientConnection = in.ClientConnection
 	return
 }

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -31,7 +31,6 @@ func (in *DeschedulerConfiguration) DeepCopyInto(out *DeschedulerConfiguration) 
 	out.TypeMeta = in.TypeMeta
 	out.Tracing = in.Tracing
 	out.LeaderElection = in.LeaderElection
-	in.Logging.DeepCopyInto(&out.Logging)
 	out.ClientConnection = in.ClientConnection
 	return
 }


### PR DESCRIPTION
Issue initially reported in Slack [[ref](https://kubernetes.slack.com/archives/C09TP78DV/p1700566355255069)]. I noticed that the issue also persists in other projects (e.g. cluster-autsocaler) so perhaps something got changed in kubernetes/kubernetes with base-component

I followed the example from https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/logs/example/cmd/logger.go

Now onto testing. running locally to just simulate logs...

before (just hangs):
```
❯ timeout 10s go run cmd/descheduler/descheduler.go --logging-format=json
❯ echo $?
124
```

after:
```
❯ go run cmd/descheduler/descheduler.go --logging-format=json
{"ts":1700705698832.446,"caller":"server/secure_serving.go:57","msg":"Forcing use of http/1.1 only\n","v":0}
{"ts":1700705698832.9558,"caller":"server/secure_serving.go:213","msg":"Serving securely on [::]:10258\n","v":0}
{"ts":1700705698833.088,"caller":"dynamiccertificates/tlsconfig.go:240","msg":"Starting DynamicServingCertificateController","v":0}
{"ts":1700705698833.113,"caller":"app/server.go:93","msg":"descheduler server","err":"unable to build in cluster config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"}
{"ts":1700705698833.158,"caller":"dynamiccertificates/tlsconfig.go:255","msg":"Shutting down DynamicServingCertificateController","v":0}
{"ts":1700705698833.206,"caller":"cli/run.go:74","msg":"command failed","err":"unable to build in cluster config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"}
{"ts":1700705698833.217,"caller":"server/secure_serving.go:258","msg":"Stopped listening on [::]:10258\n","v":0}
exit status 1
```