### PR TITLE
Fix the replicas value type for the descheduler helm-chart

### DIFF
--- a/charts/descheduler/templates/NOTES.txt
+++ b/charts/descheduler/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Descheduler installed as a {{ .Values.kind }}.
 
 {{- if eq .Values.kind "Deployment" }}
-{{- if eq .Values.replicas 1 }}
+{{- if eq (.Values.replicas | int) 1 }}
 WARNING: You set replica count as 1 and workload kind as Deployment however leaderElection is not enabled. Consider enabling Leader Election for HA mode.
 {{- end}}
 {{- if .Values.leaderElection }}

--- a/charts/descheduler/templates/NOTES.txt
+++ b/charts/descheduler/templates/NOTES.txt
@@ -1,7 +1,7 @@
 Descheduler installed as a {{ .Values.kind }}.
 
 {{- if eq .Values.kind "Deployment" }}
-{{- if eq .Values.replicas 1.0}}
+{{- if eq .Values.replicas 1 }}
 WARNING: You set replica count as 1 and workload kind as Deployment however leaderElection is not enabled. Consider enabling Leader Election for HA mode.
 {{- end}}
 {{- if .Values.leaderElection }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 spec:
-  {{- if gt .Values.replicas 1 }}
+  {{- if gt (.Values.replicas | int) 1 }}
   {{- if not .Values.leaderElection.enabled }}
   {{- fail "You must set leaderElection to use more than 1 replica"}}
   {{- end}}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 spec:
-  {{- if gt .Values.replicas 1.0}}
+  {{- if gt .Values.replicas 1 }}
   {{- if not .Values.leaderElection.enabled }}
   {{- fail "You must set leaderElection to use more than 1 replica"}}
   {{- end}}


### PR DESCRIPTION
## Fix the replicas type for the helm chart (with terraform helm_release provider)

<details>
<summary>The errors details</summary>

```bash
templates/: template: descheduler/templates/deployment.yaml:10:9: executing "descheduler/templates/deployment.yaml" at <gt .Values.replicas 1.0>: error calling gt: incompatible types for comparison
```
</details>

## How to re-produce

The environment

```bash
Client Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.13", GitCommit:"49433308be5b958856b6949df02b716e0a7cf0a3", GitTreeState:"clean", BuildDate:"2023-04-12T12:15:50Z", GoVersion:"go1.19.8", Compiler:"gc", Platform:"darwin/amd64"}
Kustomize Version: v4.5.4
Server Version: version.Info{Major:"1", Minor:"26", GitVersion:"v1.26.15", GitCommit:"1649f592f1909b97aa3c2a0a8f968a3fd05a7b8b", GitTreeState:"clean", BuildDate:"2024-03-14T00:54:27Z", GoVersion:"go1.21.8", Compiler:"gc", Platform:"linux/amd64"}
```

<details>
<summary>Re-produce step by step</summary>

1. [Install Terraform](https://developer.hashicorp.com/terraform/install) 
2. Create TF files

```bash
$ mkdir test && cd test
$ cat <<EOF > providers.tf
terraform {
  required_providers {
    helm = {
      source  = "hashicorp/helm"
      version = "~> 2.13"
    }
  }
}
provider "helm" {
  kubernetes {
    config_path = "~/.kube/config"
  }
}
EOF

$ cat <<EOF > helm.tf
# https://github.com/kubernetes-sigs/descheduler
resource "helm_release" "descheduler" {
  repository    = "https://kubernetes-sigs.github.io/descheduler/"
  name          = "descheduler"
  chart         = "descheduler"
  version       = "0.29.0"
  namespace     = "kube-system"
  set {
    name  = "kind"
    value = "Deployment"
    type  = "string"
  }
  set {
    name  = "replicas"
    value = 2
    type  = "auto"
  }
  set {
    name  = "leaderElection.enabled"
    value = true
    type  = "auto"
  }
}
EOF
```


3. Initilalize and apply

```bash
$ terraform init
$ terraform apply -auto-approve
...
helm_release.descheduler: Creating...
╷
│ Error: template: descheduler/templates/deployment.yaml:10:9: executing "descheduler/templates/deployment.yaml" at <gt .Values.replicas 1.0>: error calling gt: incompatible types for comparison
│
│   with helm_release.descheduler,
│   on helm.tf line 2, in resource "helm_release" "descheduler":
│    2: resource "helm_release" "descheduler" {
│
```

</details>
