### PR TITLE
Add argument to remove only pods violating allowlisted taints

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,18 +500,22 @@ key=value matches an excludedTaints entry, the taint will be ignored.
 For example, excludedTaints entry "dedicated" would match all taints with key "dedicated", regardless of value.
 excludedTaints entry "dedicated=special-user" would match taints with key "dedicated" and value "special-user".
 
+If a list of includedTaints is provided, a taint will be considered if and only if it matches an included key **or** key=value from the list. Otherwise it will be ignored. Leaving includedTaints unset will include any taint by default. 
+
 **Parameters:**
 
 |Name|Type|
 |---|---|
 |`excludedTaints`|list(string)|
+|`includedTaints`|list(string)|
 |`includePreferNoSchedule`|bool|
 |`namespaces`|(see [namespace filtering](#namespace-filtering))|
 |`labelSelector`|(see [label filtering](#label-filtering))|
 
 **Example:**
 
-````yaml
+Setting `excludedTaints`
+```yaml
 apiVersion: "descheduler/v1alpha2"
 kind: "DeschedulerPolicy"
 profiles:
@@ -526,7 +530,25 @@ profiles:
       deschedule:
         enabled:
           - "RemovePodsViolatingNodeTaints"
-````
+```
+
+Setting `includedTaints`
+```yaml
+apiVersion: "descheduler/v1alpha2"
+kind: "DeschedulerPolicy"
+profiles:
+  - name: ProfileName
+    pluginConfig:
+    - name: "RemovePodsViolatingNodeTaints"
+      args:
+        includedTaints:
+        - decommissioned=end-of-life # include only taints with key "decommissioned" and value "end-of-life"
+        - reserved # include all taints with key "reserved"
+    plugins:
+      deschedule:
+        enabled:
+          - "RemovePodsViolatingNodeTaints"
+```
 
 ### RemovePodsViolatingTopologySpreadConstraint
 

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -90,6 +90,7 @@ type StrategyParameters struct {
 	NodeFit                           bool                               `json:"nodeFit"`
 	IncludePreferNoSchedule           bool                               `json:"includePreferNoSchedule"`
 	ExcludedTaints                    []string                           `json:"excludedTaints,omitempty"`
+	IncludedTaints                    []string                           `json:"includedTaints,omitempty"`
 }
 
 type (

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -366,6 +366,11 @@ func (in *StrategyParameters) DeepCopyInto(out *StrategyParameters) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IncludedTaints != nil {
+		in, out := &in.IncludedTaints, &out.IncludedTaints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/defaults.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/defaults.go
@@ -37,4 +37,7 @@ func SetDefaults_RemovePodsViolatingNodeTaintsArgs(obj runtime.Object) {
 	if args.ExcludedTaints == nil {
 		args.ExcludedTaints = nil
 	}
+	if args.IncludedTaints == nil {
+		args.IncludedTaints = nil
+	}
 }

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/defaults_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/defaults_test.go
@@ -37,6 +37,7 @@ func TestSetDefaults_RemovePodsViolatingNodeTaintsArgs(t *testing.T) {
 				LabelSelector:           nil,
 				IncludePreferNoSchedule: false,
 				ExcludedTaints:          nil,
+				IncludedTaints:          nil,
 			},
 		},
 		{
@@ -46,12 +47,14 @@ func TestSetDefaults_RemovePodsViolatingNodeTaintsArgs(t *testing.T) {
 				LabelSelector:           &metav1.LabelSelector{},
 				IncludePreferNoSchedule: false,
 				ExcludedTaints:          []string{"ExcludedTaints"},
+				IncludedTaints:          []string{"IncludedTaints"},
 			},
 			want: &RemovePodsViolatingNodeTaintsArgs{
 				Namespaces:              &api.Namespaces{},
 				LabelSelector:           &metav1.LabelSelector{},
 				IncludePreferNoSchedule: false,
 				ExcludedTaints:          []string{"ExcludedTaints"},
+				IncludedTaints:          []string{"IncludedTaints"},
 			},
 		},
 	}

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -67,16 +67,25 @@ func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plug
 		return nil, fmt.Errorf("error initializing pod filter function: %v", err)
 	}
 
+	includedTaints := sets.New(nodeTaintsArgs.IncludedTaints...)
+	includeTaint := func(taint *v1.Taint) bool {
+		// Include only taints by key *or* key=value
+		// Always returns true if no includedTaints argument is provided
+		return (nodeTaintsArgs.IncludedTaints == nil) || includedTaints.Has(taint.Key) || (taint.Value != "" && includedTaints.Has(fmt.Sprintf("%s=%s", taint.Key, taint.Value)))
+	}
+
 	excludedTaints := sets.New(nodeTaintsArgs.ExcludedTaints...)
 	excludeTaint := func(taint *v1.Taint) bool {
 		// Exclude taints by key *or* key=value
 		return excludedTaints.Has(taint.Key) || (taint.Value != "" && excludedTaints.Has(fmt.Sprintf("%s=%s", taint.Key, taint.Value)))
 	}
 
-	taintFilterFnc := func(taint *v1.Taint) bool { return (taint.Effect == v1.TaintEffectNoSchedule) && !excludeTaint(taint) }
+	taintFilterFnc := func(taint *v1.Taint) bool {
+		return (taint.Effect == v1.TaintEffectNoSchedule) && !excludeTaint(taint) && includeTaint(taint)
+	}
 	if nodeTaintsArgs.IncludePreferNoSchedule {
 		taintFilterFnc = func(taint *v1.Taint) bool {
-			return (taint.Effect == v1.TaintEffectNoSchedule || taint.Effect == v1.TaintEffectPreferNoSchedule) && !excludeTaint(taint)
+			return (taint.Effect == v1.TaintEffectNoSchedule || taint.Effect == v1.TaintEffectPreferNoSchedule) && !excludeTaint(taint) && includeTaint(taint)
 		}
 	}
 

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/types.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/types.go
@@ -32,4 +32,5 @@ type RemovePodsViolatingNodeTaintsArgs struct {
 	LabelSelector           *metav1.LabelSelector `json:"labelSelector"`
 	IncludePreferNoSchedule bool                  `json:"includePreferNoSchedule"`
 	ExcludedTaints          []string              `json:"excludedTaints"`
+	IncludedTaints          []string              `json:"includedTaints"`
 }

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/validation.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/validation.go
@@ -37,5 +37,9 @@ func ValidateRemovePodsViolatingNodeTaintsArgs(obj runtime.Object) error {
 		}
 	}
 
+	if len(args.ExcludedTaints) > 0 && len(args.IncludedTaints) > 0 {
+		return fmt.Errorf("either includedTaints or excludedTaints can be set, but not both")
+	}
+
 	return nil
 }

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/validation_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/validation_test.go
@@ -54,6 +54,21 @@ func TestValidateRemovePodsViolatingNodeTaintsArgs(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			description: "valid taint filters, no errors",
+			args: &RemovePodsViolatingNodeTaintsArgs{
+				ExcludedTaints: []string{"testTaint1=test1"},
+			},
+			expectError: false,
+		},
+		{
+			description: "invalid taint filters args, expects errors",
+			args: &RemovePodsViolatingNodeTaintsArgs{
+				ExcludedTaints: []string{"do-not-evict"},
+				IncludedTaints: []string{"testTaint1=test1"},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/zz_generated.deepcopy.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/zz_generated.deepcopy.go
@@ -46,6 +46,11 @@ func (in *RemovePodsViolatingNodeTaintsArgs) DeepCopyInto(out *RemovePodsViolati
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IncludedTaints != nil {
+		in, out := &in.IncludedTaints, &out.IncludedTaints
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Fixes #1353. 

Adds the option to apply the RemovePodsViolatingNodeTaints strategy only for an explicitly allowlisted set of taints.

When a list of includedTaints is provided, a taint will be considered if and only if it matches an included key **or** key=value from the list. Otherwise it will be ignored. Leaving includedTaints unset will include any taint by default. 