### PR TITLE
feat(helm): make securityContext conditional in Deployment and CronJob

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -91,8 +91,10 @@ spec:
                 {{- toYaml .Values.livenessProbe | nindent 16 }}
               resources:
                 {{- toYaml .Values.resources | nindent 16 }}
+              {{- if .Values.securityContext }}
               securityContext:
                 {{- toYaml .Values.securityContext | nindent 16 }}
+              {{- end }}
               volumeMounts:
                 - mountPath: /policy-dir
                   name: policy-volume

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -67,8 +67,10 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.securityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume


### PR DESCRIPTION
This adds a conditional around `securityContext` in Deployment and CronJob template in order to be able to unset this property. In the same way `podSecurityContext` is handled.