### PR TITLE
fix: helm leader-election typo to `resourceNamespace`

### DIFF
--- a/charts/descheduler/templates/_helpers.tpl
+++ b/charts/descheduler/templates/_helpers.tpl
@@ -87,8 +87,10 @@ Leader Election
 {{- if .Values.leaderElection.resourceName }}
 - --leader-elect-resource-name={{ .Values.leaderElection.resourceName }}
 {{- end }}
-{{- if .Values.leaderElection.resourceNamescape }}
-- --leader-elect-resource-namespace={{ .Values.leaderElection.resourceNamescape }}
+{{/* resource namespace value starts with a typo so keeping resourceNamescape for backwards compatibility */}}
+{{- $resourceNamespace := default .Values.leaderElection.resourceNamespace .Values.leaderElection.resourceNamescape -}}
+{{- if $resourceNamespace -}}
+- --leader-elect-resource-namespace={{ $resourceNamespace }}
 {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -70,7 +70,7 @@ leaderElection: {}
 #  retryPeriod: 2s
 #  resourceLock: "leases"
 #  resourceName: "descheduler"
-#  resourceNamescape: "kube-system"
+#  resourceNamespace: "kube-system"
 
 command:
 - "/bin/descheduler"


### PR DESCRIPTION
reported issue: https://kubernetes.slack.com/archives/C09TP78DV/p1718633429179519


Test using `leaderElection.resourceNamescape`
```
helm template deschduler ./descheduler -f ./descheduler/values.yaml --set kind=Deployment --set=leaderElection.enabled=true --set=leaderElection.resourceNamescape=foo

Error: execution error at (descheduler/templates/deployment.yaml:62:16): 'leaderElection.resourceNamescape' is deprecated. instead use 'leaderElection.resourceNamespace'
```

Test using `leaderElection.resourceNamespace`
```
helm template deschduler ./descheduler -f ./descheduler/values.yaml --set kind=Deployment --set=leaderElection.enabled=true --set=leaderElection.resourceNamespace=foo | grep leader-elect-resource-namespace

            - --leader-elect-resource-namespace=foo