### PR TITLE
[e2e] no test timeouts, produce the same image tag as in production

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -54,4 +54,4 @@ fi
 kubectl apply -f kubernetes/base/rbac.yaml
 
 PRJ_PREFIX="sigs.k8s.io/descheduler"
-go test ${PRJ_PREFIX}/test/e2e/ -v
+go test ${PRJ_PREFIX}/test/e2e/ -v -timeout 0

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -23,7 +23,7 @@ SKIP_INSTALL=${SKIP_INSTALL:-}
 KIND_E2E=${KIND_E2E:-}
 
 # Build a descheduler image
-IMAGE_TAG=$(git describe --tags --match v0*)
+IMAGE_TAG=v$(date +%Y%m%d)-$(git describe --tags)
 BASEDIR=$(dirname "$0")
 VERSION="${IMAGE_TAG}" make -C ${BASEDIR}/.. image
 


### PR DESCRIPTION
1、Avoid e2e test timeout, after migrating all e2e tests to containers, the execution time may increase, and e2e tests might time out；
2、Modify IMAGE_TAG to fix the version parsing issue;