### PR TITLE
Plugin args: tag arguments with omitempty to reduce the marshalled json size

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -46,8 +46,8 @@ type DeschedulerPolicy struct {
 // Namespaces carries a list of included/excluded namespaces
 // for which a given strategy is applicable
 type Namespaces struct {
-	Include []string `json:"include"`
-	Exclude []string `json:"exclude"`
+	Include []string `json:"include,omitempty"`
+	Exclude []string `json:"exclude,omitempty"`
 }
 
 type (

--- a/pkg/framework/plugins/defaultevictor/types.go
+++ b/pkg/framework/plugins/defaultevictor/types.go
@@ -25,15 +25,15 @@ import (
 type DefaultEvictorArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	NodeSelector            string                 `json:"nodeSelector"`
-	EvictLocalStoragePods   bool                   `json:"evictLocalStoragePods"`
-	EvictDaemonSetPods      bool                   `json:"evictDaemonSetPods"`
-	EvictSystemCriticalPods bool                   `json:"evictSystemCriticalPods"`
-	IgnorePvcPods           bool                   `json:"ignorePvcPods"`
-	EvictFailedBarePods     bool                   `json:"evictFailedBarePods"`
-	LabelSelector           *metav1.LabelSelector  `json:"labelSelector"`
-	PriorityThreshold       *api.PriorityThreshold `json:"priorityThreshold"`
-	NodeFit                 bool                   `json:"nodeFit"`
-	MinReplicas             uint                   `json:"minReplicas"`
-	MinPodAge               *metav1.Duration       `json:"minPodAge"`
+	NodeSelector            string                 `json:"nodeSelector,omitempty"`
+	EvictLocalStoragePods   bool                   `json:"evictLocalStoragePods,omitempty"`
+	EvictDaemonSetPods      bool                   `json:"evictDaemonSetPods,omitempty"`
+	EvictSystemCriticalPods bool                   `json:"evictSystemCriticalPods,omitempty"`
+	IgnorePvcPods           bool                   `json:"ignorePvcPods,omitempty"`
+	EvictFailedBarePods     bool                   `json:"evictFailedBarePods,omitempty"`
+	LabelSelector           *metav1.LabelSelector  `json:"labelSelector,omitempty"`
+	PriorityThreshold       *api.PriorityThreshold `json:"priorityThreshold,omitempty"`
+	NodeFit                 bool                   `json:"nodeFit,omitempty"`
+	MinReplicas             uint                   `json:"minReplicas,omitempty"`
+	MinPodAge               *metav1.Duration       `json:"minPodAge,omitempty"`
 }

--- a/pkg/framework/plugins/nodeutilization/types.go
+++ b/pkg/framework/plugins/nodeutilization/types.go
@@ -24,15 +24,15 @@ import (
 type LowNodeUtilizationArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	UseDeviationThresholds bool                   `json:"useDeviationThresholds"`
+	UseDeviationThresholds bool                   `json:"useDeviationThresholds,omitempty"`
 	Thresholds             api.ResourceThresholds `json:"thresholds"`
 	TargetThresholds       api.ResourceThresholds `json:"targetThresholds"`
-	NumberOfNodes          int                    `json:"numberOfNodes"`
+	NumberOfNodes          int                    `json:"numberOfNodes,omitempty"`
 
 	// Naming this one differently since namespaces are still
 	// considered while considering resources used by pods
 	// but then filtered out before eviction
-	EvictableNamespaces *api.Namespaces `json:"evictableNamespaces"`
+	EvictableNamespaces *api.Namespaces `json:"evictableNamespaces,omitempty"`
 }
 
 // +k8s:deepcopy-gen=true
@@ -42,9 +42,9 @@ type HighNodeUtilizationArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
 	Thresholds    api.ResourceThresholds `json:"thresholds"`
-	NumberOfNodes int                    `json:"numberOfNodes"`
+	NumberOfNodes int                    `json:"numberOfNodes,omitempty"`
 	// Naming this one differently since namespaces are still
 	// considered while considering resources used by pods
 	// but then filtered out before eviction
-	EvictableNamespaces *api.Namespaces `json:"evictableNamespaces"`
+	EvictableNamespaces *api.Namespaces `json:"evictableNamespaces,omitempty"`
 }

--- a/pkg/framework/plugins/podlifetime/types.go
+++ b/pkg/framework/plugins/podlifetime/types.go
@@ -25,10 +25,10 @@ import (
 type PodLifeTimeArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces                   *api.Namespaces       `json:"namespaces"`
-	LabelSelector                *metav1.LabelSelector `json:"labelSelector"`
-	MaxPodLifeTimeSeconds        *uint                 `json:"maxPodLifeTimeSeconds"`
-	States                       []string              `json:"states"`
-	IncludingInitContainers      bool                  `json:"includingInitContainers"`
-	IncludingEphemeralContainers bool                  `json:"includingEphemeralContainers"`
+	Namespaces                   *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector                *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	MaxPodLifeTimeSeconds        *uint                 `json:"maxPodLifeTimeSeconds,omitempty"`
+	States                       []string              `json:"states,omitempty"`
+	IncludingInitContainers      bool                  `json:"includingInitContainers,omitempty"`
+	IncludingEphemeralContainers bool                  `json:"includingEphemeralContainers,omitempty"`
 }

--- a/pkg/framework/plugins/removeduplicates/types.go
+++ b/pkg/framework/plugins/removeduplicates/types.go
@@ -24,6 +24,6 @@ import (
 type RemoveDuplicatesArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces        *api.Namespaces `json:"namespaces"`
-	ExcludeOwnerKinds []string        `json:"excludeOwnerKinds"`
+	Namespaces        *api.Namespaces `json:"namespaces,omitempty"`
+	ExcludeOwnerKinds []string        `json:"excludeOwnerKinds,omitempty"`
 }

--- a/pkg/framework/plugins/removefailedpods/types.go
+++ b/pkg/framework/plugins/removefailedpods/types.go
@@ -25,11 +25,11 @@ import (
 type RemoveFailedPodsArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces              *api.Namespaces       `json:"namespaces"`
-	LabelSelector           *metav1.LabelSelector `json:"labelSelector"`
-	ExcludeOwnerKinds       []string              `json:"excludeOwnerKinds"`
-	MinPodLifetimeSeconds   *uint                 `json:"minPodLifetimeSeconds"`
-	Reasons                 []string              `json:"reasons"`
-	ExitCodes               []int32               `json:"exitCodes"`
-	IncludingInitContainers bool                  `json:"includingInitContainers"`
+	Namespaces              *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector           *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	ExcludeOwnerKinds       []string              `json:"excludeOwnerKinds,omitempty"`
+	MinPodLifetimeSeconds   *uint                 `json:"minPodLifetimeSeconds,omitempty"`
+	Reasons                 []string              `json:"reasons,omitempty"`
+	ExitCodes               []int32               `json:"exitCodes,omitempty"`
+	IncludingInitContainers bool                  `json:"includingInitContainers,omitempty"`
 }

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/types.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/types.go
@@ -25,9 +25,9 @@ import (
 type RemovePodsHavingTooManyRestartsArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces              *api.Namespaces       `json:"namespaces"`
-	LabelSelector           *metav1.LabelSelector `json:"labelSelector"`
-	PodRestartThreshold     int32                 `json:"podRestartThreshold"`
-	IncludingInitContainers bool                  `json:"includingInitContainers"`
-	States                  []string              `json:"states"`
+	Namespaces              *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector           *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	PodRestartThreshold     int32                 `json:"podRestartThreshold,omitempty"`
+	IncludingInitContainers bool                  `json:"includingInitContainers,omitempty"`
+	States                  []string              `json:"states,omitempty"`
 }

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/types.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/types.go
@@ -28,6 +28,6 @@ import (
 type RemovePodsViolatingInterPodAntiAffinityArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces    *api.Namespaces       `json:"namespaces"`
-	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
+	Namespaces    *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty"`
 }

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/types.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/types.go
@@ -28,7 +28,7 @@ import (
 type RemovePodsViolatingNodeAffinityArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces       *api.Namespaces       `json:"namespaces"`
-	LabelSelector    *metav1.LabelSelector `json:"labelSelector"`
-	NodeAffinityType []string              `json:"nodeAffinityType"`
+	Namespaces       *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector    *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	NodeAffinityType []string              `json:"nodeAffinityType,omitempty"`
 }

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/types.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/types.go
@@ -28,9 +28,9 @@ import (
 type RemovePodsViolatingNodeTaintsArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces              *api.Namespaces       `json:"namespaces"`
-	LabelSelector           *metav1.LabelSelector `json:"labelSelector"`
-	IncludePreferNoSchedule bool                  `json:"includePreferNoSchedule"`
-	ExcludedTaints          []string              `json:"excludedTaints"`
-	IncludedTaints          []string              `json:"includedTaints"`
+	Namespaces              *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector           *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	IncludePreferNoSchedule bool                  `json:"includePreferNoSchedule,omitempty"`
+	ExcludedTaints          []string              `json:"excludedTaints,omitempty"`
+	IncludedTaints          []string              `json:"includedTaints,omitempty"`
 }

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
@@ -29,8 +29,8 @@ import (
 type RemovePodsViolatingTopologySpreadConstraintArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces             *api.Namespaces                    `json:"namespaces"`
-	LabelSelector          *metav1.LabelSelector              `json:"labelSelector"`
-	Constraints            []v1.UnsatisfiableConstraintAction `json:"constraints"`
-	TopologyBalanceNodeFit *bool                              `json:"topologyBalanceNodeFit"`
+	Namespaces             *api.Namespaces                    `json:"namespaces,omitempty"`
+	LabelSelector          *metav1.LabelSelector              `json:"labelSelector,omitempty"`
+	Constraints            []v1.UnsatisfiableConstraintAction `json:"constraints,omitempty"`
+	TopologyBalanceNodeFit *bool                              `json:"topologyBalanceNodeFit,omitempty"`
 }


### PR DESCRIPTION
```yaml
- args:
    namespaces:
      include:
      - includedNamespace
```
looks better than
```yaml
- args:
    excludedTaints: null
    includePreferNoSchedule: false
    includedTaints: null
    labelSelector: null
    namespaces:
      exclude: []
      include:
      - includedNamespace
```