### PR TITLE
fix: github action Release Charts to have write permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - release-*
 
+permissions:
+  contents: write # allow actions to update gh-pages branch
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/kubernetes-sigs/descheduler/actions/runs/10781069567/job/29898293792

see related issue: https://github.com/helm/chart-releaser-action/issues/110

```
Looking up latest tag...
Discovering changed charts since 'v0.31.0'...
Installing chart-releaser on /opt/hostedtoolcache/cr/v1.6.1/x86_64...
Adding cr directory to PATH...
Packaging chart 'charts/descheduler'...
Successfully packaged chart in /home/runner/work/descheduler/descheduler/charts/descheduler and saved it to: .cr-release-packages/descheduler-0.31.0.tgz
Releasing charts...
Error: error creating GitHub release descheduler-helm-chart-0.31.0: POST https://api.github.com/repos/kubernetes-sigs/descheduler/releases: 403 Resource not accessible by integration []
Usage:
  cr upload [flags]

Flags:
  -c, --commit string                  Target commit for release
      --generate-release-notes         Whether to automatically generate the name and body for this release. See https://docs.github.com/en/rest/releases/releases
  -b, --git-base-url string            GitHub Base URL (only needed for private GitHub) (default "https://api.github.com/")
  -r, --git-repo string                GitHub repository
  -u, --git-upload-url string          GitHub Upload URL (only needed for private GitHub) (default "https://uploads.github.com/")
  -h, --help                           help for upload
      --make-release-latest            Mark the created GitHub release as 'latest' (default true)
  -o, --owner string                   GitHub username or organization
  -p, --package-path string            Path to directory with chart packages (default ".cr-release-packages")
      --packages-with-index            Host the package files in the GitHub Pages branch
      --pages-branch string            The GitHub pages branch (default "gh-pages")
      --pr                             Create a pull request for the chart package against the GitHub Pages branch (must not be set if --push is set)
      --push                           Push the chart package to the GitHub Pages branch (must not be set if --pr is set)
      --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
      --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead. The file is read from the chart package
      --remote string                  The Git remote used when creating a local worktree for the GitHub Pages branch (default "origin")
      --skip-existing                  Skip upload if release exists
  -t, --token string                   GitHub Auth Token

Global Flags:
      --config string   Config file (default is $HOME/.cr.yaml)

Error: Process completed with exit code 1.
```