### PR TITLE
The descheduler supports limiting the total number of pods evicted per rescheduling cycle

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -38,6 +38,9 @@ type DeschedulerPolicy struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint
+
+	// MaxNoOfPodsToTotal restricts maximum of pods to be evicted total.
+	MaxNoOfPodsToEvictTotal *uint
 }
 
 // Namespaces carries a list of included/excluded namespaces

--- a/pkg/api/v1alpha1/types.go
+++ b/pkg/api/v1alpha1/types.go
@@ -52,6 +52,9 @@ type DeschedulerPolicy struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint `json:"maxNoOfPodsToEvictPerNamespace,omitempty"`
+
+	// MaxNoOfPodsToTotal restricts maximum of pods to be evicted total.
+	MaxNoOfPodsToEvictTotal *uint `json:"maxNoOfPodsToEvictTotal,omitempty"`
 }
 
 type (

--- a/pkg/api/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha1/zz_generated.deepcopy.go
@@ -77,6 +77,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.MaxNoOfPodsToEvictTotal != nil {
+		in, out := &in.MaxNoOfPodsToEvictTotal, &out.MaxNoOfPodsToEvictTotal
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/v1alpha2/types.go
+++ b/pkg/api/v1alpha2/types.go
@@ -37,6 +37,9 @@ type DeschedulerPolicy struct {
 
 	// MaxNoOfPodsToEvictPerNamespace restricts maximum of pods to be evicted per namespace.
 	MaxNoOfPodsToEvictPerNamespace *uint `json:"maxNoOfPodsToEvictPerNamespace,omitempty"`
+
+	// MaxNoOfPodsToTotal restricts maximum of pods to be evicted total.
+	MaxNoOfPodsToEvictTotal *uint `json:"maxNoOfPodsToEvictTotal,omitempty"`
 }
 
 type DeschedulerProfile struct {

--- a/pkg/api/v1alpha2/zz_generated.conversion.go
+++ b/pkg/api/v1alpha2/zz_generated.conversion.go
@@ -104,6 +104,7 @@ func autoConvert_v1alpha2_DeschedulerPolicy_To_api_DeschedulerPolicy(in *Desched
 	out.NodeSelector = (*string)(unsafe.Pointer(in.NodeSelector))
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
+	out.MaxNoOfPodsToEvictTotal = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictTotal))
 	return nil
 }
 
@@ -122,6 +123,7 @@ func autoConvert_api_DeschedulerPolicy_To_v1alpha2_DeschedulerPolicy(in *api.Des
 	out.NodeSelector = (*string)(unsafe.Pointer(in.NodeSelector))
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
+	out.MaxNoOfPodsToEvictTotal = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictTotal))
 	return nil
 }
 

--- a/pkg/api/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha2/zz_generated.deepcopy.go
@@ -51,6 +51,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.MaxNoOfPodsToEvictTotal != nil {
+		in, out := &in.MaxNoOfPodsToEvictTotal, &out.MaxNoOfPodsToEvictTotal
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -51,6 +51,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.MaxNoOfPodsToEvictTotal != nil {
+		in, out := &in.MaxNoOfPodsToEvictTotal, &out.MaxNoOfPodsToEvictTotal
+		*out = new(uint)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -102,6 +102,7 @@ func newDescheduler(rs *options.DeschedulerServer, deschedulerPolicy *api.Desche
 			WithPolicyGroupVersion(evictionPolicyGroupVersion).
 			WithMaxPodsToEvictPerNode(deschedulerPolicy.MaxNoOfPodsToEvictPerNode).
 			WithMaxPodsToEvictPerNamespace(deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace).
+			WithMaxPodsToEvictTotal(deschedulerPolicy.MaxNoOfPodsToEvictTotal).
 			WithDryRun(rs.DryRun).
 			WithMetricsEnabled(!rs.DisableMetrics),
 	)

--- a/pkg/descheduler/evictions/errors.go
+++ b/pkg/descheduler/evictions/errors.go
@@ -35,7 +35,7 @@ var _ error = &EvictionNamespaceLimitError{}
 type EvictionTotalLimitError struct{}
 
 func (e EvictionTotalLimitError) Error() string {
-	return "maximum number of evicted pods total reached"
+	return "maximum number of evicted pods per a descheduling cycle reached"
 }
 
 func NewEvictionTotalLimitError() *EvictionTotalLimitError {

--- a/pkg/descheduler/evictions/errors.go
+++ b/pkg/descheduler/evictions/errors.go
@@ -31,3 +31,15 @@ func NewEvictionNamespaceLimitError(namespace string) *EvictionNamespaceLimitErr
 }
 
 var _ error = &EvictionNamespaceLimitError{}
+
+type EvictionTotalLimitError struct{}
+
+func (e EvictionTotalLimitError) Error() string {
+	return "maximum number of evicted pods total reached"
+}
+
+func NewEvictionTotalLimitError() *EvictionTotalLimitError {
+	return &EvictionTotalLimitError{}
+}
+
+var _ error = &EvictionTotalLimitError{}

--- a/pkg/descheduler/evictions/options.go
+++ b/pkg/descheduler/evictions/options.go
@@ -9,6 +9,7 @@ type Options struct {
 	dryRun                     bool
 	maxPodsToEvictPerNode      *uint
 	maxPodsToEvictPerNamespace *uint
+	maxPodsToEvictTotal        *uint
 	metricsEnabled             bool
 }
 
@@ -36,6 +37,11 @@ func (o *Options) WithMaxPodsToEvictPerNode(maxPodsToEvictPerNode *uint) *Option
 
 func (o *Options) WithMaxPodsToEvictPerNamespace(maxPodsToEvictPerNamespace *uint) *Options {
 	o.maxPodsToEvictPerNamespace = maxPodsToEvictPerNamespace
+	return o
+}
+
+func (o *Options) WithMaxPodsToEvictTotal(maxPodsToEvictTotal *uint) *Options {
+	o.maxPodsToEvictTotal = maxPodsToEvictTotal
 	return o
 }
 

--- a/pkg/framework/plugins/nodeutilization/lownodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/lownodeutilization_test.go
@@ -979,11 +979,14 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 		},
 	}
 
