### PR TITLE
Improve PodEvictor observability through EvictOptions

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -36,7 +36,7 @@ var (
 			Name:           "pods_evicted",
 			Help:           "Number of evicted pods, by the result, by the strategy, by the namespace, by the node name. 'error' result means a pod could not be evicted",
 			StabilityLevel: metrics.ALPHA,
-		}, []string{"result", "strategy", "namespace", "node"})
+		}, []string{"result", "strategy", "profile", "namespace", "node"})
 
 	buildInfo = metrics.NewGauge(
 		&metrics.GaugeOpts{

--- a/pkg/framework/plugins/nodeutilization/highnodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/descheduler/pkg/api"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
 
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
@@ -144,6 +145,7 @@ func (h *HighNodeUtilization) Balance(ctx context.Context, nodes []*v1.Node) *fr
 		sourceNodes,
 		highNodes,
 		h.handle.Evictor(),
+		evictions.EvictOptions{StrategyName: HighNodeUtilizationPluginName},
 		h.podFilter,
 		resourceNames,
 		continueEvictionCond)

--- a/pkg/framework/plugins/nodeutilization/lownodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/lownodeutilization.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
@@ -191,6 +192,7 @@ func (l *LowNodeUtilization) Balance(ctx context.Context, nodes []*v1.Node) *fra
 		sourceNodes,
 		lowNodes,
 		l.handle.Evictor(),
+		evictions.EvictOptions{StrategyName: LowNodeUtilizationPluginName},
 		l.podFilter,
 		resourceNames,
 		continueEvictionCond)

