### PR TITLE
Update Dockerfile - GoLang v 1.22.7 FIX - CVE-2024-34156, CVE-2024-34155 and CVE-2024-34158

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.22.5
+FROM golang:1.22.7
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .


### PR DESCRIPTION
FIX - CVE-2024-34156 (HIGH), CVE-2024-34155, CVE-2024-34158