### PR TITLE
fix: topologySpreadConstraint fields in structured logs

### DIFF
--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1608,20 +1608,20 @@ func TestCheckIdenticalConstraints(t *testing.T) {
 	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}})
 
 	newConstraintSame := topologySpreadConstraint{
-		maxSkew:     2,
-		topologyKey: "zone",
-		selector:    selector.DeepCopySelector(),
+		MaxSkew:     2,
+		TopologyKey: "zone",
+		Selector:    selector.DeepCopySelector(),
 	}
 	newConstraintDifferent := topologySpreadConstraint{
-		maxSkew:     3,
-		topologyKey: "node",
-		selector:    selector.DeepCopySelector(),
+		MaxSkew:     3,
+		TopologyKey: "node",
+		Selector:    selector.DeepCopySelector(),
 	}
 	namespaceTopologySpreadConstraint := []topologySpreadConstraint{
 		{
-			maxSkew:     2,
-			topologyKey: "zone",
-			selector:    selector.DeepCopySelector(),
+			MaxSkew:     2,
+			TopologyKey: "zone",
+			Selector:    selector.DeepCopySelector(),
 		},
 	}
 	testCases := []struct {


### PR DESCRIPTION
There is a problem with the log display due to the use of non-exported fields：
https://github.com/kubernetes-sigs/descheduler/blob/f0f7ebbe9af680b338709391cf1c0da7c2270ce5/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go#L220

Without this patch the `tsc` is printed as empty `{}`:
```sh
I1212 08:34:36.666387       1 topologyspreadconstraint.go:230] "Skipping topology constraint because it is already balanced" constraint={}
```

With this patch:
```sh
I1212 08:41:10.178744       1 topologyspreadconstraint.go:221] "Skipping topology constraint because it is already balanced" constraint={"MaxSkew":1,"TopologyKey":"topology.kubernetes.io/zone","Selector":[{}],"NodeAffinityPolicy":"Honor","NodeTaintsPolicy":"Ignore","PodNodeAffinity":{},"PodTolerations":[{"key":"node.kubernetes.io/not-ready","operator":"Exists","effect":"NoExecute","tolerationSeconds":300},{"key":"node.kubernetes.io/unreachable","operator":"Exists","effect":"NoExecute","tolerationSeconds":300}]}
```
