### PR TITLE
EnableFullEviction for RemovePodsViolatingNodeAffinity

### DIFF
--- a/pkg/api/v1alpha1/strategymigration.go
+++ b/pkg/api/v1alpha1/strategymigration.go
@@ -79,9 +79,10 @@ var StrategyParamsToPluginArgs = map[string]func(params *StrategyParameters) (*a
 	},
 	"RemovePodsViolatingNodeAffinity": func(params *StrategyParameters) (*api.PluginConfig, error) {
 		args := &removepodsviolatingnodeaffinity.RemovePodsViolatingNodeAffinityArgs{
-			Namespaces:       v1alpha1NamespacesToInternal(params.Namespaces),
-			LabelSelector:    params.LabelSelector,
-			NodeAffinityType: params.NodeAffinityType,
+			Namespaces:         v1alpha1NamespacesToInternal(params.Namespaces),
+			LabelSelector:      params.LabelSelector,
+			NodeAffinityType:   params.NodeAffinityType,
+			EnableFullEviction: params.EnableFullEviction,
 		}
 		if err := removepodsviolatingnodeaffinity.ValidateRemovePodsViolatingNodeAffinityArgs(args); err != nil {
 			klog.ErrorS(err, "unable to validate plugin arguments", "pluginName", removepodsviolatingnodeaffinity.PluginName)

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -90,6 +90,7 @@ type StrategyParameters struct {
 	NodeFit                           bool                               `json:"nodeFit"`
 	IncludePreferNoSchedule           bool                               `json:"includePreferNoSchedule"`
 	ExcludedTaints                    []string                           `json:"excludedTaints,omitempty"`
+	EnableFullEviction                bool                               `json:"enableFullEviction"`
 }
 
 type (

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/types.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/types.go
@@ -28,7 +28,8 @@ import (
 type RemovePodsViolatingNodeAffinityArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces       *api.Namespaces       `json:"namespaces"`
-	LabelSelector    *metav1.LabelSelector `json:"labelSelector"`
-	NodeAffinityType []string              `json:"nodeAffinityType"`
+	Namespaces         *api.Namespaces       `json:"namespaces"`
+	LabelSelector      *metav1.LabelSelector `json:"labelSelector"`
+	NodeAffinityType   []string              `json:"nodeAffinityType"`
+	EnableFullEviction bool                  `json:"enableFullEviction"`
 }


### PR DESCRIPTION
This PR adds a `EnableFullEviction` configuration option to the `RemovePodsViolatingNodeAffinity` plugin. Enabling it would look like this:

```yaml
apiVersion: v1
data:
  policy.yaml: |
    apiVersion: "descheduler/v1alpha2"
    kind: "DeschedulerPolicy"
    profiles:
      - name: ProfileName
        pluginConfig:
        - name: "RemovePodsViolatingNodeAffinity"
          args:
            nodeAffinityType:
            - "requiredDuringSchedulingIgnoredDuringExecution"
            enableFullEviction: true
        plugins:
          deschedule:
            enabled:
              - "RemovePodsViolatingNodeAffinity"
```

The purpose of this feature is to enable eviction of all pod replicas whose declared nodeAffinity configuration no longer matches the node they are currently scheduled onto, _even if there is no other node in the cluster that has a nodeAffinity match_. That last part (in italics) is the change that I'm advocating for here.

TODO: docs and updated helm chart