### PR TITLE
Automated cherry pick of #1599: charts: add needed perms if metricsCollector is enabled

### DIFF
--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -33,4 +33,9 @@ rules:
   resourceNames: ["{{ .Values.leaderElection.resourceName | default "descheduler" }}"]
   verbs: ["get", "patch", "delete"]
 {{- end }}
+{{- if and .Values.deschedulerPolicy .Values.deschedulerPolicy.metricsCollector .Values.deschedulerPolicy.metricsCollector.enabled }}
+- apiGroups: ["metrics.k8s.io"]
+  resources: ["pods", "nodes"]
+  verbs: ["get", "list"]
+{{- end }}
 {{- end -}}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -96,6 +96,8 @@ deschedulerPolicy:
   # nodeSelector: "key1=value1,key2=value2"
   # maxNoOfPodsToEvictPerNode: 10
   # maxNoOfPodsToEvictPerNamespace: 10
+  # metricsCollector:
+  #   enabled: true
   # ignorePvcPods: true
   # evictLocalStoragePods: true
   # evictDaemonSetPods: true


### PR DESCRIPTION
Cherry pick of #1599 on release-1.32.

#1599: charts: add needed perms if metricsCollector is enabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```