### PR TITLE
chore: add required service when serviceMonitor is enabled

### DIFF
--- a/charts/descheduler/templates/service.yaml
+++ b/charts/descheduler/templates/service.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.kind "Deployment" }}
-{{- if eq .Values.service.enabled true }}
+{{- if or .Values.service.enabled .Values.serviceMonitor.enabled }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
Currently when enabling serviceMonitor the service isn't automatically enabled, and you have to explicitly enable the service in order for the serviceMonitor to work. 

I think it would be nice to add the service when you enable serviceMonitor. Especially since the serviceMonitor don't work when you don't have a service.