### PR TITLE
descheduler v0.31.0: bump kustomize files

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         k8s-version: ["v1.31.0"]
-        descheduler-version: ["v0.30.0"]
+        descheduler-version: ["v0.31.0"]
         descheduler-api: ["v1alpha2"]
         manifest: ["deployment"]
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -93,17 +93,17 @@ See the [resources | Kustomize](https://kubectl.docs.kubernetes.io/references/ku
 
 Run As A Job
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=v0.31.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/job?ref=release-1.31' | kubectl apply -f -
 ```
 
 Run As A CronJob
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=v0.31.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/cronjob?ref=release-1.31' | kubectl apply -f -
 ```
 
 Run As A Deployment
 ```
-kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=v0.31.0' | kubectl apply -f -
+kustomize build 'github.com/kubernetes-sigs/descheduler/kubernetes/deployment?ref=release-1.31' | kubectl apply -f -
 ```
 
 ## User Guide

--- a/kubernetes/cronjob/cronjob.yaml
+++ b/kubernetes/cronjob/cronjob.yaml
@@ -16,7 +16,7 @@ spec:
           priorityClassName: system-cluster-critical
           containers:
           - name: descheduler
-            image: registry.k8s.io/descheduler/descheduler:v0.30.1
+            image: registry.k8s.io/descheduler/descheduler:v0.31.0
             volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: descheduler-sa
       containers:
         - name: descheduler
-          image: registry.k8s.io/descheduler/descheduler:v0.30.1
+          image: registry.k8s.io/descheduler/descheduler:v0.31.0
           imagePullPolicy: IfNotPresent
           command:
             - "/bin/descheduler"

--- a/kubernetes/job/job.yaml
+++ b/kubernetes/job/job.yaml
@@ -14,7 +14,7 @@ spec:
       priorityClassName: system-cluster-critical
       containers:
         - name: descheduler
-          image: registry.k8s.io/descheduler/descheduler:v0.30.1
+          image: registry.k8s.io/descheduler/descheduler:v0.31.0
           volumeMounts:
           - mountPath: /policy-dir
             name: policy-volume


### PR DESCRIPTION
Note that we can no longer reference tags, because tag is used to create the image and kustomize manifests are out of date on the tag (chicken-egg issue)