### PR TITLE
Allow eviction of DaemonSet pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,7 +941,7 @@ When the descheduler decides to evict pods from a node, it employs the following
 * [Critical pods](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/) (with priorityClassName set to system-cluster-critical or system-node-critical) are never evicted (unless `evictSystemCriticalPods: true` is set).
 * Pods (static or mirrored pods or standalone pods) not part of an ReplicationController, ReplicaSet(Deployment), StatefulSet, or Job are
 never evicted because these pods won't be recreated. (Standalone pods in failed status phase can be evicted by setting `evictFailedBarePods: true`)
-* Pods associated with DaemonSets are never evicted.
+* Pods associated with DaemonSets are never evicted (unless `evictDaemonSetPods: true` is set).
 * Pods with local storage are never evicted (unless `evictLocalStoragePods: true` is set).
 * Pods with PVCs are evicted (unless `ignorePvcPods: true` is set).
 * In `LowNodeUtilization` and `RemovePodsViolatingInterPodAntiAffinity`, pods are evicted by their priority from low to high, and if they have same priority,

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -85,6 +85,9 @@ deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"
   # maxNoOfPodsToEvictPerNode: 10
   # maxNoOfPodsToEvictPerNamespace: 10
+  # ignorePvcPods: true
+  # evictLocalStoragePods: true
+  # evictDaemonSetPods: true
   # tracing:
   #   collectorEndpoint: otel-collector.observability.svc.cluster.local:4317
   #   transportCert: ""

--- a/docs/deprecated/v1alpha1.md
+++ b/docs/deprecated/v1alpha1.md
@@ -135,6 +135,7 @@ The policy includes a common configuration that applies to all the strategies:
 |------|---------------|-------------|
 | `nodeSelector` | `nil` | limiting the nodes which are processed |
 | `evictLocalStoragePods` | `false` | allows eviction of pods with local storage |
+| `evictDaemonSetPods` | `false` | allows eviction of pods associated to DaemonSet resources |
 | `evictSystemCriticalPods` | `false` | [Warning: Will evict Kubernetes system pods] allows eviction of pods with any priority, including system pods like kube-dns |
 | `ignorePvcPods` | `false` | set whether PVC pods should be evicted or ignored |
 | `maxNoOfPodsToEvictPerNode` | `nil` | maximum number of pods evicted from each node (summed through all strategies) |
@@ -152,6 +153,7 @@ kind: "DeschedulerPolicy"
 nodeSelector: prod=dev
 evictFailedBarePods: false
 evictLocalStoragePods: true
+evictDaemonSetPods: true
 evictSystemCriticalPods: true
 maxNoOfPodsToEvictPerNode: 40
 ignorePvcPods: false

--- a/pkg/api/v1alpha1/conversion.go
+++ b/pkg/api/v1alpha1/conversion.go
@@ -139,6 +139,14 @@ func V1alpha1ToInternal(
 		}
 	}
 
