### PR TITLE
Update README about maxNoOfPodsToEvictTotal

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ These are top level keys in the Descheduler Policy that you can use to configure
 | `nodeSelector` |`string`| `nil` | limiting the nodes which are processed. Only used when `nodeFit`=`true` and only by the PreEvictionFilter Extension Point |
 | `maxNoOfPodsToEvictPerNode` |`int`| `nil` | maximum number of pods evicted from each node (summed through all strategies) |
 | `maxNoOfPodsToEvictPerNamespace` |`int`| `nil` | maximum number of pods evicted from each namespace (summed through all strategies) |
+| `maxNoOfPodsToEvictTotal` |`int`| `nil` | maximum number of pods evicted per rescheduling cycle (summed through all strategies) |
 
 ### Evictor Plugin configuration (Default Evictor)
 
@@ -159,6 +160,7 @@ kind: "DeschedulerPolicy"
 nodeSelector: "node=node1" # you don't need to set this, if not set all will be processed
 maxNoOfPodsToEvictPerNode: 5000 # you don't need to set this, unlimited if not set
 maxNoOfPodsToEvictPerNamespace: 5000 # you don't need to set this, unlimited if not set
+maxNoOfPodsToEvictTotal: 5000 # you don't need to set this, unlimited if not set
 profiles:
   - name: ProfileName
     pluginConfig:


### PR DESCRIPTION
Update README.md to include information about maxNoOfPodsToEvictTotal.  
see: https://github.com/kubernetes-sigs/descheduler/issues/1449