### PR TITLE
Bump kind to v0.26.0

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -43,7 +43,7 @@ if [ -n "$KIND_E2E" ]; then
         curl -Lo kubectl https://dl.k8s.io/release/${K8S_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && mv kubectl /usr/local/bin/
     fi
     if [ -z "${SKIP_KIND_INSTALL}" ]; then
-        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.25.0/kind-linux-amd64
+        wget https://github.com/kubernetes-sigs/kind/releases/download/v0.26.0/kind-linux-amd64
         chmod +x kind-linux-amd64
         mv kind-linux-amd64 kind
         export PATH=$PATH:$PWD


### PR DESCRIPTION
The new kind version defaults to k8s v1.32.0 version when creating new clusters.