### PR TITLE
Perform a scheduling simulation in dry-run mode.

### DIFF
--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -564,6 +564,10 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 }
 
 func (pe *PodEvictor) simulateSchedulingInDryRun(pod *v1.Pod) {
+	if !pe.dryRun {
+		return
+	}
+
 	simlatePod := pod.DeepCopy()
 	if nodeName, ok := simlatePod.Annotations[node.FitNodeToPodAnnotationKey]; ok {
 		simlatePod.Spec.NodeName = nodeName

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -563,11 +563,9 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 	return nil
 }
 
+// simulateSchedulingInDryRun is used to reserve the resources of the selected fit node for pods that will be evicted.
+// Only be used in dry-run mode.
 func (pe *PodEvictor) simulateSchedulingInDryRun(pod *v1.Pod) {
-	if !pe.dryRun {
-		return
-	}
-
 	simlatePod := pod.DeepCopy()
 	if nodeName, ok := simlatePod.Annotations[node.FitNodeToPodAnnotationKey]; ok {
 		simlatePod.Spec.NodeName = nodeName


### PR DESCRIPTION
### A bug in dry-run mode.

**Scenario:** If the descheduler determines that 10 pods in the cluster can be evicted, and each of these pods requires 8 cores and 16 GB of memory (8c/16g), while the total available resources in the cluster are sufficient, but only one node meets the 8c/16g requirement. Under the current logic, all pods are considered evictable. 

In dry-run mode, no resources are deducted because the pods are not actually evicted and rescheduled, nor is scheduling simulated.

loged:
```
klog.V(1).InfoS("Evicted pod in dry run mode", "pod", klog.KObj(pod), "reason", opts.Reason, "strategy", opts.StrategyName, "node", pod.Spec.NodeName, "profile", opts.ProfileName)
```

Using dry-run to preview which pods can be rescheduled may mislead users and cause unexpected issues.

Fix: #1584 
