### PR TITLE
descheduler v0.31: update e2e test versions

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        k8s-version: ["v1.30.0"]
+        k8s-version: ["v1.31.0"]
         descheduler-version: ["v0.30.0"]
         descheduler-api: ["v1alpha2"]
         manifest: ["deployment"]

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ ARCHS = amd64 arm arm64
 
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitbranch=${BRANCH} -X ${LDFLAG_LOCATION}.gitsha1=${SHA1}"
 
-GOLANGCI_VERSION := v1.59.1
+GOLANGCI_VERSION := v1.60.3
 HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint 2> /dev/null)
 
-GOFUMPT_VERSION := v0.4.0
+GOFUMPT_VERSION := v0.7.0
 HAS_GOFUMPT := $(shell command -v gofumpt 2> /dev/null)
 
 GO_VERSION := $(shell (command -v jq > /dev/null && (go mod edit -json | jq -r .Go)) || (sed -En 's/^go (.*)$$/\1/p' go.mod))

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -34,9 +34,9 @@ echo "DESCHEDULER_IMAGE: ${DESCHEDULER_IMAGE}"
 if [ -n "$KIND_E2E" ]; then
     # If we did not set SKIP_INSTALL
     if [ -z "$SKIP_INSTALL" ]; then
-        K8S_VERSION=${KUBERNETES_VERSION:-v1.30.0}
+        K8S_VERSION=${KUBERNETES_VERSION:-v1.31.0}
         curl -Lo kubectl https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
-        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.20.0/kind-linux-amd64
+        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-linux-amd64
         chmod +x kind-linux-amd64
         mv kind-linux-amd64 kind
         export PATH=$PATH:$PWD


### PR DESCRIPTION
Prep for v0.31 release

similar to https://github.com/kubernetes-sigs/descheduler/commit/ac4d576df8831c0c399ee8fff1e85469e90b8c44