+	evictDaemonSetPods := false
+	if deschedulerPolicy.EvictDaemonSetPods != nil {
+		evictDaemonSetPods = *deschedulerPolicy.EvictDaemonSetPods
+		if evictDaemonSetPods {
+			klog.V(1).Info("Warning: EvictDaemonSetPods is set to True. This could cause eviction of Kubernetes DaemonSet pods.")
+		}
+	}
+
 	ignorePvcPods := false
 	if deschedulerPolicy.IgnorePVCPods != nil {
 		ignorePvcPods = *deschedulerPolicy.IgnorePVCPods
@@ -193,6 +201,7 @@ func V1alpha1ToInternal(
 							Name: defaultevictor.PluginName,
 							Args: &defaultevictor.DefaultEvictorArgs{
 								EvictLocalStoragePods:   evictLocalStoragePods,
+								EvictDaemonSetPods:      evictDaemonSetPods,
 								EvictSystemCriticalPods: evictSystemCriticalPods,
 								IgnorePvcPods:           ignorePvcPods,
 								EvictFailedBarePods:     evictBarePods,

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -41,6 +41,9 @@ type DeschedulerPolicy struct {
 	// EvictSystemCriticalPods allows eviction of pods of any priority (including Kubernetes system pods)
 	EvictSystemCriticalPods *bool `json:"evictSystemCriticalPods,omitempty"`
 
+	// EvictDaemonSetPods allows pods owned by a DaemonSet resource to be evicted.
+	EvictDaemonSetPods *bool `json:"evictDaemonSetPods,omitempty"`
+
 	// IgnorePVCPods prevents pods with PVCs from being evicted.
 	IgnorePVCPods *bool `json:"ignorePvcPods,omitempty"`
 

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -57,6 +57,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EvictDaemonSetPods != nil {
+		in, out := &in.EvictDaemonSetPods, &out.EvictDaemonSetPods
+		*out = new(bool)
+		**out = **in
+	}
 	if in.IgnorePVCPods != nil {
 		in, out := &in.IgnorePVCPods, &out.IgnorePVCPods
 		*out = new(bool)

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -51,6 +51,9 @@ type DeschedulerConfiguration struct {
 	// EvictLocalStoragePods allows pods using local storage to be evicted.
 	EvictLocalStoragePods bool
 
+	// EvictDaemonSetPods allows pods owned by a DaemonSet resource to be evicted.
+	EvictDaemonSetPods bool
+
 	// IgnorePVCPods sets whether PVC pods should be allowed to be evicted
 	IgnorePVCPods bool
 

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -51,6 +51,9 @@ type DeschedulerConfiguration struct {
 	// EvictLocalStoragePods allows pods using local storage to be evicted.
 	EvictLocalStoragePods bool `json:"evictLocalStoragePods,omitempty"`
 
+	// EvictDaemonSetPods allows pods owned by a DaemonSet resource to be evicted.
+	EvictDaemonSetPods bool `json:"evictDaemonSetPods,omitempty"`
+
 	// IgnorePVCPods sets whether PVC pods should be allowed to be evicted
 	IgnorePVCPods bool `json:"ignorePvcPods,omitempty"`
 

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -67,6 +67,7 @@ func autoConvert_v1alpha1_DeschedulerConfiguration_To_componentconfig_Deschedule
 	out.NodeSelector = in.NodeSelector
 	out.MaxNoOfPodsToEvictPerNode = in.MaxNoOfPodsToEvictPerNode
 	out.EvictLocalStoragePods = in.EvictLocalStoragePods
+	out.EvictDaemonSetPods = in.EvictDaemonSetPods
 	out.IgnorePVCPods = in.IgnorePVCPods
 	if err := Convert_v1alpha1_TracingConfiguration_To_componentconfig_TracingConfiguration(&in.Tracing, &out.Tracing, s); err != nil {
 		return err
@@ -89,6 +90,7 @@ func autoConvert_componentconfig_DeschedulerConfiguration_To_v1alpha1_Deschedule
 	out.NodeSelector = in.NodeSelector
 	out.MaxNoOfPodsToEvictPerNode = in.MaxNoOfPodsToEvictPerNode
 	out.EvictLocalStoragePods = in.EvictLocalStoragePods
+	out.EvictDaemonSetPods = in.EvictDaemonSetPods
 	out.IgnorePVCPods = in.IgnorePVCPods
 	if err := Convert_componentconfig_TracingConfiguration_To_v1alpha1_TracingConfiguration(&in.Tracing, &out.Tracing, s); err != nil {
 		return err

--- a/pkg/descheduler/policyconfig_test.go
+++ b/pkg/descheduler/policyconfig_test.go
@@ -135,6 +135,71 @@ func TestV1alpha1ToV1alpha2(t *testing.T) {
 			},
 		},
 		{
+			description: "convert global policy fields to defaultevictor",
+			policy: &v1alpha1.DeschedulerPolicy{
+				EvictFailedBarePods:     utilpointer.Bool(true),
+				EvictLocalStoragePods:   utilpointer.Bool(true),
+				EvictSystemCriticalPods: utilpointer.Bool(true),
+				EvictDaemonSetPods:      utilpointer.Bool(true),
+				IgnorePVCPods:           utilpointer.Bool(true),
+				Strategies: v1alpha1.StrategyList{
+					removeduplicates.PluginName: v1alpha1.DeschedulerStrategy{
+						Enabled: true,
+						Params: &v1alpha1.StrategyParameters{
+							Namespaces: &v1alpha1.Namespaces{
+								Exclude: []string{
+									"test2",
+								},
+							},
+						},
+					},
+				},
+			},
+			result: &api.DeschedulerPolicy{
+				Profiles: []api.DeschedulerProfile{
+					{
+						Name: fmt.Sprintf("strategy-%s-profile", removeduplicates.PluginName),
+						PluginConfigs: []api.PluginConfig{
+							{
+								Name: defaultevictor.PluginName,
+								Args: &defaultevictor.DefaultEvictorArgs{
+									EvictLocalStoragePods:   true,
+									EvictDaemonSetPods:      true,
+									EvictSystemCriticalPods: true,
+									IgnorePvcPods:           true,
+									EvictFailedBarePods:     true,
+									PriorityThreshold: &api.PriorityThreshold{
+										Value: nil,
+									},
+								},
+							},
+							{
+								Name: removeduplicates.PluginName,
+								Args: &removeduplicates.RemoveDuplicatesArgs{
+									Namespaces: &api.Namespaces{
+										Exclude: []string{
+											"test2",
+										},
+									},
+								},
+							},
+						},
+						Plugins: api.Plugins{
+							Balance: api.PluginSet{
+								Enabled: []string{removeduplicates.PluginName},
+							},
+							Filter: api.PluginSet{
+								Enabled: []string{defaultevictor.PluginName},
+							},
+							PreEvictionFilter: api.PluginSet{
+								Enabled: []string{defaultevictor.PluginName},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			description: "convert all strategies",
 			policy: &v1alpha1.DeschedulerPolicy{
 				Strategies: v1alpha1.StrategyList{
@@ -947,6 +1012,7 @@ profiles:
         evictSystemCriticalPods: true
         evictFailedBarePods: true
         evictLocalStoragePods: true
+        evictDaemonSetPods: true
         nodeFit: true
     - name: "RemovePodsHavingTooManyRestarts"
       args:
@@ -968,6 +1034,7 @@ profiles:
 									EvictSystemCriticalPods: true,
 									EvictFailedBarePods:     true,
 									EvictLocalStoragePods:   true,
+									EvictDaemonSetPods:      true,
 									PriorityThreshold:       &api.PriorityThreshold{Value: utilpointer.Int32(2000000000)},
 									NodeFit:                 true,
 								},
@@ -1099,6 +1166,7 @@ profiles:
         evictSystemCriticalPods: true
         evictFailedBarePods: true
         evictLocalStoragePods: true
+        evictDaemonSetPods: true
         nodeFit: true
     - name: "RemoveFailedPods"
     plugins:
@@ -1123,6 +1191,7 @@ profiles:
 									EvictSystemCriticalPods: true,
 									EvictFailedBarePods:     true,
 									EvictLocalStoragePods:   true,
+									EvictDaemonSetPods:      true,
 									PriorityThreshold:       &api.PriorityThreshold{Value: utilpointer.Int32(2000000000)},
 									NodeFit:                 true,
 								},
@@ -1161,6 +1230,7 @@ profiles:
         evictSystemCriticalPods: true
         evictFailedBarePods: true
         evictLocalStoragePods: true
+        evictDaemonSetPods: true
         nodeFit: true
     - name: "RemoveFailedPods"
     plugins:
@@ -1179,6 +1249,7 @@ profiles:
 									EvictSystemCriticalPods: true,
 									EvictFailedBarePods:     true,
 									EvictLocalStoragePods:   true,
+									EvictDaemonSetPods:      true,
 									PriorityThreshold:       &api.PriorityThreshold{Value: utilpointer.Int32(2000000000)},
 									NodeFit:                 true,
 								},

--- a/pkg/framework/plugins/defaultevictor/defaults.go
+++ b/pkg/framework/plugins/defaultevictor/defaults.go
@@ -31,6 +31,9 @@ func SetDefaults_DefaultEvictorArgs(obj runtime.Object) {
 	if !args.EvictLocalStoragePods {
 		args.EvictLocalStoragePods = false
 	}
+	if !args.EvictDaemonSetPods {
+		args.EvictDaemonSetPods = false
+	}
 	if !args.EvictSystemCriticalPods {
 		args.EvictSystemCriticalPods = false
 	}

--- a/pkg/framework/plugins/defaultevictor/defaults_test.go
+++ b/pkg/framework/plugins/defaultevictor/defaults_test.go
@@ -35,6 +35,7 @@ func TestSetDefaults_DefaultEvictorArgs(t *testing.T) {
 			want: &DefaultEvictorArgs{
 				NodeSelector:            "",
 				EvictLocalStoragePods:   false,
+				EvictDaemonSetPods:      false,
 				EvictSystemCriticalPods: false,
 				IgnorePvcPods:           false,
 				EvictFailedBarePods:     false,
@@ -48,6 +49,7 @@ func TestSetDefaults_DefaultEvictorArgs(t *testing.T) {
 			in: &DefaultEvictorArgs{
 				NodeSelector:            "NodeSelector",
 				EvictLocalStoragePods:   true,
+				EvictDaemonSetPods:      true,
 				EvictSystemCriticalPods: true,
 				IgnorePvcPods:           true,
 				EvictFailedBarePods:     true,
@@ -60,6 +62,7 @@ func TestSetDefaults_DefaultEvictorArgs(t *testing.T) {
 			want: &DefaultEvictorArgs{
 				NodeSelector:            "NodeSelector",
 				EvictLocalStoragePods:   true,
+				EvictDaemonSetPods:      true,
 				EvictSystemCriticalPods: true,
 				IgnorePvcPods:           true,
 				EvictFailedBarePods:     true,

--- a/pkg/framework/plugins/defaultevictor/types.go
+++ b/pkg/framework/plugins/defaultevictor/types.go
@@ -27,6 +27,7 @@ type DefaultEvictorArgs struct {
 
 	NodeSelector            string                 `json:"nodeSelector"`
 	EvictLocalStoragePods   bool                   `json:"evictLocalStoragePods"`
+	EvictDaemonSetPods      bool                   `json:"evictDaemonSetPods"`
 	EvictSystemCriticalPods bool                   `json:"evictSystemCriticalPods"`
 	IgnorePvcPods           bool                   `json:"ignorePvcPods"`
 	EvictFailedBarePods     bool                   `json:"evictFailedBarePods"`


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enables eviction of DaemonSet pods with the key `evictDaemonSetPods: true` for evictors

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

By default, allowing eviction of pods from daemonsets may be dangerous if misconfigured.

With the release of `v1alpha2` profiles, we got the ability to tune granular specs for eviction profiles.  This means now that it is possible to select specific daemonset to allow pod eviction automatically. This is interesting because reduces toil of pod recreation for specific scenarios.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Allow eviction of daemonset pods by `evictDaemonSetPods` key
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```