### PR TITLE
PodEvictor: refactoring and preparation for eviction requests

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -160,7 +160,6 @@ func (d *descheduler) runDeschedulerLoop(ctx context.Context, nodes []*v1.Node) 
 		d.rs.DryRun,
 		d.deschedulerPolicy.MaxNoOfPodsToEvictPerNode,
 		d.deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace,
-		nodes,
 		!d.rs.DisableMetrics,
 		d.eventRecorder,
 	)

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -13,15 +13,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apiversion "k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/informers"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/api/v1alpha1"
+	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
 	"sigs.k8s.io/descheduler/pkg/framework/pluginregistry"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/defaultevictor"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removeduplicates"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/removepodsviolatingnodetaints"
+	"sigs.k8s.io/descheduler/pkg/utils"
 	deschedulerversion "sigs.k8s.io/descheduler/pkg/version"
 	"sigs.k8s.io/descheduler/test"
 )
@@ -174,7 +177,7 @@ func TestDuplicate(t *testing.T) {
 	}
 
 	if len(evictedPods) == 0 {
-		t.Fatalf("Unable to evict pod, node taint did not get propagated to descheduler strategies %v\n", err)
+		t.Fatalf("Unable to evict pods\n")
 	}
 }
 
@@ -321,5 +324,98 @@ func podEvictionReactionFuc(evictedPods *[]string) func(action core.Action) (boo
 			}
 		}
 		return false, nil, nil // fallback to the default reactor
+	}
+}
+
+func initPluginRegistry() {
+	pluginregistry.PluginRegistry = pluginregistry.NewRegistry()
+	pluginregistry.Register(removeduplicates.PluginName, removeduplicates.New, &removeduplicates.RemoveDuplicates{}, &removeduplicates.RemoveDuplicatesArgs{}, removeduplicates.ValidateRemoveDuplicatesArgs, removeduplicates.SetDefaults_RemoveDuplicatesArgs, pluginregistry.PluginRegistry)
+	pluginregistry.Register(defaultevictor.PluginName, defaultevictor.New, &defaultevictor.DefaultEvictor{}, &defaultevictor.DefaultEvictorArgs{}, defaultevictor.ValidateDefaultEvictorArgs, defaultevictor.SetDefaults_DefaultEvictorArgs, pluginregistry.PluginRegistry)
+}
+
+func TestPodEvictorReset(t *testing.T) {
+	initPluginRegistry()
+
+	ctx := context.Background()
+	node1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
+	node2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
+
+	p1 := test.BuildTestPod("p1", 100, 0, node1.Name, nil)
+	p1.Namespace = "dev"
+	p2 := test.BuildTestPod("p2", 100, 0, node1.Name, nil)
+	p2.Namespace = "dev"
+	p3 := test.BuildTestPod("p3", 100, 0, node1.Name, nil)
+	p3.Namespace = "dev"
+	p4 := test.BuildTestPod("p4", 100, 0, node1.Name, nil)
+	p4.Namespace = "dev"
+
+	ownerRef1 := test.GetReplicaSetOwnerRefList()
+	p1.ObjectMeta.OwnerReferences = ownerRef1
+	p2.ObjectMeta.OwnerReferences = ownerRef1
+	p3.ObjectMeta.OwnerReferences = ownerRef1
+	p4.ObjectMeta.OwnerReferences = ownerRef1
+
+	client := fakeclientset.NewSimpleClientset(node1, node2, p1, p2, p3, p4)
+	eventClient := fakeclientset.NewSimpleClientset(node1, node2, p1, p2, p3, p4)
+	dp := &v1alpha1.DeschedulerPolicy{
+		Strategies: v1alpha1.StrategyList{
+			"RemoveDuplicates": v1alpha1.DeschedulerStrategy{
+				Enabled: true,
+			},
+		},
+	}
+
+	internalDeschedulerPolicy := &api.DeschedulerPolicy{}
+	scope := scope{}
+	err := v1alpha1.V1alpha1ToInternal(dp, pluginregistry.PluginRegistry, internalDeschedulerPolicy, scope)
+	if err != nil {
+		t.Fatalf("Unable to convert v1alpha1 to v1alpha2: %v", err)
+	}
+
+	rs, err := options.NewDeschedulerServer()
+	if err != nil {
+		t.Fatalf("Unable to initialize server: %v", err)
+	}
+	rs.Client = client
+	rs.EventClient = eventClient
+
+	var evictedPods []string
+	client.PrependReactor("create", "pods", podEvictionReactionFuc(&evictedPods))
+
+	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(rs.Client, 0, informers.WithTransform(trimManagedFields))
+	eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, client)
+	defer eventBroadcaster.Shutdown()
+
+	descheduler, err := newDescheduler(rs, internalDeschedulerPolicy, "v1", eventRecorder, sharedInformerFactory)
+	if err != nil {
+		t.Fatalf("Unable to create a descheduler instance: %v", err)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sharedInformerFactory.Start(ctx.Done())
+	sharedInformerFactory.WaitForCacheSync(ctx.Done())
+
+	nodes, err := nodeutil.ReadyNodes(ctx, rs.Client, descheduler.nodeLister, "")
+	if err != nil {
+		t.Fatalf("Unable to get ready nodes: %v", err)
+	}
+
+	// a single pod eviction expected
+	err = descheduler.runDeschedulerLoop(ctx, nodes)
+	if err != nil {
+		t.Fatalf("Unable to run a descheduling loop: %v", err)
+	}
+	if descheduler.podEvictor.TotalEvicted() != 2 || len(evictedPods) != 2 {
+		t.Fatalf("Expected (2,2) pods evicted, got (%v, %v) instead", descheduler.podEvictor.TotalEvicted(), len(evictedPods))
+	}
+
+	// a single pod eviction expected
+	err = descheduler.runDeschedulerLoop(ctx, nodes)
+	if err != nil {
+		t.Fatalf("Unable to run a descheduling loop: %v", err)
+	}
+	if descheduler.podEvictor.TotalEvicted() != 2 || len(evictedPods) != 4 {
+		t.Fatalf("Expected (2,4) pods evicted, got (%v, %v) instead", descheduler.podEvictor.TotalEvicted(), len(evictedPods))
 	}
 }

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -98,7 +98,7 @@ func TestTaintsUpdated(t *testing.T) {
 	}
 
 	var evictedPods []string
