### PR TITLE
add `ignoreMinNodesCheck` to allow disabling minimum node size check

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ These are top level keys in the Descheduler Policy that you can use to configure
 | `nodeSelector` |`string`| `nil` | limiting the nodes which are processed. Only used when `nodeFit`=`true` and only by the PreEvictionFilter Extension Point |
 | `maxNoOfPodsToEvictPerNode` |`int`| `nil` | maximum number of pods evicted from each node (summed through all strategies) |
 | `maxNoOfPodsToEvictPerNamespace` |`int`| `nil` | maximum number of pods evicted from each namespace (summed through all strategies) |
+| `ignoreMinNodesCheck` |`bool`| `nil` | descheduler requires more than one node in the cluster, setting this to `true` will disable the check |
 
 ### Evictor Plugin configuration (Default Evictor)
 

--- a/docs/deprecated/v1alpha1.md
+++ b/docs/deprecated/v1alpha1.md
@@ -155,6 +155,7 @@ evictLocalStoragePods: true
 evictSystemCriticalPods: true
 maxNoOfPodsToEvictPerNode: 40
 ignorePvcPods: false
+ignoreMinNodesCheck: false
 strategies:
   ...
 ```

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -38,6 +38,9 @@ type DeschedulerPolicy struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint
+
+	// IgnoreMinNodesCheck allows skipping the min nodes check, if set to true.
+	IgnoreMinNodesCheck *bool
 }
 
 // Namespaces carries a list of included/excluded namespaces

--- a/pkg/api/v1alpha1/conversion.go
+++ b/pkg/api/v1alpha1/conversion.go
@@ -234,6 +234,7 @@ func V1alpha1ToInternal(
 	out.NodeSelector = deschedulerPolicy.NodeSelector
 	out.MaxNoOfPodsToEvictPerNamespace = deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace
 	out.MaxNoOfPodsToEvictPerNode = deschedulerPolicy.MaxNoOfPodsToEvictPerNode
+	out.IgnoreMinNodesCheck = deschedulerPolicy.IgnoreMinNodesCheck
 
 	return nil
 }

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -49,6 +49,9 @@ type DeschedulerPolicy struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint `json:"maxNoOfPodsToEvictPerNamespace,omitempty"`
+
+	// IgnoreMinNodesCheck allows skipping the min nodes check, if set to true.
+	IgnoreMinNodesCheck *bool `json:"ignoreMinNodesCheck,omitempty"`
 }
 
 type (

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -72,6 +72,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.IgnoreMinNodesCheck != nil {
+		in, out := &in.IgnoreMinNodesCheck, &out.IgnoreMinNodesCheck
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/v1alpha2/types.go
+++ b/pkg/api/v1alpha2/types.go
@@ -37,6 +37,9 @@ type DeschedulerPolicy struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint `json:"maxNoOfPodsToEvictPerNamespace,omitempty"`
+
+	// IgnoreMinNodesCheck allows skipping the min nodes check, if set to true.
+	IgnoreMinNodesCheck *bool `json:"ignoreMinNodesCheck,omitempty"`
 }
 
 type DeschedulerProfile struct {

--- a/pkg/api/v1alpha2/zz_generated.conversion.go
+++ b/pkg/api/v1alpha2/zz_generated.conversion.go
@@ -104,6 +104,7 @@ func autoConvert_v1alpha2_DeschedulerPolicy_To_api_DeschedulerPolicy(in *Desched
 	out.NodeSelector = (*string)(unsafe.Pointer(in.NodeSelector))
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
+	out.IgnoreMinNodesCheck = (*bool)(unsafe.Pointer(in.IgnoreMinNodesCheck))
 	return nil
 }
 
@@ -122,6 +123,7 @@ func autoConvert_api_DeschedulerPolicy_To_v1alpha2_DeschedulerPolicy(in *api.Des
 	out.NodeSelector = (*string)(unsafe.Pointer(in.NodeSelector))
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
+	out.IgnoreMinNodesCheck = (*bool)(unsafe.Pointer(in.IgnoreMinNodesCheck))
 	return nil
 }
 

--- a/pkg/api/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha2/zz_generated.deepcopy.go
@@ -51,6 +51,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.IgnoreMinNodesCheck != nil {
+		in, out := &in.IgnoreMinNodesCheck, &out.IgnoreMinNodesCheck
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -51,6 +51,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.IgnoreMinNodesCheck != nil {
+		in, out := &in.IgnoreMinNodesCheck, &out.IgnoreMinNodesCheck
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/descheduler/issues/1347
and https://github.com/kubernetes-sigs/descheduler/issues/1298