### PR TITLE
helm unit tests

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -42,6 +42,14 @@ jobs:
         with:
           version: v3.7.0
 
+      - name: Install Helm Unit Test Plugin
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest
+
+      - name: Run Helm Unit Tests
+        run: |
+          helm unittest charts/descheduler --strict -d
+
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |

--- a/charts/descheduler/tests/.gitignore
+++ b/charts/descheduler/tests/.gitignore
@@ -1,0 +1,1 @@
+__snapshot__

--- a/charts/descheduler/tests/cronjob_test.yaml
+++ b/charts/descheduler/tests/cronjob_test.yaml
@@ -1,0 +1,17 @@
+suite: Test Descheduler CronJob
+
+templates:
+  - "*.yaml"
+
+release:
+  name: descheduler
+
+set:
+  kind: CronJob
+
+tests:
+  - it: creates CronJob when kind is set
+    template: templates/cronjob.yaml
+    asserts:
+      - isKind:
+          of: CronJob

--- a/charts/descheduler/tests/deployment_test.yaml
+++ b/charts/descheduler/tests/deployment_test.yaml
@@ -1,0 +1,49 @@
+suite: Test Descheduler Deployment
+
+templates:
+  - "*.yaml"
+
+release:
+  name: descheduler
+
+set:
+  kind: Deployment
+
+tests:
+  - it: creates Deployment when kind is set
+    template: templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+  
+  - it: enables leader-election
+    set:
+      leaderElection:
+        enabled: true
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect=true
+
+  - it: support leader-election resourceNamespace
+    set:
+      leaderElection:
+        enabled: true
+        resourceNamespace: test
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-resource-namespace=test
+
+  - it: support legacy leader-election resourceNamescape
+    set:
+      leaderElection:
+        enabled: true
+        resourceNamescape: typo
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --leader-elect-resource-namespace=typo


### PR DESCRIPTION
there's been a few issues recently raised about helm chart not working after releases.

this PR proposes a unit test harness and if approved, I can contribute more unit tests


Output: https://github.com/kubernetes-sigs/descheduler/actions/runs/9944911041/job/27471971492?pr=1467
```
 PASS  Test Descheduler Deployment	charts/descheduler/tests/deployment_test.yaml
Charts:      1 passed, 1 total
Test Suites: 2 passed, 2 total
Tests:       5 passed, 5 total
Snapshot:    0 passed, 0 total
Time:        27.609379ms
```