### PR TITLE
Bump to Go 1.23.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.22.7
+FROM golang:1.23.3
 
 WORKDIR /go/src/sigs.k8s.io/descheduler
 COPY . .

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -3,7 +3,7 @@
 ## Required Tools
 
 - [Git](https://git-scm.com/downloads)
-- [Go 1.16+](https://golang.org/dl/)
+- [Go 1.23+](https://golang.org/dl/)
 - [Docker](https://docs.docker.com/install/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl)
 - [kind v0.10.0+](https://kind.sigs.k8s.io/)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/descheduler
 
-go 1.22.5
+go 1.23.3
 
 require (
 	github.com/client9/misspell v0.3.4

--- a/hack/lib/go.sh
+++ b/hack/lib/go.sh
@@ -19,7 +19,7 @@
 go::verify_version() {
   GO_VERSION=($(go version))
 
-  if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.20|go1.21|go1.22') ]]; then
+  if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.21|go1.22|go1.23') ]]; then
     echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
     exit 1
   fi


### PR DESCRIPTION
The k/k repo was bumped to Go 1.23.3. See below PR for reference.

https://github.com/kubernetes/kubernetes/pull/128852