### PR TITLE
charts: add needed perms if metricsCollector is enabled

### DIFF
--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -36,4 +36,9 @@ rules:
   resourceNames: ["{{ .Values.leaderElection.resourceName | default "descheduler" }}"]
   verbs: ["get", "patch", "delete"]
 {{- end }}
+{{- if and .Values.deschedulerPolicy .Values.deschedulerPolicy.metricsCollector .Values.deschedulerPolicy.metricsCollector.enabled }}
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+{{- end }}
 {{- end -}}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -96,6 +96,8 @@ deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"
   # maxNoOfPodsToEvictPerNode: 10
   # maxNoOfPodsToEvictPerNamespace: 10
+  # metricsCollector:
+  #   enabled: true
   # ignorePvcPods: true
   # evictLocalStoragePods: true
   # evictDaemonSetPods: true


### PR DESCRIPTION
fixes #1597

```
E0103 12:37:27.584970       1 metricscollector.go:128] "Error fetching metrics" err="nodes.metrics.k8s.io \"k3s-node3\" is forbidden: User \"system:serviceaccount:kube-system:descheduler\" cannot get resource \"nodes\" in API group \"metrics.k8s.io\" at the cluster scope" node="k3s-node3"
```