### PR TITLE
feat: Add namespace override settings in Helm Chart

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -52,6 +52,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `imagePullSecrets`                  | Docker repository secrets                                                                                             | `[]`                                      |
 | `nameOverride`                      | String to partially override `descheduler.fullname` template (will prepend the release name)                          | `""`                                      |
 | `fullnameOverride`                  | String to fully override `descheduler.fullname` template                                                              | `""`                                      |
+| `namespaceOverride`                 | Override the deployment namespace; defaults to .Release.Namespace                                                     | `""`                                      |
 | `cronJobApiVersion`                 | CronJob API Group Version                                                                                             | `"batch/v1"`                              |
 | `schedule`                          | The cron schedule to run the _descheduler_ job on                                                                     | `"*/2 * * * *"`                           |
 | `startingDeadlineSeconds`           | If set, configure `startingDeadlineSeconds` for the _descheduler_ job                                                 | `nil`                                     |

--- a/charts/descheduler/templates/_helpers.tpl
+++ b/charts/descheduler/templates/_helpers.tpl
@@ -25,6 +25,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Expand the namespace of the release.
+Allows overriding it for multi-namespace deployments in combined charts.
+*/}}
+{{- define "descheduler.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "descheduler.chart" -}}

--- a/charts/descheduler/templates/clusterrolebinding.yaml
+++ b/charts/descheduler/templates/clusterrolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ template "descheduler.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "descheduler.namespace" . }}
 {{- end -}}

--- a/charts/descheduler/templates/configmap.yaml
+++ b/charts/descheduler/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "descheduler.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "descheduler.namespace" . }}
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 data:

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ .Values.cronJobApiVersion | default "batch/v1" }}
 kind: CronJob
 metadata:
   name: {{ template "descheduler.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "descheduler.namespace" . }}
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 spec:

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "descheduler.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "descheduler.namespace" . }}
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 spec:

--- a/charts/descheduler/templates/service.yaml
+++ b/charts/descheduler/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
   name: {{ template "descheduler.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "descheduler.namespace" . }}
 spec:
   clusterIP: None
   {{- if .Values.service.ipFamilyPolicy }}

--- a/charts/descheduler/templates/serviceaccount.yaml
+++ b/charts/descheduler/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "descheduler.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "descheduler.namespace" . }}
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
 {{- if .Values.serviceAccount.annotations }}

--- a/charts/descheduler/templates/servicemonitor.yaml
+++ b/charts/descheduler/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@ spec:
   jobLabel: jobLabel
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ include "descheduler.namespace" . }}
   selector:
     matchLabels:
       {{- include "descheduler.selectorLabels" . | nindent 6 }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -39,6 +39,9 @@ podSecurityContext: {}
 nameOverride: ""
 fullnameOverride: ""
 
+# -- Override the deployment namespace; defaults to .Release.Namespace
+namespaceOverride: ""
+
 # labels that'll be applied to all resources
 commonLabels: {}
 


### PR DESCRIPTION
### PR description
This PR includes changes to allow the descheduler Helm chart to be deployed to a specified namespace.

### Usage
You can deploy to a specific namespace by setting namespaceOverride in the values.yaml file as follows:
```
namespaceOverride: your-custom-namespace
```