### PR TITLE
fix: revert defer of context done

### DIFF
--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -78,7 +78,6 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 			secureServing.DisableHTTP2 = !s.EnableHTTP2
 
 			ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-			defer done()
 
 			pathRecorderMux := mux.NewPathRecorderMux("descheduler")
 			if !s.DisableMetrics {
@@ -98,6 +97,7 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 				return err
 			}
 
+			done()
 			// wait for metrics server to close
 			<-stoppedCh
 


### PR DESCRIPTION
In #1296 , I moved things around a bit and used defer for `done`. This breaks Job cancel, see comment: https://github.com/kubernetes-sigs/descheduler/pull/731#discussion_r811752424