### PR TITLE
Add Support to ppc64le Architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ image.arm64:
 	$(CONTAINER_ENGINE) build --build-arg VERSION="$(VERSION)" --build-arg ARCH="arm64" -t $(IMAGE)-arm64 .
 
 image.ppc64le:
-        docker build --build-arg VERSION="$(VERSION)" --build-arg ARCH="ppc64le" -t $(IMAGE)-ppc64le .
+	$(CONTAINER_ENGINE) build --build-arg VERSION="$(VERSION)" --build-arg ARCH="ppc64le" -t $(IMAGE)-ppc64le .
 
 push: image
 	gcloud auth configure-docker

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ build.arm64:
 build.ppc64le:
         CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build ${LDFLAGS} -o _output/bin/descheduler sigs.k8s.io/descheduler/cmd/descheduler
 
-
 dev-image: build
 	$(CONTAINER_ENGINE) build -f Dockerfile.dev -t $(IMAGE) .
 


### PR DESCRIPTION
This request aims to have support for the ppc64le Architecture used in OpenShift installed on IBM Power, widely used in on-premises environments.