### PR TITLE
return pod qos in advance

### DIFF
--- a/pkg/utils/qos.go
+++ b/pkg/utils/qos.go
@@ -20,6 +20,10 @@ func isSupportedQoSComputeResource(name v1.ResourceName) bool {
 // A pod is guaranteed only when requests and limits are specified for all the containers and they are equal.
 // A pod is burstable if limits and requests do not match across all containers.
 func GetPodQOS(pod *v1.Pod) v1.PodQOSClass {
+	if len(pod.Status.QOSClass) != 0 {
+		return pod.Status.QOSClass
+	}
+
 	requests := v1.ResourceList{}
 	limits := v1.ResourceList{}
 	zeroQuantity := resource.MustParse("0")


### PR DESCRIPTION
If the pod's Qos has a value, return the QoS value early. For pods evicted within the descheduler, they are typically already scheduled onto nodes, and in most cases, the QoS value is already present on the pod's status. Therefore, it is unnecessary to start the determination process from scratch.