### PR TITLE
nodeutilization: NodeUtilization: make pod utilization extraction configurable

### DIFF
--- a/pkg/descheduler/pod/pods.go
+++ b/pkg/descheduler/pod/pods.go
@@ -39,6 +39,9 @@ type FilterFunc func(*v1.Pod) bool
 // as input and returns the pods that assigned to the node.
 type GetPodsAssignedToNodeFunc func(string, FilterFunc) ([]*v1.Pod, error)
 
+// PodUtilizationFnc is a function for getting pod's utilization. E.g. requested resources of utilization from metrics.
+type PodUtilizationFnc func(pod *v1.Pod) (v1.ResourceList, error)
+
 // WrapFilterFuncs wraps a set of FilterFunc in one.
 func WrapFilterFuncs(filters ...FilterFunc) FilterFunc {
 	return func(pod *v1.Pod) bool {

--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -80,12 +80,16 @@ func getNodeThresholds(
 	resourceNames []v1.ResourceName,
 	getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc,
 	useDeviationThresholds bool,
-) map[string]NodeThresholds {
+) (map[string]NodeThresholds, error) {
 	nodeThresholdsMap := map[string]NodeThresholds{}
 
 	averageResourceUsagePercent := api.ResourceThresholds{}
 	if useDeviationThresholds {
-		averageResourceUsagePercent = averageNodeBasicresources(nodes, getPodsAssignedToNode, resourceNames)
+		usage, err := averageNodeBasicresources(nodes, getPodsAssignedToNode, resourceNames)
+		if err != nil {
+			return nil, err
+		}
+		averageResourceUsagePercent = usage
 	}
 
 	for _, node := range nodes {
@@ -116,14 +120,14 @@ func getNodeThresholds(
 		}
 
 	}
-	return nodeThresholdsMap
+	return nodeThresholdsMap, nil
 }
 
 func getNodeUsage(
 	nodes []*v1.Node,
 	resourceNames []v1.ResourceName,
 	getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc,
-) []NodeUsage {
+) ([]NodeUsage, error) {
 	var nodeUsageList []NodeUsage
 
 	for _, node := range nodes {
@@ -133,14 +137,22 @@ func getNodeUsage(
 			continue
 		}
 
+		nodeUsage, err := nodeutil.NodeUtilization(pods, resourceNames, func(pod *v1.Pod) (v1.ResourceList, error) {
+			req, _ := utils.PodRequestsAndLimits(pod)
+			return req, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
 		nodeUsageList = append(nodeUsageList, NodeUsage{
 			node:    node,
-			usage:   nodeutil.NodeUtilization(pods, resourceNames),
+			usage:   nodeUsage,
 			allPods: pods,
 		})
 	}
 
-	return nodeUsageList
+	return nodeUsageList, nil
 }
 
 func resourceThreshold(nodeCapacity v1.ResourceList, resourceName v1.ResourceName, threshold api.Percentage) *resource.Quantity {
@@ -451,7 +463,7 @@ func classifyPods(pods []*v1.Pod, filter func(pod *v1.Pod) bool) ([]*v1.Pod, []*
 	return nonRemovablePods, removablePods
 }
 
-func averageNodeBasicresources(nodes []*v1.Node, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc, resourceNames []v1.ResourceName) api.ResourceThresholds {
+func averageNodeBasicresources(nodes []*v1.Node, getPodsAssignedToNode podutil.GetPodsAssignedToNodeFunc, resourceNames []v1.ResourceName) (api.ResourceThresholds, error) {
 	total := api.ResourceThresholds{}
 	average := api.ResourceThresholds{}
 	numberOfNodes := len(nodes)
@@ -461,7 +473,14 @@ func averageNodeBasicresources(nodes []*v1.Node, getPodsAssignedToNode podutil.G
 			numberOfNodes--
 			continue
 		}
-		usage := nodeutil.NodeUtilization(pods, resourceNames)
+		usage, err := nodeutil.NodeUtilization(pods, resourceNames, func(pod *v1.Pod) (v1.ResourceList, error) {
+			req, _ := utils.PodRequestsAndLimits(pod)
+			return req, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
 		nodeCapacity := node.Status.Capacity
 		if len(node.Status.Allocatable) > 0 {
 			nodeCapacity = node.Status.Allocatable
@@ -478,5 +497,5 @@ func averageNodeBasicresources(nodes []*v1.Node, getPodsAssignedToNode podutil.G
 	for resource, value := range total {
 		average[resource] = value / api.Percentage(numberOfNodes)
 	}
-	return average
+	return average, nil
 }


### PR DESCRIPTION
Extracting requested resource is not the only way to get pod's utilization. Consuming actual usage from metrics is another option. Thus, abstracting `NodeUtilization` so the utilization function can be replaced as needed.