### PR TITLE
`PodLifeTime`: consider pods with container status `ImagePullBackOff`

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ This strategy evicts pods that are older than `maxPodLifeTimeSeconds`.
 
 You can also specify `states` parameter to **only** evict pods matching the following conditions:
   - [Pod Phase](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) status of: `Running`, `Pending`
-  - [Container State Waiting](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-waiting) condition of: `PodInitializing`, `ContainerCreating`
+  - [Container State Waiting](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-waiting) condition of: `PodInitializing`, `ContainerCreating`, `ImagePullBackOff`
 
 If a value for `states` or `podStatusPhases` is not specified,
 Pods in any state (even `Running`) are considered for eviction.

--- a/pkg/framework/plugins/podlifetime/validation.go
+++ b/pkg/framework/plugins/podlifetime/validation.go
@@ -50,6 +50,9 @@ func ValidatePodLifeTimeArgs(obj runtime.Object) error {
 		// Container state reasons: https://github.com/kubernetes/kubernetes/blob/release-1.24/pkg/kubelet/kubelet_pods.go#L76-L79
 		"PodInitializing",
 		"ContainerCreating",
+
+		// containerStatuses[*].state.waiting.reason: ImagePullBackOff
+		"ImagePullBackOff",
 	)
 
 	if !podLifeTimeAllowedStates.HasAll(args.States...) {


### PR DESCRIPTION
`PodLifeTime` plugin to support pods with container status `ImagePullBackOff`

```yaml
  containerStatuses:
  - image: test-podlifetime:latest
    imageID: ""
    lastState: {}
    name: test-podlifetime
    ready: false
    restartCount: 0
    started: false
    state:
      waiting:
        message: Back-off pulling image "test-podlifetime:latest"
        reason: ImagePullBackOff
```