### PR TITLE
v0.29.0: bump helm chart and update manifests/docs

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         k8s-version: ["v1.29.0"]
-        descheduler-version: ["v0.28.1"]
+        descheduler-version: ["v0.29.0"]
         descheduler-api: ["v1alpha1", "v1alpha2"]
         manifest: ["deployment"]
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ gen:
 	./hack/update-docs.sh
 
 gen-docker:
-	$(CONTAINER_ENGINE) run --entrypoint make -it -v $(CURRENT_DIR):/go/src/sigs.k8s.io/descheduler -w /go/src/sigs.k8s.io/descheduler golang:1.20.7 gen
+	$(CONTAINER_ENGINE) run --entrypoint make -it -v $(CURRENT_DIR):/go/src/sigs.k8s.io/descheduler -w /go/src/sigs.k8s.io/descheduler golang:1.21.5 gen
 
 verify-gen:
 	./hack/verify-conversions.sh

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ that version's release branch, as listed below:
 
 |Descheduler Version|Docs link|
 |---|---|
+|v0.29.x|[`release-1.29`](https://github.com/kubernetes-sigs/descheduler/blob/release-1.29/README.md)|
 |v0.28.x|[`release-1.28`](https://github.com/kubernetes-sigs/descheduler/blob/release-1.28/README.md)|
 |v0.27.x|[`release-1.27`](https://github.com/kubernetes-sigs/descheduler/blob/release-1.27/README.md)|
 |v0.26.x|[`release-1.26`](https://github.com/kubernetes-sigs/descheduler/blob/release-1.26/README.md)|

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: descheduler
-version: 0.28.1
-appVersion: 0.28.1
+version: 0.29.0
+appVersion: 0.29.0
 description: Descheduler for Kubernetes is used to rebalance clusters by evicting pods that can potentially be scheduled on better nodes. In the current implementation, descheduler does not schedule replacement of evicted pods but relies on the default scheduler for that.
 keywords:
 - kubernetes

--- a/docs/deprecated/v1alpha1.md
+++ b/docs/deprecated/v1alpha1.md
@@ -109,17 +109,17 @@ See the [resources | Kustomize](https://kubectl.docs.kubernetes.io/references/ku
 
 Run As A Job
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.28.1' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.29.0' | kubectl apply -f -
 ```
 
 Run As A CronJob
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.28.1' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.29.0' | kubectl apply -f -
 ```
 
 Run As A Deployment
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.28.1' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.29.0' | kubectl apply -f -
 ```
 
 ## User Guide

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,6 +4,7 @@ Starting with descheduler release v0.10.0 container images are available in the 
 
 Descheduler Version | Container Image                                 | Architectures           |
 ------------------- |-------------------------------------------------|-------------------------|
+v0.29.0             | registry.k8s.io/descheduler/descheduler:v0.29.0 | AMD64<br>ARM64<br>ARMv7 |
 v0.28.1             | registry.k8s.io/descheduler/descheduler:v0.28.1 | AMD64<br>ARM64<br>ARMv7 |
 v0.28.0             | registry.k8s.io/descheduler/descheduler:v0.28.0 | AMD64<br>ARM64<br>ARMv7 |
 v0.27.1             | registry.k8s.io/descheduler/descheduler:v0.27.1 | AMD64<br>ARM64<br>ARMv7 |

--- a/hack/kind_config.yaml
+++ b/hack/kind_config.yaml
@@ -1,9 +1,5 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
-featureGates:
-  # beta as of 1.27 but we currently run e2e on 1.26
-  # this flag should be removed as part of Descheduler 0.29 release
-  MatchLabelKeysInPodTopologySpread: true
 nodes:
 - role: control-plane
 - role: worker

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
-            image: registry.k8s.io/descheduler/descheduler:v0.28.1
+            image: registry.k8s.io/descheduler/descheduler:v0.29.0
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: descheduler-sa
       containers:
         - name: descheduler
-          image: registry.k8s.io/descheduler/descheduler:v0.28.1
+          image: registry.k8s.io/descheduler/descheduler:v0.29.0
           imagePullPolicy: IfNotPresent
           command:
             - "/bin/descheduler"

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
-          image: registry.k8s.io/descheduler/descheduler:v0.28.1
+          image: registry.k8s.io/descheduler/descheduler:v0.29.0
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume


### PR DESCRIPTION
Needs: https://github.com/kubernetes/k8s.io/pull/6236

Closes #1320 and #1326