### PR TITLE
bump(github.com/golangci/golangci-lint)=v1.59.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ARCHS = amd64 arm arm64
 
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitbranch=${BRANCH} -X ${LDFLAG_LOCATION}.gitsha1=${SHA1}"
 
-GOLANGCI_VERSION := v1.58.1
+GOLANGCI_VERSION := v1.59.1
 HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint 2> /dev/null)
 
 GOFUMPT_VERSION := v0.4.0


### PR DESCRIPTION
Get the latest to see if it helps with the timeouts