### PR TITLE
fix(podlifetime): fix failed unittest

### DIFF
--- a/pkg/framework/plugins/podlifetime/pod_lifetime.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
 
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
@@ -67,8 +68,8 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 	}
 
 	podFilter = podutil.WrapFilterFuncs(podFilter, func(pod *v1.Pod) bool {
-		podAgeSeconds := uint(metav1.Now().Sub(pod.GetCreationTimestamp().Local()).Seconds())
-		return podAgeSeconds > *podLifeTimeArgs.MaxPodLifeTimeSeconds
+		podAgeSeconds := int(metav1.Now().Sub(pod.GetCreationTimestamp().Local()).Seconds())
+		return podAgeSeconds > int(*podLifeTimeArgs.MaxPodLifeTimeSeconds)
 	})
 
 	if len(podLifeTimeArgs.States) > 0 {

--- a/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/events"
 	utilptr "k8s.io/utils/ptr"
+
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	frameworkfake "sigs.k8s.io/descheduler/pkg/framework/fake"
@@ -72,7 +73,7 @@ func TestPodLifeTime(t *testing.T) {
 	p5.ObjectMeta.CreationTimestamp = newerPodCreationTime
 	p6 := test.BuildTestPod("p6", 100, 0, node1.Name, nil)
 	p6.Namespace = "dev"
-	p6.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 605))
+	p6.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Second * 605))
 
 	ownerRef3 := test.GetReplicaSetOwnerRefList()
 	p5.ObjectMeta.OwnerReferences = ownerRef3
@@ -84,7 +85,7 @@ func TestPodLifeTime(t *testing.T) {
 	p7.ObjectMeta.CreationTimestamp = newerPodCreationTime
 	p8 := test.BuildTestPod("p8", 100, 0, node1.Name, nil)
 	p8.Namespace = "dev"
-	p8.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Second * 595))
+	p8.ObjectMeta.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Second * 595))
 
 	ownerRef4 := test.GetReplicaSetOwnerRefList()
 	p5.ObjectMeta.OwnerReferences = ownerRef4


### PR DESCRIPTION
correct desired pod creation time

"Two pods in the `dev` Namespace, 1 created 605 seconds ago. 1 should be evicted.", the create time stamp should be 605 s before current time
