### PR TITLE
Move values.yaml comment about defining your own configmap to a NOTES.txt output instead

### DIFF
--- a/charts/descheduler/templates/NOTES.txt
+++ b/charts/descheduler/templates/NOTES.txt
@@ -10,3 +10,13 @@ WARNING: You enabled DryRun mode, you can't use Leader Election.
 {{- end}}
 {{- end}}
 {{- end}}
+{{- if .Values.deschedulerPolicy }}
+A default DeschedulerPolicy has been applied for you. You can view the policy with:
+
+kubectl get configmap -n {{ include "descheduler.namespace" . }} {{ template "descheduler.fullname" . }} -o yaml
+
+If you wish to define your own policies out of band from this chart, you may define a configmap named {{ template "descheduler.fullname" . }}.
+To avoid a conflict between helm and your out of band method to deploy the configmap, please set deschedulerPolicy in values.yaml to an empty object as below.
+
+deschedulerPolicy: {}
+{{- end }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -59,7 +59,9 @@ spec:
             - {{ printf "--%s" $key }}
             {{- end }}
             {{- end }}
+            {{- if .Values.leaderElection.enabled }}
             {{- include "descheduler.leaderElection" . | nindent 12 }}
+            {{- end }}
           ports:
             {{- toYaml .Values.ports | nindent 12 }}
           livenessProbe:

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -89,9 +89,6 @@ cmdOptions:
 deschedulerPolicyAPIVersion: "descheduler/v1alpha2"
 
 # deschedulerPolicy contains the policies the descheduler will execute.
-# To use policies stored in an existing configMap use:
-# NOTE: The name of the cm should comply to {{ template "descheduler.fullname" . }}
-# deschedulerPolicy: {}
 deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"
   # maxNoOfPodsToEvictPerNode: 10


### PR DESCRIPTION
This PR intends to make the chart easier to use by providing clear instructions visible to the user after an install. I found the comment in values.yaml to be confusing and ultimately made a PR in error trying to fix something which wasn't broken, so I hope that this PR will be found to be useful and more helpful, not to mention visible.