### PR TITLE
bump go to 1.22.4 for CVE-2024-24790 and CVE-2024-24789

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.22.3
+FROM golang:1.22.4
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/descheduler
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
rebased on top of #1432 

[bump go to 1.22.4 for](https://github.com/kubernetes-sigs/descheduler/pull/1433/commits/1aa7ef88e6d572804098b80ed8325549590832d5) https://github.com/advisories/GHSA-49gw-vxvf-fc2g [and](https://github.com/kubernetes-sigs/descheduler/pull/1433/commits/1aa7ef88e6d572804098b80ed8325549590832d5) https://github.com/advisories/GHSA-236w-p7wf-5ph8