### PR TITLE
use cmd context instead of using context.Background()

### DIFF
--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -77,7 +77,7 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 
 			secureServing.DisableHTTP2 = !s.EnableHTTP2
 
-			ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+			ctx, done := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 
 			pathRecorderMux := mux.NewPathRecorderMux("descheduler")
 			if !s.DisableMetrics {


### PR DESCRIPTION
- use cmd context instead of using context.Background().
cmd *cobra.Command provided the context ctx, we should use this one provided by cmd instead of using context.Background(). We should pass the upstream ctx to the downstream.