### PR TITLE
Minor fixes

### DIFF
--- a/charts/descheduler/templates/configmap.yaml
+++ b/charts/descheduler/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.deschedulerPolicy }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,6 +7,7 @@ metadata:
     {{- include "descheduler.labels" . | nindent 4 }}
 data:
   policy.yaml: |
+{{- if .Values.deschedulerPolicy }}
     apiVersion: "{{ .Values.deschedulerPolicyAPIVersion }}"
     kind: "DeschedulerPolicy"
 {{ toYaml .Values.deschedulerPolicy | trim | indent 4 }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -59,7 +59,9 @@ spec:
             - {{ printf "--%s" $key }}
             {{- end }}
             {{- end }}
+            {{- if .Values.leaderElection }}
             {{- include "descheduler.leaderElection" . | nindent 12 }}
+            {{- end }}
           ports:
             {{- toYaml .Values.ports | nindent 12 }}
           livenessProbe:


### PR DESCRIPTION
This PR fixes 2 small issues with the Deployment resource:

1. There is an unnecessary blank line after args in the rendered yaml due to using `toYaml . | nindent`. It always creates a newline even if there is no content, so I've wrapped it with an `if`.
2. If the values.yaml used with the chart has `deschedulerPolicy` set to `""`, the chart was being rendered with no configmap while the deployment still tried to create a volume that referenced the configmap. To avoid this, I've moved the `if` down so that the configmap will always be created but if the key is set as above, policy.yaml will simply be a blank file in the volume.

Descheduler starts up properly with a blank policy.yaml and takes no action, which was the goal for me. I couldn't just deploy this and risk it starting to kill things; I needed to test a very basic policy of my own, but couldn't get the configmap to be deployed with the blank policy.yaml. I assume too that the app would have issues if the policy.yaml file is missing so better to just have it be blank than to remove the volume, which was the other option I could think of to solve my issues.