### PR TITLE
Check whether pod matches the inter-pod anti-affinity of another Pod in a given Node in `NodeFit()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,6 +881,7 @@ profiles:
 - `nodeAffinity` on the pod
 - Resource `requests` made by the pod and the resources available on other nodes
 - Whether any of the other nodes are marked as `unschedulable`
+- Any `podAntiAffinity` between the pod and the pods on the other nodes
 
 E.g.
 
@@ -902,7 +903,7 @@ profiles:
           - "PodLifeTime"
 ```
 
-Note that node fit filtering references the current pod spec, and not that of it's owner.
+Note that node fit filtering references the current pod spec, and not that of its owner.
 Thus, if the pod is owned by a ReplicationController (and that ReplicationController was modified recently),
 the pod may be running with an outdated spec, which the descheduler will reference when determining node fit.
 This is expected behavior as the descheduler is a "best-effort" mechanism.

--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -130,8 +130,10 @@ func NodeFit(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, node *v
 		errors = append(errors, fmt.Errorf("node is not schedulable"))
 	}
 
-	// Check if pod matches pod anti-affinity rule of other pod on node
-	if matchesInterPodAntiAffinityRule(pod, node) {
+	// Check if pod matches inter-pod anti-affinity rule of pod on node
+	if match, err := podMatchesInterPodAntiAffinity(nodeIndexer, pod, node); err != nil {
+		errors = append(errors, err)
+	} else if match {
 		errors = append(errors, fmt.Errorf("pod matches inter-pod anti-affinity rule of other pod on node"))
 	}
 
@@ -329,10 +331,17 @@ func PodMatchNodeSelector(pod *v1.Pod, node *v1.Node) bool {
 	return matches
 }
 
-// matchesInterPodAntiAffinityRule checks if a pod anti-affinity rule matches that of any other pod(s)
-// that are already on the node.
-func matchesInterPodAntiAffinityRule(pod *v1.Pod, node *v1.Node) bool {
-	// if it matches pod anti affinity, return true
-	// if it does not match pod anti affinity, return false
-	return len(node.ObjectMeta.Labels) > 0
+// podMatchesInterPodAntiAffinity checks if the pod matches the anti-affinity rule
+// of another pod that is already on the given node.
+// If a match is found, it returns true.
+func podMatchesInterPodAntiAffinity(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, node *v1.Node) (bool, error) {
+	podsOnNode, err := podutil.ListPodsOnANode(node.Name, nodeIndexer, nil)
+	if err != nil {
+		return false, fmt.Errorf("error listing all pods: %v", err)
+	}
+
+	podsInANamespace := podutil.GroupByNamespace(podsOnNode)
+	nodeMap := utils.CreateNodeMap([]*v1.Node{node})
+
+	return utils.CheckPodsWithAntiAffinityExist(pod, podsInANamespace, nodeMap), nil
 }

--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -335,6 +335,10 @@ func PodMatchNodeSelector(pod *v1.Pod, node *v1.Node) bool {
 // of another pod that is already on the given node.
 // If a match is found, it returns true.
 func podMatchesInterPodAntiAffinity(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, node *v1.Node) (bool, error) {
+	if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAntiAffinity == nil {
+		return false, nil
+	}
+
 	podsOnNode, err := podutil.ListPodsOnANode(node.Name, nodeIndexer, nil)
 	if err != nil {
 		return false, fmt.Errorf("error listing all pods: %v", err)

--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -130,6 +130,11 @@ func NodeFit(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, node *v
 		errors = append(errors, fmt.Errorf("node is not schedulable"))
 	}
 
+	// Check if pod matches pod anti-affinity rule of other pod on node
+	if matchesInterPodAntiAffinityRule(pod, node) {
+		errors = append(errors, fmt.Errorf("pod matches inter-pod anti-affinity rule of other pod on node"))
+	}
+
 	return errors
 }
 
@@ -322,4 +327,12 @@ func PodMatchNodeSelector(pod *v1.Pod, node *v1.Node) bool {
 		return false
 	}
 	return matches
+}
+
+// matchesInterPodAntiAffinityRule checks if a pod anti-affinity rule matches that of any other pod(s)
+// that are already on the node.
+func matchesInterPodAntiAffinityRule(pod *v1.Pod, node *v1.Node) bool {
+	// if it matches pod anti affinity, return true
+	// if it does not match pod anti affinity, return false
+	return len(node.ObjectMeta.Labels) > 0
 }

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -790,7 +790,7 @@ func TestNodeFit(t *testing.T) {
 			err: errors.New("insufficient pods"),
 		},
 		{
-			description: "matches pod anti-affinity rule of pod on node",
+			description: "matches inter-pod anti-affinity rule of pod on node",
 			pod:         podAntiAffinityPod1,
 			node: test.BuildTestNode("node2", 2000, 3000, 10, func(node *v1.Node) {
 				node.ObjectMeta.Labels = map[string]string{

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -755,6 +755,14 @@ func TestPodFitsAnyOtherNode(t *testing.T) {
 
 func TestNodeFit(t *testing.T) {
 	node := test.BuildTestNode("node", 64000, 128*1000*1000*1000, 2, nil)
+
+	// pod anti-affinity pods
+	podAntiAffinityPod1 := test.BuildTestPod("p1", 1000, 1000, "node", nil)
+	test.SetPodAntiAffinity(podAntiAffinityPod1, "foo", "bar")
+
+	podAntiAffinityPod2 := test.BuildTestPod("p2", 1000, 1000, "node2", nil)
+	test.SetPodAntiAffinity(podAntiAffinityPod2, "foo", "bar")
+
 	tests := []struct {
 		description string
 		pod         *v1.Pod
@@ -781,6 +789,24 @@ func TestNodeFit(t *testing.T) {
 			},
 			err: errors.New("insufficient pods"),
 		},
+		{
+			description: "matches pod anti-affinity rule of pod on node",
+			pod:         podAntiAffinityPod1,
+			node: test.BuildTestNode("node2", 2000, 3000, 10, func(node *v1.Node) {
+				node.ObjectMeta.Labels = map[string]string{
+					"region": "main-region",
+				}
+			}),
+			podsOnNode: []*v1.Pod{podAntiAffinityPod2},
+			err:        errors.New("pod matches inter-pod anti-affinity rule of other pod on node"),
+		},
+		{
+			description: "pod fits on node",
+			pod:         test.BuildTestPod("p1", 1000, 1000, "", func(pod *v1.Pod) {}),
+			node:        node,
+			podsOnNode:  []*v1.Pod{},
+			err:         nil,
+		},
 	}
 
 	for _, tc := range tests {
@@ -804,7 +830,8 @@ func TestNodeFit(t *testing.T) {
 
 			sharedInformerFactory.Start(ctx.Done())
 			sharedInformerFactory.WaitForCacheSync(ctx.Done())
-			if errs := NodeFit(getPodsAssignedToNode, tc.pod, tc.node); (len(errs) == 0 && tc.err != nil) || errs[0].Error() != tc.err.Error() {
+			errs := NodeFit(getPodsAssignedToNode, tc.pod, tc.node)
+			if (len(errs) == 0 && tc.err != nil) || (len(errs) > 0 && errs[0].Error() != tc.err.Error()) {
 				t.Errorf("Test %#v failed, got %v, expect %v", tc.description, errs, tc.err)
 			}
 		})

--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -257,3 +257,12 @@ func SortPodsBasedOnAge(pods []*v1.Pod) {
 		return pods[i].CreationTimestamp.Before(&pods[j].CreationTimestamp)
 	})
 }
+
+func GroupByNodeName(pods []*v1.Pod) map[string][]*v1.Pod {
+	m := make(map[string][]*v1.Pod)
+	for i := 0; i < len(pods); i++ {
+		pod := pods[i]
+		m[pod.Spec.NodeName] = append(m[pod.Spec.NodeName], pod)
+	}
+	return m
+}

--- a/pkg/descheduler/pod/pods_test.go
+++ b/pkg/descheduler/pod/pods_test.go
@@ -176,3 +176,67 @@ func TestSortPodsBasedOnAge(t *testing.T) {
 		}
 	}
 }
+
+func TestGroupByNodeName(t *testing.T) {
+	tests := []struct {
+		name   string
+		pods   []*v1.Pod
+		expMap map[string][]*v1.Pod
+	}{
+		{
+			name:   "list of pods is empty",
+			pods:   []*v1.Pod{},
+			expMap: map[string][]*v1.Pod{},
+		},
+		{
+			name: "pods are on same node",
+			pods: []*v1.Pod{
+				{Spec: v1.PodSpec{
+					NodeName: "node1",
+				}},
+				{Spec: v1.PodSpec{
+					NodeName: "node1",
+				}},
+			},
+			expMap: map[string][]*v1.Pod{"node1": {
+				{Spec: v1.PodSpec{
+					NodeName: "node1",
+				}},
+				{Spec: v1.PodSpec{
+					NodeName: "node1",
+				}},
+			}},
+		},
+		{
+			name: "pods are on different nodes",
+			pods: []*v1.Pod{
+				{Spec: v1.PodSpec{
+					NodeName: "node1",
+				}},
+				{Spec: v1.PodSpec{
+					NodeName: "node2",
+				}},
+			},
+			expMap: map[string][]*v1.Pod{
+				"node1": {
+					{Spec: v1.PodSpec{
+						NodeName: "node1",
+					}},
+				},
+				"node2": {
+					{Spec: v1.PodSpec{
+						NodeName: "node2",
+					}},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resultMap := GroupByNodeName(test.pods)
+			if !reflect.DeepEqual(resultMap, test.expMap) {
+				t.Errorf("Expected %v node map, got %v", test.expMap, resultMap)
+			}
+		})
+	}
+}

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -182,10 +182,13 @@ func checkPodsWithAntiAffinityExist(pod *v1.Pod, pods map[string][]*v1.Pod, node
 	return false
 }
 
+// hasSameLabelValue checks if the pods are in the same topology zone.
 func hasSameLabelValue(node1, node2 *v1.Node, key string) bool {
 	if node1.Name == node2.Name {
 		return true
 	}
+
+	// no match if node has empty labels
 	node1Labels := node1.Labels
 	if node1Labels == nil {
 		return false
@@ -194,6 +197,8 @@ func hasSameLabelValue(node1, node2 *v1.Node, key string) bool {
 	if node2Labels == nil {
 		return false
 	}
+
+	// no match if node has no topology zone label with given key
 	value1, ok := node1Labels[key]
 	if !ok {
 		return false
@@ -202,6 +207,7 @@ func hasSameLabelValue(node1, node2 *v1.Node, key string) bool {
 	if !ok {
 		return false
 	}
+
 	return value1 == value2
 }
 

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -24,9 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
-	"sigs.k8s.io/descheduler/pkg/utils"
-
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
+	"sigs.k8s.io/descheduler/pkg/utils"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
@@ -96,14 +96,14 @@ func TestPodAntiAffinity(t *testing.T) {
 	test.SetNormalOwnerRef(p11)
 
 	// set pod anti affinity
-	setPodAntiAffinity(p1, "foo", "bar")
-	setPodAntiAffinity(p3, "foo", "bar")
-	setPodAntiAffinity(p4, "foo", "bar")
-	setPodAntiAffinity(p5, "foo1", "bar1")
-	setPodAntiAffinity(p6, "foo1", "bar1")
-	setPodAntiAffinity(p7, "foo", "bar")
-	setPodAntiAffinity(p9, "foo", "bar")
-	setPodAntiAffinity(p10, "foo", "bar")
+	test.SetPodAntiAffinity(p1, "foo", "bar")
+	test.SetPodAntiAffinity(p3, "foo", "bar")
+	test.SetPodAntiAffinity(p4, "foo", "bar")
+	test.SetPodAntiAffinity(p5, "foo1", "bar1")
+	test.SetPodAntiAffinity(p6, "foo1", "bar1")
+	test.SetPodAntiAffinity(p7, "foo", "bar")
+	test.SetPodAntiAffinity(p9, "foo", "bar")
+	test.SetPodAntiAffinity(p10, "foo", "bar")
 
 	// set pod priority
 	test.SetPodPriority(p5, 100)
@@ -282,26 +282,5 @@ func TestPodAntiAffinity(t *testing.T) {
 				t.Errorf("Unexpected no of pods evicted: pods evicted: %d, expected: %d", podsEvicted, test.expectedEvictedPodCount)
 			}
 		})
-	}
-}
-
-func setPodAntiAffinity(inputPod *v1.Pod, labelKey, labelValue string) {
-	inputPod.Spec.Affinity = &v1.Affinity{
-		PodAntiAffinity: &v1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
-				{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      labelKey,
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{labelValue},
-							},
-						},
-					},
-					TopologyKey: "region",
-				},
-			},
-		},
 	}
 }

--- a/pkg/utils/predicates.go
+++ b/pkg/utils/predicates.go
@@ -332,7 +332,7 @@ func CheckPodsWithAntiAffinityExist(pod *v1.Pod, pods map[string][]*v1.Pod, node
 							continue
 						}
 						if hasSameLabelValue(node, nodeHavingExistingPod, term.TopologyKey) {
-							klog.V(1).InfoS("Found Pods violating PodAntiAffinity", "pod to evicted", klog.KObj(pod))
+							klog.V(1).InfoS("Found Pods matching PodAntiAffinity", "pod with anti-affinity", klog.KObj(pod))
 							return true
 						}
 					}

--- a/pkg/utils/priority.go
+++ b/pkg/utils/priority.go
@@ -14,10 +14,10 @@ import (
 
 const SystemCriticalPriority = 2 * int32(1000000000)
 
-// GetNamespacesFromPodAffinityTerm returns a set of names
+// getNamespacesFromPodAffinityTerm returns a set of names
 // according to the namespaces indicated in podAffinityTerm.
 // If namespaces is empty it considers the given pod's namespace.
-func GetNamespacesFromPodAffinityTerm(pod *v1.Pod, podAffinityTerm *v1.PodAffinityTerm) sets.Set[string] {
+func getNamespacesFromPodAffinityTerm(pod *v1.Pod, podAffinityTerm *v1.PodAffinityTerm) sets.Set[string] {
 	names := sets.New[string]()
 	if len(podAffinityTerm.Namespaces) == 0 {
 		names.Insert(pod.Namespace)
@@ -27,9 +27,9 @@ func GetNamespacesFromPodAffinityTerm(pod *v1.Pod, podAffinityTerm *v1.PodAffini
 	return names
 }
 
-// PodMatchesTermsNamespaceAndSelector returns true if the given <pod>
+// podMatchesTermsNamespaceAndSelector returns true if the given <pod>
 // matches the namespace and selector defined by <affinityPod>`s <term>.
-func PodMatchesTermsNamespaceAndSelector(pod *v1.Pod, namespaces sets.Set[string], selector labels.Selector) bool {
+func podMatchesTermsNamespaceAndSelector(pod *v1.Pod, namespaces sets.Set[string], selector labels.Selector) bool {
 	if !namespaces.Has(pod.Namespace) {
 		return false
 	}

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -20,6 +20,7 @@ set -o nounset
 
 # Set to empty if unbound/empty
 SKIP_INSTALL=${SKIP_INSTALL:-}
+KIND_E2E=${KIND_E2E:-}
 
 # This just runs e2e tests.
 if [ -n "$KIND_E2E" ]; then

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -358,3 +358,9 @@ func SetPodAntiAffinity(inputPod *v1.Pod, labelKey, labelValue string) {
 		},
 	}
 }
+
+func PodWithPodAntiAffinity(inputPod *v1.Pod, labelKey, labelValue string) *v1.Pod {
+	SetPodAntiAffinity(inputPod, labelKey, labelValue)
+	inputPod.Labels = map[string]string{labelKey: labelValue}
+	return inputPod
+}

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -337,3 +337,24 @@ func WaitForDeploymentPodsRunning(ctx context.Context, t *testing.T, clientSet c
 		t.Fatalf("Error waiting for pods running: %v", err)
 	}
 }
+
+func SetPodAntiAffinity(inputPod *v1.Pod, labelKey, labelValue string) {
+	inputPod.Spec.Affinity = &v1.Affinity{
+		PodAntiAffinity: &v1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				{
+					LabelSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      labelKey,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{labelValue},
+							},
+						},
+					},
+					TopologyKey: "region",
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/descheduler/issues/1279
More context: https://github.com/kubernetes-sigs/descheduler/issues/1149

This PR:
* Adds a check so that NodeFit() assesses whether it is possible for a given Pod to be scheduled on a given Node before descheduling it.
* Uses the logic from the plugin [RemovePodsViolatingInterPodAntiAffinity](https://github.com/kubernetes-sigs/descheduler/blob/master/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go) which already contains logic for fetching and comparing the pod anti-affinity rule of pods in [checkPodsWithAntiAffinityExist](https://github.com/kubernetes-sigs/descheduler/blob/6c865fdf32ac8fa9b20fd9a971b2631eabab0b1d/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go#L152). The logic is extracted from `pkg/framework/plugins/removepodsviolatinginterpodantiaffinity` -> `pkg/utils/predicates.go` (for the most part).
* Updates user-facing docs about this change
* Adds lots of unit tests!