### PR TITLE
helm: ability to specify security context for pod

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -90,7 +90,7 @@ spec:
                   name: policy-volume
           {{- if .Values.podSecurityContext }}
           securityContext:
-            {{- .Values.podSecurityContext | toYaml | nindent 12 }}
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           {{- end }}
           volumes:
           - name: policy-volume

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -88,6 +88,10 @@ spec:
               volumeMounts:
                 - mountPath: /policy-dir
                   name: policy-volume
+          {{- if .Values.podSecurityContext }}
+          securityContext:
+            {{- .Values.podSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
           volumes:
           - name: policy-volume
             configMap:

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               name: policy-volume
       {{- if .Values.podSecurityContext }}
       securityContext:
-        {{- .Values.podSecurityContext | toYaml | nindent 12 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       volumes:
         - name: policy-volume

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
           volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+        {{- .Values.podSecurityContext | toYaml | nindent 12 }}
+      {{- end }}
       volumes:
         - name: policy-volume
           configMap:

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -32,6 +32,10 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+# podSecurityContext -- [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+podSecurityContext: {}
+  # fsGroup: 1000
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
This pull request adds the ability to specify the security context for the descheduler pod.

Other Kubernetes projects like the [cluster-autoscaler](https://github.com/kubernetes/autoscaler/blob/master/charts/cluster-autoscaler/templates/deployment.yaml#L303-L305) has this ability, useful to define the `fsGroup` setting which is only available at the pod level.

I tested it doing the change below and installing the helm chart in a kind cluster to be sure the schema is valid:
```diff
diff --git a/charts/descheduler/values.yaml b/charts/descheduler/values.yaml
index afc3b8ca3..d47c0a581 100644
--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -33,8 +33,8 @@ securityContext:
   runAsUser: 1000

 # podSecurityContext -- [Security context for pod](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-podSecurityContext: {}
-  # fsGroup: 1000
+podSecurityContext:
+  fsGroup: 1000

 nameOverride: ""
 fullnameOverride: ""
```

The pods running has the `fsGroup` set:
```
~/src/descheduler pod-security-context !1 ❯ k get pod descheduler-28357494-4snw7 -o yaml|grep fsGroup                                                                                        

fsGroup: 1000
```