### PR TITLE
feature(eviction): add event when EvictPod failed

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -42,6 +42,10 @@ type DeschedulerPolicy struct {
 	// MaxNoOfPodsToTotal restricts maximum of pods to be evicted total.
 	MaxNoOfPodsToEvictTotal *uint
 
+	// EvictionFailureEventNotification should be set to true to enable eviction failure event notification.
+	// Default is false.
+	EvictionFailureEventNotification *bool
+
 	// MetricsCollector configures collection of metrics about actual resource utilization
 	MetricsCollector MetricsCollector
 }

--- a/pkg/api/v1alpha2/types.go
+++ b/pkg/api/v1alpha2/types.go
@@ -41,6 +41,10 @@ type DeschedulerPolicy struct {
 	// MaxNoOfPodsToTotal restricts maximum of pods to be evicted total.
 	MaxNoOfPodsToEvictTotal *uint `json:"maxNoOfPodsToEvictTotal,omitempty"`
 
+	// EvictionFailureEventNotification should be set to true to enable eviction failure event notification.
+	// Default is false.
+	EvictionFailureEventNotification *bool
+
 	// MetricsCollector configures collection of metrics for actual resource utilization
 	MetricsCollector MetricsCollector `json:"metricsCollector,omitempty"`
 }

--- a/pkg/api/v1alpha2/zz_generated.conversion.go
+++ b/pkg/api/v1alpha2/zz_generated.conversion.go
@@ -115,6 +115,7 @@ func autoConvert_v1alpha2_DeschedulerPolicy_To_api_DeschedulerPolicy(in *Desched
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
 	out.MaxNoOfPodsToEvictTotal = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictTotal))
+	out.EvictionFailureEventNotification = (*bool)(unsafe.Pointer(in.EvictionFailureEventNotification))
 	if err := Convert_v1alpha2_MetricsCollector_To_api_MetricsCollector(&in.MetricsCollector, &out.MetricsCollector, s); err != nil {
 		return err
 	}
@@ -137,6 +138,7 @@ func autoConvert_api_DeschedulerPolicy_To_v1alpha2_DeschedulerPolicy(in *api.Des
 	out.MaxNoOfPodsToEvictPerNode = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNode))
 	out.MaxNoOfPodsToEvictPerNamespace = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictPerNamespace))
 	out.MaxNoOfPodsToEvictTotal = (*uint)(unsafe.Pointer(in.MaxNoOfPodsToEvictTotal))
+	out.EvictionFailureEventNotification = (*bool)(unsafe.Pointer(in.EvictionFailureEventNotification))
 	if err := Convert_api_MetricsCollector_To_v1alpha2_MetricsCollector(&in.MetricsCollector, &out.MetricsCollector, s); err != nil {
 		return err
 	}

--- a/pkg/api/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/api/v1alpha2/zz_generated.deepcopy.go
@@ -56,6 +56,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.EvictionFailureEventNotification != nil {
+		in, out := &in.EvictionFailureEventNotification, &out.EvictionFailureEventNotification
+		*out = new(bool)
+		**out = **in
+	}
 	out.MetricsCollector = in.MetricsCollector
 	return
 }

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -56,6 +56,11 @@ func (in *DeschedulerPolicy) DeepCopyInto(out *DeschedulerPolicy) {
 		*out = new(uint)
 		**out = **in
 	}
+	if in.EvictionFailureEventNotification != nil {
+		in, out := &in.EvictionFailureEventNotification, &out.EvictionFailureEventNotification
+		*out = new(bool)
+		**out = **in
+	}
 	out.MetricsCollector = in.MetricsCollector
 	return
 }

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -156,6 +156,7 @@ func newDescheduler(ctx context.Context, rs *options.DeschedulerServer, deschedu
 			WithMaxPodsToEvictPerNode(deschedulerPolicy.MaxNoOfPodsToEvictPerNode).
 			WithMaxPodsToEvictPerNamespace(deschedulerPolicy.MaxNoOfPodsToEvictPerNamespace).
 			WithMaxPodsToEvictTotal(deschedulerPolicy.MaxNoOfPodsToEvictTotal).
+			WithEvictionFailureEventNotification(deschedulerPolicy.EvictionFailureEventNotification).
 			WithDryRun(rs.DryRun).
 			WithMetricsEnabled(!rs.DisableMetrics),
 	)

--- a/pkg/descheduler/evictions/options.go
+++ b/pkg/descheduler/evictions/options.go
@@ -5,12 +5,13 @@ import (
 )
 
 type Options struct {
-	policyGroupVersion         string
-	dryRun                     bool
-	maxPodsToEvictPerNode      *uint
-	maxPodsToEvictPerNamespace *uint
-	maxPodsToEvictTotal        *uint
-	metricsEnabled             bool
+	policyGroupVersion               string
+	dryRun                           bool
+	maxPodsToEvictPerNode            *uint
+	maxPodsToEvictPerNamespace       *uint
+	maxPodsToEvictTotal              *uint
+	evictionFailureEventNotification bool
+	metricsEnabled                   bool
 }
 
 // NewOptions returns an Options with default values.
@@ -47,5 +48,12 @@ func (o *Options) WithMaxPodsToEvictTotal(maxPodsToEvictTotal *uint) *Options {
 
 func (o *Options) WithMetricsEnabled(metricsEnabled bool) *Options {
 	o.metricsEnabled = metricsEnabled
+	return o
+}
+
+func (o *Options) WithEvictionFailureEventNotification(evictionFailureEventNotification *bool) *Options {
+	if evictionFailureEventNotification != nil {
+		o.evictionFailureEventNotification = *evictionFailureEventNotification
+	}
 	return o
 }


### PR DESCRIPTION
/kind feature
- add event when EvictPod failed.
- add unit test coverage

When it comes to eviction, what we really care about are the errors that occur during evictions. So I tend to include events when an eviction fails. Besides metrics and application logs, events are also a valuable source of information. Typically, operations personnel respond to events to manage the cluster effectively. 