### PR TITLE
bump go to 1.22.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.22.4
+FROM golang:1.22.5
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/descheduler
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
This will address [GO-2024-2887 ](https://pkg.go.dev/vuln/GO-2024-2887 ) and [GO-2024-2963](https://pkg.go.dev/vuln/GO-2024-2963).