### PR TITLE
docs: Provide OCI annotation for where to find image sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ FROM scratch
 
 MAINTAINER Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>
 
+LABEL org.opencontainers.image.source https://github.com/kubernetes-sigs/descheduler
+
 USER 1000
 
 COPY --from=0 /go/src/sigs.k8s.io/descheduler/_output/bin/descheduler /bin/descheduler


### PR DESCRIPTION
Add a label for the OCI annotation for image source, as per https://github.com/opencontainers/image-spec/blob/main/annotations.md

This can allow for tools such as "[renovatebot](https://docs.renovatebot.com/modules/datasource/docker/)" to find the source code for a container image via its manifest, and with that, finding changelogs to publish in automated PRs for dependency updates ([example](https://github.com/renovate-reproductions/26286/pull/1)).