### PR TITLE
Bump golangci-lint timeout from 2m to 5m

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 2m
+  timeout: 5m
 
 linters:
   disable-all: true


### PR DESCRIPTION
Sometimes golangci-lint timesout when running in CI. Bump the timeout from 2 minutes to 5 minutes to reduce flakey CI failures.

ref: https://golangci-lint.run/usage/configuration/#run-configurationhttps://golangci-lint.run/usage/configuration/#run-configuration