-	client.PrependReactor("create", "pods", podEvictionReactionFuc(&evictedPods))
+	client.PrependReactor("create", "pods", podEvictionReactionTestingFnc(&evictedPods))
 
 	internalDeschedulerPolicy := &api.DeschedulerPolicy{}
 	scope := scope{}
@@ -164,7 +164,7 @@ func TestDuplicate(t *testing.T) {
 	}
 
 	var evictedPods []string
-	client.PrependReactor("create", "pods", podEvictionReactionFuc(&evictedPods))
+	client.PrependReactor("create", "pods", podEvictionReactionTestingFnc(&evictedPods))
 
 	internalDeschedulerPolicy := &api.DeschedulerPolicy{}
 	scope := scope{}
@@ -312,7 +312,7 @@ func TestValidateVersionCompatibility(t *testing.T) {
 	}
 }
 
-func podEvictionReactionFuc(evictedPods *[]string) func(action core.Action) (bool, runtime.Object, error) {
+func podEvictionReactionTestingFnc(evictedPods *[]string) func(action core.Action) (bool, runtime.Object, error) {
 	return func(action core.Action) (bool, runtime.Object, error) {
 		if action.GetSubresource() == "eviction" {
 			createAct, matched := action.(core.CreateActionImpl)
@@ -380,7 +380,7 @@ func TestPodEvictorReset(t *testing.T) {
 	rs.EventClient = eventClient
 
 	var evictedPods []string
-	client.PrependReactor("create", "pods", podEvictionReactionFuc(&evictedPods))
+	client.PrependReactor("create", "pods", podEvictionReactionTestingFnc(&evictedPods))
 
 	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(rs.Client, 0, informers.WithTransform(trimManagedFields))
 	eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, client)

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -97,6 +97,15 @@ func (pe *PodEvictor) NodeLimitExceeded(node *v1.Node) bool {
 	return false
 }
 
+func (pe *PodEvictor) ResetCounters() {
+	pe.nodepodCount = make(nodePodEvictedCount)
+	pe.namespacePodCount = make(namespacePodEvictCount)
+}
+
+func (pe *PodEvictor) SetClient(client clientset.Interface) {
+	pe.client = client
+}
+
 // EvictOptions provides a handle for passing additional info to EvictPod
 type EvictOptions struct {
 	// Reason allows for passing details about the specific eviction for logging.

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -43,7 +43,6 @@ type (
 
 type PodEvictor struct {
 	client                     clientset.Interface
-	nodes                      []*v1.Node
 	policyGroupVersion         string
 	dryRun                     bool
 	maxPodsToEvictPerNode      *uint
@@ -60,26 +59,17 @@ func NewPodEvictor(
 	dryRun bool,
 	maxPodsToEvictPerNode *uint,
 	maxPodsToEvictPerNamespace *uint,
-	nodes []*v1.Node,
 	metricsEnabled bool,
 	eventRecorder events.EventRecorder,
 ) *PodEvictor {
-	nodePodCount := make(nodePodEvictedCount)
-	namespacePodCount := make(namespacePodEvictCount)
-	for _, node := range nodes {
-		// Initialize podsEvicted till now with 0.
-		nodePodCount[node.Name] = 0
-	}
-
 	return &PodEvictor{
 		client:                     client,
-		nodes:                      nodes,
 		policyGroupVersion:         policyGroupVersion,
 		dryRun:                     dryRun,
 		maxPodsToEvictPerNode:      maxPodsToEvictPerNode,
 		maxPodsToEvictPerNamespace: maxPodsToEvictPerNamespace,
-		nodepodCount:               nodePodCount,
-		namespacePodCount:          namespacePodCount,
+		nodepodCount:               make(nodePodEvictedCount),
+		namespacePodCount:          make(namespacePodEvictCount),
 		metricsEnabled:             metricsEnabled,
 		eventRecorder:              eventRecorder,
 	}

--- a/pkg/framework/plugins/nodeutilization/highnodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization_test.go
@@ -490,7 +490,6 @@ func TestHighNodeUtilization(t *testing.T) {
 				false,
 				nil,
 				nil,
-				testCase.nodes,
 				false,
 				eventRecorder,
 			)
@@ -642,7 +641,6 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 				false,
 				&item.evictionsExpected,
 				nil,
-				item.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/nodeutilization/lownodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/lownodeutilization_test.go
@@ -892,7 +892,6 @@ func TestLowNodeUtilization(t *testing.T) {
 				false,
 				nil,
 				nil,
-				test.nodes,
 				false,
 				eventRecorder,
 			)
@@ -1064,7 +1063,6 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				false,
 				&item.evictionsExpected,
 				nil,
-				item.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
@@ -562,7 +562,6 @@ func TestPodLifeTime(t *testing.T) {
 				false,
 				tc.maxPodsToEvictPerNode,
 				tc.maxPodsToEvictPerNamespace,
-				tc.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
@@ -319,7 +319,6 @@ func TestFindDuplicatePods(t *testing.T) {
 				false,
 				nil,
 				nil,
-				testCase.nodes,
 				false,
 				eventRecorder,
 			)
@@ -768,7 +767,6 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 				false,
 				nil,
 				nil,
-				testCase.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/removefailedpods/failedpods_test.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods_test.go
@@ -381,7 +381,6 @@ func TestRemoveFailedPods(t *testing.T) {
 				false,
 				nil,
 				nil,
-				tc.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts_test.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts_test.go
@@ -350,7 +350,6 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 				false,
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
-				tc.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
@@ -239,7 +239,6 @@ func TestPodAntiAffinity(t *testing.T) {
 				false,
 				test.maxPodsToEvictPerNode,
 				test.maxNoOfPodsToEvictPerNamespace,
-				test.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity_test.go
@@ -365,7 +365,6 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 				false,
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
-				tc.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
@@ -406,7 +406,6 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				false,
 				tc.maxPodsToEvictPerNode,
 				tc.maxNoOfPodsToEvictPerNamespace,
-				tc.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1462,7 +1462,6 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				false,
 				nil,
 				nil,
-				tc.nodes,
 				false,
 				eventRecorder,
 			)

--- a/pkg/framework/profile/profile_test.go
+++ b/pkg/framework/profile/profile_test.go
@@ -244,7 +244,7 @@ func TestProfileDescheduleBalanceExtensionPointsEviction(t *testing.T) {
 			eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, eventClient)
 			defer eventBroadcaster.Shutdown()
 
-			podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, nodes, true, eventRecorder)
+			podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, true, eventRecorder)
 
 			prfl, err := NewProfile(
 				test.config,
@@ -306,7 +306,6 @@ func TestProfileExtensionPoints(t *testing.T) {
 
 	n1 := testutils.BuildTestNode("n1", 2000, 3000, 10, nil)
 	n2 := testutils.BuildTestNode("n2", 2000, 3000, 10, nil)
-	nodes := []*v1.Node{n1, n2}
 
 	p1 := testutils.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, nil)
 	p1.ObjectMeta.OwnerReferences = []metav1.OwnerReference{{}}
@@ -393,7 +392,7 @@ func TestProfileExtensionPoints(t *testing.T) {
 	eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, eventClient)
 	defer eventBroadcaster.Shutdown()
 
-	podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, nodes, true, eventRecorder)
+	podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, true, eventRecorder)
 
 	prfl, err := NewProfile(
 		api.DeschedulerProfile{
@@ -605,7 +604,7 @@ func TestProfileExtensionPointOrdering(t *testing.T) {
 	eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, eventClient)
 	defer eventBroadcaster.Shutdown()
 
-	podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, nodes, true, eventRecorder)
+	podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, true, eventRecorder)
 
 	prfl, err := NewProfile(
 		api.DeschedulerProfile{

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -48,7 +48,7 @@ func TestRemoveDuplicates(t *testing.T) {
 		t.Errorf("Error listing node with %v", err)
 	}
 
-	nodes, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
+	_, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
 
 	t.Log("Creating testing namespace")
 	testNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-" + strings.ToLower(t.Name())}}
@@ -177,7 +177,6 @@ func TestRemoveDuplicates(t *testing.T) {
 				false,
 				nil,
 				nil,
-				nodes,
 				false,
 				eventRecorder,
 			)

--- a/test/e2e/e2e_failedpods_test.go
+++ b/test/e2e/e2e_failedpods_test.go
@@ -75,7 +75,7 @@ func TestFailedPods(t *testing.T) {
 			defer jobClient.Delete(ctx, job.Name, metav1.DeleteOptions{PropagationPolicy: &deletePropagationPolicy})
 			waitForJobPodPhase(ctx, t, clientSet, job, v1.PodFailed)
 
-			podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode, nodes)
+			podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods:   true,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -196,7 +196,6 @@ func runPodLifetimePlugin(
 		false,
 		nil,
 		maxPodsToEvictPerNamespace,
-		nodes,
 		false,
 		&events.FakeRecorder{},
 	)
@@ -285,7 +284,7 @@ func TestLowNodeUtilization(t *testing.T) {
 		t.Errorf("Error listing node with %v", err)
 	}
 
-	nodes, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
+	_, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
 
 	t.Log("Creating testing namespace")
 	testNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-" + strings.ToLower(t.Name())}}
@@ -374,7 +373,7 @@ func TestLowNodeUtilization(t *testing.T) {
 	waitForRCPodsRunning(ctx, t, clientSet, rc)
 
 	// Run LowNodeUtilization plugin
-	podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode, nodes)
+	podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode)
 
 	defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{
 		EvictLocalStoragePods:   true,
@@ -1570,7 +1569,7 @@ func splitNodesAndWorkerNodes(nodes []v1.Node) ([]*v1.Node, []*v1.Node) {
 	return allNodes, workerNodes
 }
 
-func initPodEvictorOrFail(t *testing.T, clientSet clientset.Interface, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc, nodes []*v1.Node) *evictions.PodEvictor {
+func initPodEvictorOrFail(t *testing.T, clientSet clientset.Interface, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc) *evictions.PodEvictor {
 	evictionPolicyGroupVersion, err := eutils.SupportEviction(clientSet)
 	if err != nil || len(evictionPolicyGroupVersion) == 0 {
 		t.Fatalf("Error creating eviction policy group: %v", err)
@@ -1584,7 +1583,6 @@ func initPodEvictorOrFail(t *testing.T, clientSet clientset.Interface, getPodsAs
 		false,
 		nil,
 		nil,
-		nodes,
 		false,
 		eventRecorder,
 	)

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -50,7 +50,7 @@ func TestTooManyRestarts(t *testing.T) {
 		t.Errorf("Error listing node with %v", err)
 	}
 
-	nodes, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
+	_, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
 
 	t.Logf("Creating testing namespace %v", t.Name())
 	testNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-" + strings.ToLower(t.Name())}}
@@ -167,7 +167,6 @@ func TestTooManyRestarts(t *testing.T) {
 				false,
 				nil,
 				nil,
-				nodes,
 				false,
 				eventRecorder,
 			)

--- a/test/e2e/e2e_topologyspreadconstraint_test.go
+++ b/test/e2e/e2e_topologyspreadconstraint_test.go
@@ -27,7 +27,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error listing node with %v", err)
 	}
-	nodes, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
+	_, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
 	t.Log("Creating testing namespace")
 	testNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-" + strings.ToLower(t.Name())}}
 	if _, err := clientSet.CoreV1().Namespaces().Create(ctx, testNamespace, metav1.CreateOptions{}); err != nil {
@@ -138,7 +138,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			defer test.DeleteDeployment(ctx, t, clientSet, violatorDeployment)
 			test.WaitForDeploymentPodsRunning(ctx, t, clientSet, violatorDeployment)
 
-			podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode, nodes)
+			podEvictor := initPodEvictorOrFail(t, clientSet, getPodsAssignedToNode)
 
 			// Run TopologySpreadConstraint strategy
 			t.Logf("Running RemovePodsViolatingTopologySpreadConstraint strategy for %s", name)


### PR DESCRIPTION
Drop nodes parameter from NewPodEvictor and set up the pod evictor only once for all descheduling cycles. While resetting the inner counters at the end of each descheduling cycle.

This is a pre-requisite for implementing eviction requests (https://github.com/kubernetes-sigs/descheduler/issues/1397).