### PR TITLE
bump to to 1.22.3 to address CVE-2024-24788

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22.2'
+          go-version: '1.22.3'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.22.2
+FROM golang:1.22.3
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ gen:
 	./hack/update-docs.sh
 
 gen-docker:
-	$(CONTAINER_ENGINE) run --entrypoint make -it -v $(CURRENT_DIR):/go/src/sigs.k8s.io/descheduler -w /go/src/sigs.k8s.io/descheduler golang:1.22.2 gen
+	$(CONTAINER_ENGINE) run --entrypoint make -it -v $(CURRENT_DIR):/go/src/sigs.k8s.io/descheduler -w /go/src/sigs.k8s.io/descheduler golang:1.22.3 gen
 
 verify-gen:
 	./hack/verify-conversions.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/descheduler
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
https://github.com/kubernetes-sigs/descheduler/security/code-scanning/21