### PR TITLE
tracing: test for and address semconv/SDK version conflicts

### DIFF
--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/credentials"
 	"k8s.io/klog/v2"

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -121,7 +121,7 @@ func NewTracerProvider(ctx context.Context, endpoint, caCert, name, namespace st
 		klog.V(5).InfoS("no name provided, using default service name for tracing", "name", DefaultServiceName)
 		name = DefaultServiceName
 	}
-	resourceOpts := []sdkresource.Option{sdkresource.WithAttributes(semconv.ServiceNameKey.String(name)), sdkresource.WithSchemaURL(semconv.SchemaURL), sdkresource.WithProcess()}
+	resourceOpts := defaultResourceOpts(name)
 	if namespace != "" {
 		resourceOpts = append(resourceOpts, sdkresource.WithAttributes(semconv.ServiceNamespaceKey.String(namespace)))
 	}
@@ -139,6 +139,10 @@ func NewTracerProvider(ctx context.Context, endpoint, caCert, name, namespace st
 	)
 	klog.V(2).Info("Successfully setup trace provider")
 	return
+}
+
+func defaultResourceOpts(name string) []sdkresource.Option {
+	return []sdkresource.Option{sdkresource.WithAttributes(semconv.ServiceNameKey.String(name)), sdkresource.WithSchemaURL(semconv.SchemaURL), sdkresource.WithProcess()}
 }
 
 // Shutdown shuts down the global trace exporter.

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,17 @@
+package tracing
+
+import (
+	"context"
+	"testing"
+
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+)
+
+func TestCreateTraceableResource(t *testing.T) {
+	ctx := context.TODO()
+	resourceOpts := defaultResourceOpts("descheduler")
+	_, err := sdkresource.New(ctx, resourceOpts...)
+	if err != nil {
+		t.Errorf("error initialising tracer provider: %!", err)
+	}
+}


### PR DESCRIPTION
Looks like this has previously come up in #1428, so add a test this time.

Specifying `--otel-collector-endpoint` currently causes:

```text
E0122 20:09:35.824338  267288 tracing.go:130] "failed to create traceable resource" err=<
        1 errors occurred detecting resource:
                * conflicting Schema URL: https://opentelemetry.io/schemas/1.24.0 and https://opentelemetry.io/schemas/1.26.0
 >
E0122 20:09:35.824366  267288 server.go:108] "failed to create tracer provider" err=<
        1 errors occurred detecting resource:
                * conflicting Schema URL: https://opentelemetry.io/schemas/1.24.0 and https://opentelemetry.io/schemas/1.26.0
 >
```

This appears to address that problem.