### PR TITLE
tracing: fix context cancellation during shutdown

### DIFF
--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -107,7 +107,6 @@ func Run(rootCtx context.Context, rs *options.DeschedulerServer) error {
 	if err != nil {
 		klog.ErrorS(err, "failed to create tracer provider")
 	}
-	defer tracing.Shutdown(ctx)
 
 	// increase the fake watch channel so the dry-run mode can be run
 	// over a cluster with thousands of pods
@@ -117,6 +116,7 @@ func Run(rootCtx context.Context, rs *options.DeschedulerServer) error {
 		return err
 	}
 
+	tracing.Shutdown(ctx)
 	done()
 	// wait for metrics server to close
 	<-stoppedCh


### PR DESCRIPTION
`tracing.Shutdown()` must be invoked before `done()`, else the context will be cancelled before it's invoked and the following error will be emitted:

```text
E0130 14:31:04.963323       1 tracing.go:156] "failed to shutdown the trace exporter" err="context canceled"
```

~~Interestingly, not observed when running with a `deschedulingInterval`, but reliably reproducible when running as a `CronJob`.~~

Nope, I do see it, I just also see metrics that have already been flushed.