### PR TITLE
Enable golangci-lint Verbose Output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ lint:
 ifndef HAS_GOLANGCI
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./_output/bin ${GOLANGCI_VERSION}
 endif
-	./_output/bin/golangci-lint run
+	./_output/bin/golangci-lint run -v
 
 fmt:
 ifndef HAS_GOFUMPT


### PR DESCRIPTION
The golangci-lint tool gets stuck for a variety of reasons when running in Prow CI. Enabling verbose output in an attempt to make debugging easier.

ref: https://golangci-lint.run/contributing/debug/