### PR TITLE
Fix node taint wrong EvictOption field

### DIFF
--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -112,7 +112,7 @@ func (d *RemovePodsViolatingNodeTaints) Deschedule(ctx context.Context, nodes []
 				d.taintFilterFnc,
 			) {
 				klog.V(2).InfoS("Not all taints with NoSchedule effect are tolerated after update for pod on node", "pod", klog.KObj(pods[i]), "node", klog.KObj(node))
-				d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{ProfileName: PluginName})
+				d.handle.Evictor().Evict(ctx, pods[i], evictions.EvictOptions{StrategyName: PluginName})
 				if d.handle.Evictor().NodeLimitExceeded(node) {
 					break
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

[This PR](https://github.com/kubernetes-sigs/descheduler/pull/1349) introduced extended observability capabilities. One of the strategies (`RemovePodsViolatingNodeTaints`) is [pointing to the wrong field](https://github.com/kubernetes-sigs/descheduler/pull/1349/files#diff-74787e2a818e9f68036e134eee3882d886eaebda722cf297285b0b9d3e715d47R115) (`ProfileName` instead of `StrategyName`). Looks like the only place `profileName` should be set is [here](https://github.com/kubernetes-sigs/descheduler/pull/1349/files#diff-3adf3dff318d6a906144789d65afdeb99231e8eb6d6bc0707dda3ca8278337edR257).

This change fixes it by pointing right struct field.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