+	var uint0, uint1 uint = 0, 1
 	tests := []struct {
-		name              string
-		nodes             []*v1.Node
-		pods              []*v1.Pod
-		evictionsExpected uint
+		name                  string
+		nodes                 []*v1.Node
+		pods                  []*v1.Pod
+		maxPodsToEvictPerNode *uint
+		maxPodsToEvictTotal   *uint
+		evictionsExpected     uint
 	}{
 		{
 			name:  "No taints",
@@ -1038,6 +1041,26 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n3withTaints.Name), 200, 0, n3withTaints.Name, test.SetRSOwnerRef),
 			},
 			evictionsExpected: 1,
+		},
+		{
+			name:  "Pod which tolerates node taint, set maxPodsToEvictTotal(0), should not be expelled",
+			nodes: []*v1.Node{n1, n3withTaints},
+			pods: []*v1.Pod{
+				// Node 1 pods
+				test.BuildTestPod(fmt.Sprintf("pod_1_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_2_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_3_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_4_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_5_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_6_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				test.BuildTestPod(fmt.Sprintf("pod_7_%s", n1.Name), 200, 0, n1.Name, test.SetRSOwnerRef),
+				podThatToleratesTaint,
+				// Node 3 pods
+				test.BuildTestPod(fmt.Sprintf("pod_9_%s", n3withTaints.Name), 200, 0, n3withTaints.Name, test.SetRSOwnerRef),
+			},
+			maxPodsToEvictPerNode: &uint1,
+			maxPodsToEvictTotal:   &uint0,
+			evictionsExpected:     0,
 		},
 	}
 

--- a/pkg/framework/plugins/podlifetime/pod_lifetime.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime.go
@@ -140,6 +140,8 @@ loop:
 		switch err.(type) {
 		case *evictions.EvictionNodeLimitError:
 			continue loop
+		case *evictions.EvictionTotalLimitError:
+			return nil
 		default:
 			klog.Errorf("eviction failed: %v", err)
 		}

--- a/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
@@ -156,6 +156,7 @@ func TestPodLifeTime(t *testing.T) {
 		ignorePvcPods              bool
 		maxPodsToEvictPerNode      *uint
 		maxPodsToEvictPerNamespace *uint
+		maxPodsToEvictTotal        *uint
 		applyPodsFunc              func(pods []*v1.Pod)
 	}{
 		{
@@ -312,6 +313,17 @@ func TestPodLifeTime(t *testing.T) {
 			pods:                       []*v1.Pod{p1, p2, p9},
 			nodes:                      []*v1.Node{node1},
 			maxPodsToEvictPerNamespace: utilptr.To[uint](1),
+			expectedEvictedPodCount:    1,
+		},
+		{
+			description: "1 Oldest pod should be evicted when maxPodsToEvictTotal is set to 1",
+			args: &PodLifeTimeArgs{
+				MaxPodLifeTimeSeconds: &maxLifeTime,
+			},
+			pods:                       []*v1.Pod{p1, p2, p9},
+			nodes:                      []*v1.Node{node1},
+			maxPodsToEvictPerNamespace: utilptr.To[uint](2),
+			maxPodsToEvictTotal:        utilptr.To[uint](1),
 			expectedEvictedPodCount:    1,
 		},
 		{
@@ -560,7 +572,8 @@ func TestPodLifeTime(t *testing.T) {
 				eventRecorder,
 				evictions.NewOptions().
 					WithMaxPodsToEvictPerNode(tc.maxPodsToEvictPerNode).
-					WithMaxPodsToEvictPerNamespace(tc.maxPodsToEvictPerNamespace),
+					WithMaxPodsToEvictPerNamespace(tc.maxPodsToEvictPerNamespace).
+					WithMaxPodsToEvictTotal(tc.maxPodsToEvictTotal),
 			)
 
 			defaultEvictorFilterArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/removeduplicates/removeduplicates.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates.go
@@ -217,6 +217,8 @@ func (r *RemoveDuplicates) Balance(ctx context.Context, nodes []*v1.Node) *frame
 					switch err.(type) {
 					case *evictions.EvictionNodeLimitError:
 						continue loop
+					case *evictions.EvictionTotalLimitError:
+						return nil
 					default:
 						klog.Errorf("eviction failed: %v", err)
 					}

--- a/pkg/framework/plugins/removefailedpods/failedpods.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods.go
@@ -111,6 +111,8 @@ func (d *RemoveFailedPods) Deschedule(ctx context.Context, nodes []*v1.Node) *fr
 			switch err.(type) {
 			case *evictions.EvictionNodeLimitError:
 				break loop
+			case *evictions.EvictionTotalLimitError:
+				return nil
 			default:
 				klog.Errorf("eviction failed: %v", err)
 			}

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
@@ -131,6 +131,8 @@ func (d *RemovePodsHavingTooManyRestarts) Deschedule(ctx context.Context, nodes 
 			switch err.(type) {
 			case *evictions.EvictionNodeLimitError:
 				break loop
+			case *evictions.EvictionTotalLimitError:
+				return nil
 			default:
 				klog.Errorf("eviction failed: %v", err)
 			}

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -112,6 +112,8 @@ loop:
 					switch err.(type) {
 					case *evictions.EvictionNodeLimitError:
 						continue loop
+					case *evictions.EvictionTotalLimitError:
+						return nil
 					default:
 						klog.Errorf("eviction failed: %v", err)
 					}

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
@@ -121,6 +121,7 @@ func TestPodAntiAffinity(t *testing.T) {
 		description                    string
 		maxPodsToEvictPerNode          *uint
 		maxNoOfPodsToEvictPerNamespace *uint
+		maxNoOfPodsToEvictTotal        *uint
 		pods                           []*v1.Pod
 		expectedEvictedPodCount        uint
 		nodeFit                        bool
@@ -145,6 +146,14 @@ func TestPodAntiAffinity(t *testing.T) {
 			pods:                           []*v1.Pod{p1, p2, p3, p4},
 			nodes:                          []*v1.Node{node1},
 			expectedEvictedPodCount:        3,
+		},
+		{
+			description:                    "Maximum pods to evict (maxNoOfPodsToEvictTotal)",
+			maxNoOfPodsToEvictPerNamespace: &uint3,
+			maxNoOfPodsToEvictTotal:        &uint1,
+			pods:                           []*v1.Pod{p1, p2, p3, p4},
+			nodes:                          []*v1.Node{node1},
+			expectedEvictedPodCount:        1,
 		},
 		{
 			description:             "Evict only 1 pod after sorting",
@@ -237,7 +246,8 @@ func TestPodAntiAffinity(t *testing.T) {
 				eventRecorder,
 				evictions.NewOptions().
 					WithMaxPodsToEvictPerNode(test.maxPodsToEvictPerNode).
-					WithMaxPodsToEvictPerNamespace(test.maxNoOfPodsToEvictPerNamespace),
+					WithMaxPodsToEvictPerNamespace(test.maxNoOfPodsToEvictPerNamespace).
+					WithMaxPodsToEvictTotal(test.maxNoOfPodsToEvictTotal),
 			)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
@@ -144,6 +144,8 @@ func (d *RemovePodsViolatingNodeAffinity) processNodes(ctx context.Context, node
 			switch err.(type) {
 			case *evictions.EvictionNodeLimitError:
 				break loop
+			case *evictions.EvictionTotalLimitError:
+				return nil
 			default:
 				klog.Errorf("eviction failed: %v", err)
 			}

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -129,6 +129,8 @@ func (d *RemovePodsViolatingNodeTaints) Deschedule(ctx context.Context, nodes []
 				switch err.(type) {
 				case *evictions.EvictionNodeLimitError:
 					break loop
+				case *evictions.EvictionTotalLimitError:
+					return nil
 				default:
 					klog.Errorf("eviction failed: %v", err)
 				}

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -242,6 +242,8 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) Balance(ctx context.Contex
 			switch err.(type) {
 			case *evictions.EvictionNodeLimitError:
 				nodeLimitExceeded[pod.Spec.NodeName] = true
+			case *evictions.EvictionTotalLimitError:
+				return nil
 			default:
 				klog.Errorf("eviction failed: %v", err)
 			}


### PR DESCRIPTION
The MaxNoOfPodsToEvictTotal serves to prevent scenarios where an unintended issue, such as a software bug or incorrect usage of Pod Disruption Budgets (PDBs), could result in a substantial number of pods being evicted simultaneously, potentially compromising the availability of services.

Fixes #1449