### PR TITLE
Automated cherry pick of #1514: fix: github action Release Charts to have write permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - release-*
 
+permissions:
+  contents: write # allow actions to update gh-pages branch
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cherry pick of #1514 on release-1.31.

#1514: fix: github action Release Charts to have write permissions

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```