### PR TITLE
sortNodesByUsage: drop extended resources as they are already counted in

### DIFF
--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -385,14 +385,6 @@ func sortNodesByUsage(nodes []NodeInfo, ascending bool) {
 			}
 		}
 
-		// extended resources
-		for name := range nodes[i].usage {
-			if !nodeutil.IsBasicResource(name) {
-				ti = ti + nodes[i].usage[name].Value()
-				tj = tj + nodes[j].usage[name].Value()
-			}
-		}
-
 		// Return ascending order for HighNodeUtilization plugin
 		if ascending {
 			return ti < tj


### PR DESCRIPTION
To address https://github.com/kubernetes-sigs/descheduler/pull/1541#discussion_r1840440872