### PR TITLE
feat: pod evictor options

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -97,12 +97,13 @@ func newDescheduler(rs *options.DeschedulerServer, deschedulerPolicy *api.Desche
 
 	podEvictor := evictions.NewPodEvictor(
 		nil,
-		evictionPolicyGroupVersion,
-		rs.DryRun,
-		deschedulerPolicy.MaxNoOfPodsToEvictPerNode,
-		deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace,
-		!rs.DisableMetrics,
 		eventRecorder,
+		evictions.NewOptions().
+			WithPolicyGroupVersion(evictionPolicyGroupVersion).
+			WithMaxPodsToEvictPerNode(deschedulerPolicy.MaxNoOfPodsToEvictPerNode).
+			WithMaxPodsToEvictPerNamespace(deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace).
+			WithDryRun(rs.DryRun).
+			WithMetricsEnabled(!rs.DisableMetrics),
 	)
 
 	return &descheduler{

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -55,23 +55,23 @@ type PodEvictor struct {
 
 func NewPodEvictor(
 	client clientset.Interface,
-	policyGroupVersion string,
-	dryRun bool,
-	maxPodsToEvictPerNode *uint,
-	maxPodsToEvictPerNamespace *uint,
-	metricsEnabled bool,
 	eventRecorder events.EventRecorder,
+	options *Options,
 ) *PodEvictor {
+	if options == nil {
+		options = NewOptions()
+	}
+
 	return &PodEvictor{
 		client:                     client,
-		policyGroupVersion:         policyGroupVersion,
-		dryRun:                     dryRun,
-		maxPodsToEvictPerNode:      maxPodsToEvictPerNode,
-		maxPodsToEvictPerNamespace: maxPodsToEvictPerNamespace,
+		eventRecorder:              eventRecorder,
+		policyGroupVersion:         options.policyGroupVersion,
+		dryRun:                     options.dryRun,
+		maxPodsToEvictPerNode:      options.maxPodsToEvictPerNode,
+		maxPodsToEvictPerNamespace: options.maxPodsToEvictPerNamespace,
+		metricsEnabled:             options.metricsEnabled,
 		nodepodCount:               make(nodePodEvictedCount),
 		namespacePodCount:          make(namespacePodEvictCount),
-		metricsEnabled:             metricsEnabled,
-		eventRecorder:              eventRecorder,
 	}
 }
 

--- a/pkg/descheduler/evictions/evictions_test.go
+++ b/pkg/descheduler/evictions/evictions_test.go
@@ -126,12 +126,8 @@ func TestNewPodEvictor(t *testing.T) {
 
 	podEvictor := NewPodEvictor(
 		fakeClient,
-		"policy/v1",
-		false,
-		utilpointer.Uint(1),
-		nil,
-		false,
 		eventRecorder,
+		NewOptions().WithMaxPodsToEvictPerNode(utilpointer.Uint(1)),
 	)
 
 	stubNode := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node"}}

--- a/pkg/descheduler/evictions/options.go
+++ b/pkg/descheduler/evictions/options.go
@@ -1,0 +1,45 @@
+package evictions
+
+import (
+	policy "k8s.io/api/policy/v1"
+)
+
+type Options struct {
+	policyGroupVersion         string
+	dryRun                     bool
+	maxPodsToEvictPerNode      *uint
+	maxPodsToEvictPerNamespace *uint
+	metricsEnabled             bool
+}
+
+// NewOptions returns an Options with default values.
+func NewOptions() *Options {
+	return &Options{
+		policyGroupVersion: policy.SchemeGroupVersion.String(),
+	}
+}
+
+func (o *Options) WithPolicyGroupVersion(policyGroupVersion string) *Options {
+	o.policyGroupVersion = policyGroupVersion
+	return o
+}
+
+func (o *Options) WithDryRun(dryRun bool) *Options {
+	o.dryRun = dryRun
+	return o
+}
+
+func (o *Options) WithMaxPodsToEvictPerNode(maxPodsToEvictPerNode *uint) *Options {
+	o.maxPodsToEvictPerNode = maxPodsToEvictPerNode
+	return o
+}
+
+func (o *Options) WithMaxPodsToEvictPerNamespace(maxPodsToEvictPerNamespace *uint) *Options {
+	o.maxPodsToEvictPerNamespace = maxPodsToEvictPerNamespace
+	return o
+}
+
+func (o *Options) WithMetricsEnabled(metricsEnabled bool) *Options {
+	o.metricsEnabled = metricsEnabled
+	return o
+}

--- a/pkg/framework/plugins/nodeutilization/highnodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization_test.go
@@ -486,15 +486,7 @@ func TestHighNodeUtilization(t *testing.T) {
 
 			eventRecorder := &events.FakeRecorder{}
 
-			podEvictor := evictions.NewPodEvictor(
-				fakeClient,
-				"v1",
-				false,
-				nil,
-				nil,
-				false,
-				eventRecorder,
-			)
+			podEvictor := evictions.NewPodEvictor(fakeClient, eventRecorder, nil)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods:   false,
@@ -639,12 +631,8 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
-				"policy/v1",
-				false,
-				&item.evictionsExpected,
-				nil,
-				false,
 				eventRecorder,
+				evictions.NewOptions().WithMaxPodsToEvictPerNode(&item.evictionsExpected),
 			)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -558,12 +557,10 @@ func TestPodLifeTime(t *testing.T) {
 
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
-				policyv1.SchemeGroupVersion.String(),
-				false,
-				tc.maxPodsToEvictPerNode,
-				tc.maxPodsToEvictPerNamespace,
-				false,
 				eventRecorder,
+				evictions.NewOptions().
+					WithMaxPodsToEvictPerNode(tc.maxPodsToEvictPerNode).
+					WithMaxPodsToEvictPerNamespace(tc.maxPodsToEvictPerNamespace),
 			)
 
 			defaultEvictorFilterArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
@@ -26,7 +26,6 @@ import (
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -313,15 +312,7 @@ func TestFindDuplicatePods(t *testing.T) {
 
 			eventRecorder := &events.FakeRecorder{}
 
-			podEvictor := evictions.NewPodEvictor(
-				fakeClient,
-				"v1",
-				false,
-				nil,
-				nil,
-				false,
-				eventRecorder,
-			)
+			podEvictor := evictions.NewPodEvictor(fakeClient, eventRecorder, nil)
 
 			nodeFit := testCase.nodefit
 
@@ -761,15 +752,7 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 
 			eventRecorder := &events.FakeRecorder{}
 
-			podEvictor := evictions.NewPodEvictor(
-				fakeClient,
-				policyv1.SchemeGroupVersion.String(),
-				false,
-				nil,
-				nil,
-				false,
-				eventRecorder,
-			)
+			podEvictor := evictions.NewPodEvictor(fakeClient, eventRecorder, nil)
 
 			defaultEvictorFilterArgs := &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods:   false,

--- a/pkg/framework/plugins/removefailedpods/failedpods_test.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -375,15 +374,7 @@ func TestRemoveFailedPods(t *testing.T) {
 
 			eventRecorder := &events.FakeRecorder{}
 
-			podEvictor := evictions.NewPodEvictor(
-				fakeClient,
-				policyv1.SchemeGroupVersion.String(),
-				false,
-				nil,
-				nil,
-				false,
-				eventRecorder,
-			)
+			podEvictor := evictions.NewPodEvictor(fakeClient, eventRecorder, nil)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods:   false,

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts_test.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -346,12 +345,10 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
-				policyv1.SchemeGroupVersion.String(),
-				false,
-				tc.maxPodsToEvictPerNode,
-				tc.maxNoOfPodsToEvictPerNamespace,
-				false,
 				eventRecorder,
+				evictions.NewOptions().
+					WithMaxPodsToEvictPerNode(tc.maxPodsToEvictPerNode).
+					WithMaxPodsToEvictPerNamespace(tc.maxNoOfPodsToEvictPerNamespace),
 			)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -235,12 +234,10 @@ func TestPodAntiAffinity(t *testing.T) {
 
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
-				policyv1.SchemeGroupVersion.String(),
-				false,
-				test.maxPodsToEvictPerNode,
-				test.maxNoOfPodsToEvictPerNamespace,
-				false,
 				eventRecorder,
+				evictions.NewOptions().
+					WithMaxPodsToEvictPerNode(test.maxPodsToEvictPerNode).
+					WithMaxPodsToEvictPerNamespace(test.maxNoOfPodsToEvictPerNamespace),
 			)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -361,12 +360,10 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
-				policyv1.SchemeGroupVersion.String(),
-				false,
-				tc.maxPodsToEvictPerNode,
-				tc.maxNoOfPodsToEvictPerNamespace,
-				false,
 				eventRecorder,
+				evictions.NewOptions().
+					WithMaxPodsToEvictPerNode(tc.maxPodsToEvictPerNode).
+					WithMaxPodsToEvictPerNamespace(tc.maxNoOfPodsToEvictPerNamespace),
 			)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
@@ -406,12 +405,10 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 
 			podEvictor := evictions.NewPodEvictor(
 				fakeClient,
-				policyv1.SchemeGroupVersion.String(),
-				false,
-				tc.maxPodsToEvictPerNode,
-				tc.maxNoOfPodsToEvictPerNamespace,
-				false,
 				eventRecorder,
+				evictions.NewOptions().
+					WithMaxPodsToEvictPerNode(tc.maxPodsToEvictPerNode).
+					WithMaxPodsToEvictPerNamespace(tc.maxNoOfPodsToEvictPerNamespace),
 			)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1456,15 +1456,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 
 			eventRecorder := &events.FakeRecorder{}
 
-			podEvictor := evictions.NewPodEvictor(
-				fakeClient,
-				"v1",
-				false,
-				nil,
-				nil,
-				false,
-				eventRecorder,
-			)
+			podEvictor := evictions.NewPodEvictor(fakeClient, eventRecorder, nil)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods:   false,

--- a/pkg/framework/profile/profile_test.go
+++ b/pkg/framework/profile/profile_test.go
@@ -244,7 +244,7 @@ func TestProfileDescheduleBalanceExtensionPointsEviction(t *testing.T) {
 			eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, eventClient)
 			defer eventBroadcaster.Shutdown()
 
-			podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, true, eventRecorder)
+			podEvictor := evictions.NewPodEvictor(client, eventRecorder, nil)
 
 			prfl, err := NewProfile(
 				test.config,
@@ -392,7 +392,7 @@ func TestProfileExtensionPoints(t *testing.T) {
 	eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, eventClient)
 	defer eventBroadcaster.Shutdown()
 
-	podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, true, eventRecorder)
+	podEvictor := evictions.NewPodEvictor(client, eventRecorder, nil)
 
 	prfl, err := NewProfile(
 		api.DeschedulerProfile{
@@ -604,7 +604,7 @@ func TestProfileExtensionPointOrdering(t *testing.T) {
 	eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, eventClient)
 	defer eventBroadcaster.Shutdown()
 
-	podEvictor := evictions.NewPodEvictor(client, "policy/v1", false, nil, nil, true, eventRecorder)
+	podEvictor := evictions.NewPodEvictor(client, eventRecorder, nil)
 
 	prfl, err := NewProfile(
 		api.DeschedulerProfile{

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -171,15 +171,7 @@ func TestRemoveDuplicates(t *testing.T) {
 
 			eventRecorder := &events.FakeRecorder{}
 
-			podEvictor := evictions.NewPodEvictor(
-				clientSet,
-				evictionPolicyGroupVersion,
-				false,
-				nil,
-				nil,
-				false,
-				eventRecorder,
-			)
+			podEvictor := evictions.NewPodEvictor(clientSet, eventRecorder, nil)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods:   true,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -192,12 +192,10 @@ func runPodLifetimePlugin(
 
 	podEvictor := evictions.NewPodEvictor(
 		clientset,
-		evictionPolicyGroupVersion,
-		false,
-		nil,
-		maxPodsToEvictPerNamespace,
-		false,
 		&events.FakeRecorder{},
+		evictions.NewOptions().
+			WithPolicyGroupVersion(evictionPolicyGroupVersion).
+			WithMaxPodsToEvictPerNamespace(maxPodsToEvictPerNamespace),
 	)
 
 	var thresholdPriority int32
@@ -1579,11 +1577,7 @@ func initPodEvictorOrFail(t *testing.T, clientSet clientset.Interface, getPodsAs
 
 	return evictions.NewPodEvictor(
 		clientSet,
-		evictionPolicyGroupVersion,
-		false,
-		nil,
-		nil,
-		false,
 		eventRecorder,
+		evictions.NewOptions().WithPolicyGroupVersion(evictionPolicyGroupVersion),
 	)
 }

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -163,12 +163,8 @@ func TestTooManyRestarts(t *testing.T) {
 
 			podEvictor := evictions.NewPodEvictor(
 				clientSet,
-				evictionPolicyGroupVersion,
-				false,
-				nil,
-				nil,
-				false,
 				eventRecorder,
+				evictions.NewOptions().WithPolicyGroupVersion(evictionPolicyGroupVersion),
 			)
 
 			defaultevictorArgs := &defaultevictor.DefaultEvictorArgs{


### PR DESCRIPTION
when we add a new option to PodEvictor, it typically ends up touch dozens of files because it requires adding a new arg to the initializer. this is the first step in reducing the number of initializer args