--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -310,7 +310,7 @@ func evictPods(
 			}
 
 			if preEvictionFilterWithOptions(pod) {
-				if podEvictor.Evict(ctx, pod, evictions.EvictOptions{}) {
+				if podEvictor.Evict(ctx, pod, evictions.EvictOptions{StrategyName: "NodeUtilization"}) {
 					klog.V(3).InfoS("Evicted pods", "pod", klog.KObj(pod))
 
 					for name := range totalAvailableUsage {

--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -310,7 +310,7 @@ func evictPods(
 			}
 
 			if preEvictionFilterWithOptions(pod) {
-				if podEvictor.Evict(ctx, pod, evictions.EvictOptions{StrategyName: "NodeUtilization"}) {
+				if podEvictor.Evict(ctx, pod, evictions.EvictOptions{}) {
 					klog.V(3).InfoS("Evicted pods", "pod", klog.KObj(pod))
 
 					for name := range totalAvailableUsage {

--- a/pkg/framework/plugins/podlifetime/pod_lifetime.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime.go
@@ -133,7 +133,7 @@ func (d *PodLifeTime) Deschedule(ctx context.Context, nodes []*v1.Node) *framewo
 
 	for _, pod := range podsToEvict {
 		if !d.handle.Evictor().NodeLimitExceeded(nodeMap[pod.Spec.NodeName]) {
-			d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{})
+			d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{StrategyName: PluginName})
 		}
 	}
 

--- a/pkg/framework/plugins/removeduplicates/removeduplicates.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates.go
@@ -210,7 +210,7 @@ func (r *RemoveDuplicates) Balance(ctx context.Context, nodes []*v1.Node) *frame
 				// It's assumed all duplicated pods are in the same priority class
 				// TODO(jchaloup): check if the pod has a different node to lend to
 				for _, pod := range pods[upperAvg-1:] {
-					r.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{})
+					r.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{StrategyName: PluginName})
 					if r.handle.Evictor().NodeLimitExceeded(nodeMap[nodeName]) {
 						continue loop
 					}

--- a/pkg/framework/plugins/removefailedpods/failedpods.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods.go
@@ -103,7 +103,7 @@ func (d *RemoveFailedPods) Deschedule(ctx context.Context, nodes []*v1.Node) *fr
 		}
 		totalPods := len(pods)
 		for i := 0; i < totalPods; i++ {
-			d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{})
+			d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{StrategyName: PluginName})
 			if d.handle.Evictor().NodeLimitExceeded(node) {
 				break
 			}

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
@@ -123,7 +123,7 @@ func (d *RemovePodsHavingTooManyRestarts) Deschedule(ctx context.Context, nodes 
 		}
 		totalPods := len(pods)
 		for i := 0; i < totalPods; i++ {
-			d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{})
+			d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{StrategyName: PluginName})
 			if d.handle.Evictor().NodeLimitExceeded(node) {
 				break
 			}

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -98,7 +98,7 @@ loop:
 		totalPods := len(pods)
 		for i := 0; i < totalPods; i++ {
 			if checkPodsWithAntiAffinityExist(pods[i], podsInANamespace, nodeMap) && d.handle.Evictor().Filter(pods[i]) && d.handle.Evictor().PreEvictionFilter(pods[i]) {
-				if d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{}) {
+				if d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{StrategyName: PluginName}) {
 					// Since the current pod is evicted all other pods which have anti-affinity with this
 					// pod need not be evicted.
 					// Update allPods.

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
@@ -136,7 +136,7 @@ func (d *RemovePodsViolatingNodeAffinity) processNodes(ctx context.Context, node
 
 		for _, pod := range pods {
 			klog.V(1).InfoS("Evicting pod", "pod", klog.KObj(pod))
-			d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{})
+			d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{StrategyName: PluginName})
 			if d.handle.Evictor().NodeLimitExceeded(node) {
 				break
 			}

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -112,7 +112,7 @@ func (d *RemovePodsViolatingNodeTaints) Deschedule(ctx context.Context, nodes []
 				d.taintFilterFnc,
 			) {
 				klog.V(2).InfoS("Not all taints with NoSchedule effect are tolerated after update for pod on node", "pod", klog.KObj(pods[i]), "node", klog.KObj(node))
-				d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{})
+				d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{ProfileName: PluginName})
 				if d.handle.Evictor().NodeLimitExceeded(node) {
 					break
 				}

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -235,7 +235,7 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) Balance(ctx context.Contex
 		}
 
 		if d.handle.Evictor().PreEvictionFilter(pod) {
-			d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{})
+			d.handle.Evictor().Evict(ctx, pod, evictions.EvictOptions{StrategyName: PluginName})
 		}
 		if d.handle.Evictor().NodeLimitExceeded(nodeMap[pod.Spec.NodeName]) {
 			nodeLimitExceeded[pod.Spec.NodeName] = true

--- a/pkg/framework/profile/profile.go
+++ b/pkg/framework/profile/profile.go
@@ -224,6 +224,8 @@ func NewProfile(config api.DeschedulerProfile, reg pluginregistry.Registry, opts
 		return nil, fmt.Errorf("podEvictor missing")
 	}
 
+	hOpts.podEvictor.ProfileName(config.Name)
+
 	pi := &profileImpl{
 		profileName:              config.Name,
 		podEvictor:               hOpts.podEvictor,

--- a/pkg/framework/profile/profile_test.go
+++ b/pkg/framework/profile/profile_test.go
@@ -185,7 +185,7 @@ func TestProfileDescheduleBalanceExtensionPointsEviction(t *testing.T) {
 			if test.extensionPoint == frameworktypes.DescheduleExtensionPoint {
 				fakePlugin.AddReactor(string(frameworktypes.DescheduleExtensionPoint), func(action fakeplugin.Action) (handled, filter bool, err error) {
 					if dAction, ok := action.(fakeplugin.DescheduleAction); ok {
-						if dAction.Handle().Evictor().Evict(ctx, p1, evictions.EvictOptions{}) {
+						if dAction.Handle().Evictor().Evict(ctx, p1, evictions.EvictOptions{StrategyName: fakePlugin.PluginName}) {
 							return true, false, nil
 						}
 						return true, false, fmt.Errorf("pod not evicted")
@@ -196,7 +196,7 @@ func TestProfileDescheduleBalanceExtensionPointsEviction(t *testing.T) {
 			if test.extensionPoint == frameworktypes.BalanceExtensionPoint {
 				fakePlugin.AddReactor(string(frameworktypes.BalanceExtensionPoint), func(action fakeplugin.Action) (handled, filter bool, err error) {
 					if dAction, ok := action.(fakeplugin.BalanceAction); ok {
-						if dAction.Handle().Evictor().Evict(ctx, p1, evictions.EvictOptions{}) {
+						if dAction.Handle().Evictor().Evict(ctx, p1, evictions.EvictOptions{StrategyName: fakePlugin.PluginName}) {
 							return true, false, nil
 						}
 						return true, false, fmt.Errorf("pod not evicted")


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Supports profile name set under the label `profile`  for the metric `pods_evicted`. 

This allows the possibility of alerting different severities for different profiles.

Also, some refactors related to `EvictOptions` to make it more standard.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

~~I really do not think `ProfileName` as a public function was the best idea for `PodEvictor`, but adding to `NewPodEvictor` would require changes over many lines of code. Any suggestions on how to improve it?~~

Already discussed in the comments.

##### Results for `v1alpha1`

###### Config

```yaml
apiVersion: "descheduler/v1alpha1"
kind: "DeschedulerPolicy"
strategies:
  "PodLifeTime":
     enabled: true
     params:
       podLifeTime:
         maxPodLifeTimeSeconds: 5
         states:
         - "Running"
         - "Pending"
         - "PodInitializing"
  "RemoveFailedPods":
     enabled: true
     params:
       failedPods:
         reasons:
         - "NodeAffinity"
         includingInitContainers: true
         excludeOwnerKinds:
         - "Job"
         minPodLifetimeSeconds: 5

```

###### Metric output

```go
// + profile="strategy-RemoveFailedPods-profile"
descheduler_pods_evicted{namespace="local-path-storage",node="kind-control-plane",profile="strategy-RemoveFailedPods-profile",result="success",strategy="PodLifeTime"} 2
```

##### Results for `v1alpha2`

###### Config

```yaml
apiVersion: descheduler/v1alpha2
kind: DeschedulerPolicy
profiles:
  - name: profile-01
    pluginConfig:
    - name: PodLifeTime
      args:
        maxPodLifeTimeSeconds: 5
        states:
        - Running
        - Pending
        - PodInitializing
    - name: RemoveFailedPods
      args:
        reasons:
        - OutOfcpu
        - CreateContainerConfigError
        includingInitContainers: true
        excludeOwnerKinds:
        - Job
        minPodLifetimeSeconds: 5
    plugins:
      deschedule:
        enabled:
          - PodLifeTime
          - RemoveFailedPods
```

###### Metric output

```go
// + profile="profile-01"
descheduler_pods_evicted{namespace="local-path-storage",node="kind-control-plane",profile="profile-01",result="success",strategy="PodLifeTime"} 2
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Metric `pods_evicted` gained `profile` label
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```