### PR TITLE
Fixed the issue when successfulJobsHistoryLimit and failedJobsHistoryLimit variables are 0.

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -15,10 +15,10 @@ spec:
   {{- if .Values.startingDeadlineSeconds }}
   startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
   {{- end }}
-  {{- if .Values.successfulJobsHistoryLimit }}
+  {{- if ne .Values.successfulJobsHistoryLimit nil }}
   successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
   {{- end }}
-  {{- if .Values.failedJobsHistoryLimit }}
+  {{- if ne .Values.failedJobsHistoryLimit nil }}
   failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
   {{- end }}
   {{- if .Values.timeZone }}


### PR DESCRIPTION
Fixed the issue that template rendering failed when the values ​​of successfulJobsHistoryLimit and failedJobsHistoryLimit variables are 0.