### PR TITLE
chore: reduce repetition of go versions

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22.3'
+          go-version-file: 'go.mod'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint 2> /dev/null)
 GOFUMPT_VERSION := v0.4.0
 HAS_GOFUMPT := $(shell command -v gofumpt 2> /dev/null)
 
-GO_VERSION := $(shell sed -En 's/^go (.*)$$/\1/p' go.mod)
+GO_VERSION := $(shell (command -v jq > /dev/null && (go mod edit -json | jq -r .Go)) || (sed -En 's/^go (.*)$$/\1/p' go.mod))
 
 # REGISTRY is the container registry to push
 # into. The default is to push to the staging

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint 2> /dev/null)
 GOFUMPT_VERSION := v0.4.0
 HAS_GOFUMPT := $(shell command -v gofumpt 2> /dev/null)
 
+GO_VERSION := $(shell sed -En 's/^go (.*)$$/\1/p' go.mod)
+
 # REGISTRY is the container registry to push
 # into. The default is to push to the staging
 # registry, not production.
@@ -134,7 +136,7 @@ gen:
 	./hack/update-docs.sh
 
 gen-docker:
-	$(CONTAINER_ENGINE) run --entrypoint make -it -v $(CURRENT_DIR):/go/src/sigs.k8s.io/descheduler -w /go/src/sigs.k8s.io/descheduler golang:1.22.3 gen
+	$(CONTAINER_ENGINE) run --entrypoint make -it -v $(CURRENT_DIR):/go/src/sigs.k8s.io/descheduler -w /go/src/sigs.k8s.io/descheduler golang:$(GO_VERSION) gen
 
 verify-gen:
 	./hack/verify-conversions.sh

--- a/hack/lib/go.sh
+++ b/hack/lib/go.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# go::verify_version verifies the go version is supported by the project.
+# descheduler actively supports 3 versions, therefore 3 go versions are supported.
+go::verify_version() {
+  GO_VERSION=($(go version))
+
+  if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.20|go1.21|go1.22') ]]; then
+    echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
+    exit 1
+  fi
+}

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -20,13 +20,9 @@ set -o nounset
 set -o pipefail
 
 DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${DESCHEDULER_ROOT}/hack/lib/go.sh"
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.18|go1.19|go1.20|go1.21|go1.22') ]]; then
-  echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
-  exit 1
-fi
+go::verify_version
 
 cd "${DESCHEDULER_ROOT}"
 

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -20,13 +20,9 @@ set -o nounset
 set -o pipefail
 
 DESCHEDULER_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${DESCHEDULER_ROOT}/hack/lib/go.sh"
 
-GO_VERSION=($(go version))
-
-if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.18|go1.19|go1.20|go1.21|go1.22') ]]; then
-  echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
-  exit 1
-fi
+go::verify_version
 
 cd "${DESCHEDULER_ROOT}"
 


### PR DESCRIPTION
when we cut a new release of descheduler, we have to update the go version in multiple places dquote> which presents an opportunity to miss updating one.