### PR TITLE
deprecate descheduler custom flag of http-enabled

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -56,6 +56,7 @@ func NewDeschedulerServer() (*DeschedulerServer, error) {
 
 	secureServing := apiserveroptions.NewSecureServingOptions().WithLoopback()
 	secureServing.BindPort = DefaultDeschedulerPort
+	secureServing.DisableHTTP2Serving = true
 
 	return &DeschedulerServer{
 		DeschedulerConfiguration: *cfg,
@@ -101,7 +102,7 @@ func (rs *DeschedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&rs.Tracing.ServiceNamespace, "otel-trace-namespace", "", "OTEL Trace namespace to be used with the resources")
 	fs.Float64Var(&rs.Tracing.SampleRate, "otel-sample-rate", 1.0, "Sample rate to collect the Traces")
 	fs.BoolVar(&rs.Tracing.FallbackToNoOpProviderOnError, "otel-fallback-no-op-on-error", false, "Fallback to NoOp Tracer in case of error")
-	fs.BoolVar(&rs.EnableHTTP2, "enable-http2", false, "If http/2 should be enabled for the metrics and health check")
+	fs.BoolVar(&rs.EnableHTTP2, "enable-http2", false, "Deprecated: use disable-http2-serving instead. If http/2 should be enabled for the metrics and health check")
 
 	componentbaseoptions.BindLeaderElectionFlags(&rs.LeaderElection, fs)
 

--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -75,7 +75,9 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 				return err
 			}
 
-			secureServing.DisableHTTP2 = !s.EnableHTTP2
+			if cmd.Flag("enable-http2").Changed {
+				secureServing.DisableHTTP2 = !s.EnableHTTP2
+			}
 
 			ctx, done := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 

--- a/docs/cli/descheduler.md
+++ b/docs/cli/descheduler.md
@@ -19,10 +19,10 @@ descheduler [flags]
       --client-connection-kubeconfig string      File path to kube configuration for interacting with kubernetes apiserver.
       --client-connection-qps float32            QPS to use for interacting with kubernetes apiserver.
       --descheduling-interval duration           Time interval between two consecutive descheduler executions. Setting this value instructs the descheduler to run in a continuous loop at the interval specified.
-      --disable-http2-serving                    If true, HTTP2 serving will be disabled [default=false]
+      --disable-http2-serving                    If true, HTTP2 serving will be disabled [default=false] (default true)
       --disable-metrics                          Disables metrics. The metrics are by default served through https://localhost:10258/metrics. Secure address, resp. port can be changed through --bind-address, resp. --secure-port flags.
       --dry-run                                  Execute descheduler in dry run mode.
-      --enable-http2                             If http/2 should be enabled for the metrics and health check
+      --enable-http2                             Deprecated: use disable-http2-serving instead. If http/2 should be enabled for the metrics and health check
   -h, --help                                     help for descheduler
       --http2-max-streams-per-connection int     The limit that the server gives to clients for the maximum number of streams in an HTTP/2 connection. Zero means to use golang's default.
       --kubeconfig string                        File with kube configuration. Deprecated, use client-connection-kubeconfig instead.


### PR DESCRIPTION
Follow up to https://github.com/kubernetes-sigs/descheduler/pull/1496#issuecomment-2291531874

cc: @jklaw90  and @ingvagabund 