### PR TITLE
helm: allow configuration of ipFamilyPolicy

### DIFF
--- a/charts/descheduler/templates/service.yaml
+++ b/charts/descheduler/templates/service.yaml
@@ -10,6 +10,10 @@ metadata:
 spec:
   clusterIP: None
   ports:
+{{- if .Values.service.ipDualStack.enabled }}
+  ipFamilies: {{ toYaml .Values.service.ipDualStack.ipFamilies | nindent 4 }}
+  ipFamilyPolicy: {{ .Values.service.ipDualStack.ipFamilyPolicy }}
+{{- end }}
   - name: http-metrics
     port: 10258
     protocol: TCP

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -212,3 +212,7 @@ serviceMonitor:
     #   targetLabel: nodename
     #   replacement: $1
     #   action: replace
+  ipDualStack:
+    enabled: false
+    ipFamilies: ["IPv6", "IPv4"]
+    ipFamilyPolicy: "PreferDualStack"


### PR DESCRIPTION
This pull request adds allow configuration of ipFamilyPolicy for the descheduler service.

Since different versions of k8s have different support for ipv6/ipv4 dual stack, it is not enabled by default.