### PR TITLE
Fix golangci-lint timeout issue in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - gosimple
     - gocyclo
     - misspell
-    - govet
 
 linters-settings:
   gofumpt:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,7 @@ linters:
     - gosimple
     - gocyclo
     - misspell
+    - govet
 
 linters-settings:
   gofumpt:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Testing CI
+
 [![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/descheduler)](https://goreportcard.com/report/sigs.k8s.io/descheduler)
 ![Release Charts](https://github.com/kubernetes-sigs/descheduler/workflows/Release%20Charts/badge.svg)
 


### PR DESCRIPTION
Trying to pinpoint what is causing the golangci-lint timouts when running in CI.

/hold