### PR TITLE
Fix: Critical Vulnerabilities | EOL Increased

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.23.1
+FROM golang:1.23.3
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.22.7
+FROM golang:1.23.1
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/descheduler
 
-go 1.22.3
+go 1.23.3
 
 require (
 	github.com/client9/misspell v0.3.4


### PR DESCRIPTION
1. Scanned using trivy.
2. updated golang to v1.23.1 
3. EOL Increased