### PR TITLE
WIP: [nodeutilization]: allow to set/remove a soft taint from overutilized nodes

### DIFF
--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -54,3 +54,88 @@ subjects:
   - name: descheduler-sa
     kind: ServiceAccount
     namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: descheduler-cluster-role-node-update
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: descheduler-cluster-role-binding-node-update
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: descheduler-cluster-role-node-update
+subjects:
+  - kind: ServiceAccount
+    name: descheduler-sa
+    namespace: kube-system
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "descheduler-sa-update-nodes"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    matchPolicy: Equivalent
+    namespaceSelector: {}
+    objectSelector: {}
+    resourceRules:
+      - apiGroups:   [""]
+        apiVersions: ["*"]
+        operations:  ["UPDATE"]
+        resources:   ["nodes"]
+        scope: "*"
+  matchConditions:
+    - name: 'descheduler-sa'
+      expression: "request.userInfo.username=='system:serviceaccount:kube-system:descheduler-sa'"
+  variables:
+    - name: "oldNonDeschedulerTaints"
+      expression: "has(oldObject.spec.taints) ? oldObject.spec.taints.filter(t, !t.key.contains('descheduler.kubernetes.io')) : []"
+    - name: "oldTaints"
+      expression: "has(oldObject.spec.taints) ? oldObject.spec.taints : []"
+    - name: "newNonDeschedulerTaints"
+      expression: "has(object.spec.taints) ? object.spec.taints.filter(t, !t.key.contains('descheduler.kubernetes.io')) : []"
+    - name: "newTaints"
+      expression: "has(object.spec.taints) ? object.spec.taints : []"
+    - name: "newDeschedulerTaints"
+      expression: "has(object.spec.taints) ? object.spec.taints.filter(t, t.key.contains('descheduler.kubernetes.io')) : []"
+  validations:
+    - expression: |
+        oldObject.metadata.filter(k, k != "resourceVersion" && k != "generation" && k != "managedFields").all(k, k in object.metadata) &&
+        object.metadata.filter(k, k != "resourceVersion" && k != "generation" && k != "managedFields").all(k, k in oldObject.metadata && oldObject.metadata[k] == object.metadata[k])
+      messageExpression: "'User ' + string(request.userInfo.username) + ' is only allowed to update taints'"
+      reason: Forbidden
+    - expression: |
+        oldObject.spec.filter(k, k != "taints").all(k, k in object.spec) &&
+        object.spec.filter(k, k != "taints").all(k, k in oldObject.spec && oldObject.spec[k] == object.spec[k])
+      messageExpression: "'User ' + string(request.userInfo.username) + ' is only allowed to update taints'"
+      reason: Forbidden
+    - expression: "size(variables.newNonDeschedulerTaints) == size(variables.oldNonDeschedulerTaints)"
+      messageExpression: "'User ' + string(request.userInfo.username) + ' is not allowed to create/delete non descheduler taints'"
+      reason: Forbidden
+    - expression: "variables.newNonDeschedulerTaints.all(nt, size(variables.oldNonDeschedulerTaints.filter(ot, nt.key==ot.key)) > 0 ? variables.oldNonDeschedulerTaints.filter(ot, nt.key==ot.key)[0].value == nt.value && variables.oldNonDeschedulerTaints.filter(ot, nt.key==ot.key)[0].effect == nt.effect : true)"
+      messageExpression: "'User ' + string(request.userInfo.username) + ' is not allowed to update non descheduler taints'"
+      reason: Forbidden
+    - expression: "variables.newDeschedulerTaints.all(t, t.effect == 'PreferNoSchedule')"
+      messageExpression: "'User ' + string(request.userInfo.username) + ' is only allowed to set taints with PreferNoSchedule effect'"
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: "descheduler-sa-update-nodes"
+spec:
+  policyName: "descheduler-sa-update-nodes"
+  validationActions: [Deny]

--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -18,6 +18,7 @@ package node
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync/atomic"
@@ -26,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	clientset "k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/util/workqueue"
@@ -385,4 +388,113 @@ func podMatchesInterPodAntiAffinity(nodeIndexer podutil.GetPodsAssignedToNodeFun
 	}
 
 	return false, nil
+}
+
+// IsNodeSoftTainted checks if the node is already tainted
+// with the provided key and value and PreferNoSchedule effect.
+// If a match is found, it returns true.
+func IsNodeSoftTainted(node *v1.Node, taintKey, taintValue string) bool {
+	if node == nil {
+		return false
+	}
+	for _, taint := range node.Spec.Taints {
+		if (taint.Effect == v1.TaintEffectPreferNoSchedule) && taint.Key == taintKey && taint.Value == taintValue {
+			return true
+		}
+	}
+	return false
+}
+
+// AddOrUpdateSoftTaint add a soft taint to the node. If taint was added/updated into node, it'll trigger a patch operation
+// to update the node; otherwise, no API calls. Return error if any.
+func AddOrUpdateSoftTaint(ctx context.Context, c clientset.Interface, node *v1.Node, taintKey, taintValue string) (bool, error) {
+	newNode := node.DeepCopy()
+	nodeTaints := newNode.Spec.Taints
+
+	var newTaints []v1.Taint
+	updated := false
+	found := false
+
+	for _, taint := range nodeTaints {
+		if taint.Key != taintKey {
+			newTaints = append(newTaints, taint)
+		} else {
+			if taint.Value != taintValue || taint.Effect != v1.TaintEffectPreferNoSchedule {
+				newTaints = append(newTaints, v1.Taint{Key: taint.Key, Value: taintValue, Effect: v1.TaintEffectPreferNoSchedule})
+				updated = true
+			} else {
+				found = true
+			}
+		}
+	}
+	if !updated && !found {
+		newTaints = append(newTaints, v1.Taint{Key: taintKey, Value: taintValue, Effect: v1.TaintEffectPreferNoSchedule})
+		updated = true
+	}
+
+	if updated {
+		newNode.Spec.Taints = newTaints
+		err := patchNodeTaints(ctx, c, node.Name, node, newNode)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// RemoveSoftTaint delete a soft taint from the node. If taint was found on the node, it'll trigger a patch operation
+// to update the node; otherwise, no API calls. Return error if any.
+func RemoveSoftTaint(ctx context.Context, c clientset.Interface, node *v1.Node, taintKey string) (bool, error) {
+	newNode := node.DeepCopy()
+	nodeTaints := newNode.Spec.Taints
+	var newTaints []v1.Taint
+	found := false
+
+	for _, taint := range nodeTaints {
+		if taint.Key != taintKey {
+			newTaints = append(newTaints, taint)
+		} else {
+			found = true
+		}
+	}
+
+	if found {
+		newNode.Spec.Taints = newTaints
+		err := patchNodeTaints(ctx, c, node.Name, node, newNode)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// patchNodeTaints patches node's taints.
+func patchNodeTaints(ctx context.Context, c clientset.Interface, nodeName string, oldNode, newNode *v1.Node) error {
+	// Strip base diff node from RV to ensure that our Patch request will set RV to check for conflicts over .spec.taints.
+	// This is needed because .spec.taints does not specify patchMergeKey and patchStrategy and adding them is no longer an option for compatibility reasons.
+	// Using other Patch strategy works for adding new taints, however will not resolve problem with taint removal.
+	oldNodeNoRV := oldNode.DeepCopy()
+	oldNodeNoRV.ResourceVersion = ""
+	oldDataNoRV, err := json.Marshal(&oldNodeNoRV)
+	if err != nil {
+		return fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNodeNoRV, nodeName, err)
+	}
+
+	newTaints := newNode.Spec.Taints
+	newNodeClone := oldNode.DeepCopy()
+	newNodeClone.Spec.Taints = newTaints
+	newData, err := json.Marshal(newNodeClone)
+	if err != nil {
+		return fmt.Errorf("failed to marshal new node %#v for node %q: %v", newNodeClone, nodeName, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldDataNoRV, newData, v1.Node{})
+	if err != nil {
+		return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
+	}
+
+	_, err = c.CoreV1().Nodes().Patch(ctx, nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
+	return err
 }

--- a/pkg/descheduler/node/node_test.go
+++ b/pkg/descheduler/node/node_test.go
@@ -19,6 +19,7 @@ package node
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -1130,4 +1131,293 @@ func createResourceList(cpu, memory, ephemeralStorage int64) v1.ResourceList {
 	resourceList[v1.ResourceMemory] = *resource.NewQuantity(memory, resource.DecimalSI)
 	resourceList[v1.ResourceEphemeralStorage] = *resource.NewQuantity(ephemeralStorage, resource.DecimalSI)
 	return resourceList
+}
+
+func TestAddOrUpdateSoftTaint(t *testing.T) {
+	const testKey = "testTaintKey"
+	const testValue = "testTaintValue"
+	const otherValue = "testOtherValue"
+	const otherKey1 = "testOtherKey1"
+	const otherKey2 = "testOtherKey2"
+	ctx := context.Background()
+	node := test.BuildTestNode("node1", 1000, 2000, 9, nil)
+	node.Labels = map[string]string{"type": "compute"}
+
+	tests := []struct {
+		description     string
+		nodeTaints      []v1.Taint
+		expectedTaints  []v1.Taint
+		expectedUpdated bool
+		expectedErr     error
+	}{
+		{
+			description: "no taints - empty taints",
+			nodeTaints:  []v1.Taint{},
+			expectedTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "no taints - nil",
+			nodeTaints:  nil,
+			expectedTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "only the soft taint, same value",
+			nodeTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: false,
+			expectedErr:     nil,
+		},
+		{
+			description: "only the soft taint, different value",
+			nodeTaints: []v1.Taint{
+				{Key: testKey, Value: otherValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "only the soft taint, different effect",
+			nodeTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "only a different taint",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other different taints",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoSchedule},
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other taints + update (begin)",
+			nodeTaints: []v1.Taint{
+				{Key: testKey, Value: otherValue, Effect: v1.TaintEffectPreferNoSchedule},
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other taints + update (middle)",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: testKey, Value: otherValue, Effect: v1.TaintEffectPreferNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other taints + update (end)",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+				{Key: testKey, Value: otherValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+				{Key: testKey, Value: testValue, Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedUpdated: true,
+			expectedErr:     nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			node.Spec.Taints = tc.nodeTaints
+			fakeClient := fake.NewSimpleClientset(node)
+			removed, err := AddOrUpdateSoftTaint(ctx, fakeClient, node, testKey, testValue)
+			if removed != tc.expectedUpdated {
+				t.Errorf("Test %#v failed, unexepcted updated", tc.description)
+			}
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("Test %#v failed, unexpected error: %v", tc.description, err)
+			}
+			tNode, err := fakeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("Test %#v failed, test case error: %v", tc.description, err)
+			}
+			if !reflect.DeepEqual(tNode.Spec.Taints, tc.expectedTaints) {
+				t.Errorf("Test %#v failed, the node should have taints %+v, but got: %+v", tc.description, tc.expectedTaints, tNode.Spec.Taints)
+			}
+		})
+	}
+}
+
+func TestRemoveSoftTaint(t *testing.T) {
+	const testKey = "testTaintKey"
+	const otherKey1 = "testOtherKey1"
+	const otherKey2 = "testOtherKey2"
+	ctx := context.Background()
+	node := test.BuildTestNode("node1", 1000, 2000, 9, nil)
+	node.Labels = map[string]string{"type": "compute"}
+
+	tests := []struct {
+		description     string
+		nodeTaints      []v1.Taint
+		expectedTaints  []v1.Taint
+		expectedRemoved bool
+		expectedErr     error
+	}{
+		{
+			description:     "no taints - empty taints",
+			nodeTaints:      []v1.Taint{},
+			expectedTaints:  []v1.Taint{},
+			expectedRemoved: false,
+			expectedErr:     nil,
+		},
+		{
+			description:     "no taints - nil",
+			nodeTaints:      nil,
+			expectedTaints:  nil,
+			expectedRemoved: false,
+			expectedErr:     nil,
+		},
+		{
+			description: "only the soft taint",
+			nodeTaints: []v1.Taint{
+				{Key: testKey, Value: "value1", Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedTaints:  nil,
+			expectedRemoved: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "only another taint",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+			},
+			expectedRemoved: false,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other taints",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedRemoved: false,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other taints + soft taint (begin)",
+			nodeTaints: []v1.Taint{
+				{Key: testKey, Value: "value1", Effect: v1.TaintEffectPreferNoSchedule},
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedRemoved: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other taints + soft taint (middle)",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: testKey, Value: "value1", Effect: v1.TaintEffectPreferNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedRemoved: true,
+			expectedErr:     nil,
+		},
+		{
+			description: "two other taints + soft taint (end)",
+			nodeTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+				{Key: testKey, Value: "value1", Effect: v1.TaintEffectPreferNoSchedule},
+			},
+			expectedTaints: []v1.Taint{
+				{Key: otherKey1, Value: "value1", Effect: v1.TaintEffectNoSchedule},
+				{Key: otherKey2, Value: "value2", Effect: v1.TaintEffectNoExecute},
+			},
+			expectedRemoved: true,
+			expectedErr:     nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			node.Spec.Taints = tc.nodeTaints
+			fakeClient := fake.NewSimpleClientset(node)
+			removed, err := RemoveSoftTaint(ctx, fakeClient, node, testKey)
+			if removed != tc.expectedRemoved {
+				t.Errorf("Test %#v failed, unexepcted removed", tc.description)
+			}
+			if !errors.Is(err, tc.expectedErr) {
+				t.Errorf("Test %#v failed, unexpected error: %v", tc.description, err)
+			}
+			tNode, err := fakeClient.CoreV1().Nodes().Get(ctx, node.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Errorf("Test %#v failed, test case error: %v", tc.description, err)
+			}
+			if !reflect.DeepEqual(tNode.Spec.Taints, tc.expectedTaints) {
+				t.Errorf("Test %#v failed, the node should have taints %+v, but got: %+v", tc.description, tc.expectedTaints, tNode.Spec.Taints)
+			}
+		})
+	}
 }

--- a/pkg/framework/plugins/nodeutilization/defaults.go
+++ b/pkg/framework/plugins/nodeutilization/defaults.go
@@ -37,6 +37,9 @@ func SetDefaults_LowNodeUtilizationArgs(obj runtime.Object) {
 	if args.NumberOfNodes == 0 {
 		args.NumberOfNodes = 0
 	}
+	if args.NumberOfNodes == 0 {
+		args.NumberOfNodes = 0
+	}
 }
 
 // SetDefaults_HighNodeUtilizationArgs

--- a/pkg/framework/plugins/nodeutilization/highnodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization.go
@@ -102,7 +102,7 @@ func (h *HighNodeUtilization) Balance(ctx context.Context, nodes []*v1.Node) *fr
 		}
 	}
 
-	sourceNodes, highNodes := classifyNodes(
+	sourceNodes, _, highNodes := classifyNodes(
 		getNodeUsage(nodes, h.usageClient),
 		getNodeThresholds(nodes, h.args.Thresholds, h.targetThresholds, h.resourceNames, false, h.usageClient),
 		func(node *v1.Node, usage NodeUsage, threshold NodeThresholds) bool {

--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -184,8 +184,8 @@ func classifyNodes(
 	nodeUsages []NodeUsage,
 	nodeThresholds map[string]NodeThresholds,
 	lowThresholdFilter, highThresholdFilter func(node *v1.Node, usage NodeUsage, threshold NodeThresholds) bool,
-) ([]NodeInfo, []NodeInfo) {
-	lowNodes, highNodes := []NodeInfo{}, []NodeInfo{}
+) ([]NodeInfo, []NodeInfo, []NodeInfo) {
+	lowNodes, apprNodes, highNodes := []NodeInfo{}, []NodeInfo{}, []NodeInfo{}
 
 	for _, nodeUsage := range nodeUsages {
 		nodeInfo := NodeInfo{
@@ -200,10 +200,11 @@ func classifyNodes(
 			highNodes = append(highNodes, nodeInfo)
 		} else {
 			klog.InfoS("Node is appropriately utilized", "node", klog.KObj(nodeUsage.node), "usage", nodeUsage.usage, "usagePercentage", resourceUsagePercentages(nodeUsage))
+			apprNodes = append(apprNodes, nodeInfo)
 		}
 	}
 
-	return lowNodes, highNodes
+	return lowNodes, apprNodes, highNodes
 }
 
 func usageToKeysAndValues(usage map[v1.ResourceName]*resource.Quantity) []interface{} {

--- a/pkg/framework/plugins/nodeutilization/types.go
+++ b/pkg/framework/plugins/nodeutilization/types.go
@@ -29,6 +29,7 @@ type LowNodeUtilizationArgs struct {
 	TargetThresholds       api.ResourceThresholds `json:"targetThresholds"`
 	NumberOfNodes          int                    `json:"numberOfNodes,omitempty"`
 	MetricsUtilization     MetricsUtilization     `json:"metricsUtilization,omitempty"`
+	SoftTainter            SoftTainter            `json:"softTainter,omitempty"`
 
 	// Naming this one differently since namespaces are still
 	// considered while considering resources used by pods
@@ -57,4 +58,16 @@ type MetricsUtilization struct {
 	// metricsServer enables metrics from a kubernetes metrics server.
 	// Please see https://kubernetes-sigs.github.io/metrics-server/ for more.
 	MetricsServer bool `json:"metricsServer,omitempty"`
+}
+
+// SoftTainter allow to dynamically set/remove a soft taint to hint the scheduler to avoid overutilized nodes
+type SoftTainter struct {
+	// ApplySoftTaints enables the node soft tainter
+	ApplySoftTaints bool `json:"applySoftTaints,omitempty"`
+
+	// +default="nodeutilization.descheduler.kubernetes.io/overutilized"
+	SoftTaintKey string `json:"softTaintKey,omitempty"`
+
+	// +default="true"
+	SoftTaintValue string `json:"softTaintValue,omitempty"`
 }

--- a/pkg/framework/plugins/nodeutilization/zz_generated.deepcopy.go
+++ b/pkg/framework/plugins/nodeutilization/zz_generated.deepcopy.go
@@ -83,6 +83,7 @@ func (in *LowNodeUtilizationArgs) DeepCopyInto(out *LowNodeUtilizationArgs) {
 		}
 	}
 	out.MetricsUtilization = in.MetricsUtilization
+	out.SoftTainter = in.SoftTainter
 	if in.EvictableNamespaces != nil {
 		in, out := &in.EvictableNamespaces, &out.EvictableNamespaces
 		*out = new(api.Namespaces)

--- a/pkg/framework/plugins/nodeutilization/zz_generated.defaults.go
+++ b/pkg/framework/plugins/nodeutilization/zz_generated.defaults.go
@@ -29,5 +29,15 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&LowNodeUtilizationArgs{}, func(obj interface{}) { SetObjectDefaults_LowNodeUtilizationArgs(obj.(*LowNodeUtilizationArgs)) })
 	return nil
+}
+
+func SetObjectDefaults_LowNodeUtilizationArgs(in *LowNodeUtilizationArgs) {
+	if in.SoftTainter.SoftTaintKey == "" {
+		in.SoftTainter.SoftTaintKey = "nodeutilization.descheduler.kubernetes.io/overutilized"
+	}
+	if in.SoftTainter.SoftTaintValue == "" {
+		in.SoftTainter.SoftTaintValue = "true"
+	}
 }

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -240,6 +240,11 @@ func SetNodeUnschedulable(node *v1.Node) {
 	node.Spec.Unschedulable = true
 }
 
+// SetNodeSoftTainted sets the descheduler soft taints on the given node
+func SetNodeSoftTainted(node *v1.Node) {
+	node.Spec.Taints = append(node.Spec.Taints, v1.Taint{Key: "nodeutilization.descheduler.kubernetes.io/overutilized", Value: "true", Effect: v1.TaintEffectPreferNoSchedule})
+}
+
 // SetPodExtendedResourceRequest sets the given pod's extended resources
 func SetPodExtendedResourceRequest(pod *v1.Pod, resourceName v1.ResourceName, requestQuantity int64) {
 	pod.Spec.Containers[0].Resources.Requests[resourceName] = *resource.NewQuantity(requestQuantity, resource.DecimalSI)


### PR DESCRIPTION
Dynamically set/remove a soft taint (effect: PreferNoSchedule) to/from nodes that the descheduler identified as overutilized according to the nodeutilization plugin.
After #1555 the nodeutilization plugin can consume utilization data from actual kubernetes metrics and not only static reservations (requests).
On the other side, the default kube-scheduler is only going to ensure that Pod's specific resource requests can be satisfied.
The soft taint will simply gave an hint to the scheduler to try avoiding nodes that looks overutilized at
descheduler eyes.
Since it's just a soft taint (do it just if possible) there is no need to restrict it only to a certain amount of nodes in the cluster or be strict on error handling.
With a fine-grained `ValidatingAdmissionPolicy` (GA in k8s 1.30) 
we can enforce that the `descheduler-sa` is only allowed
to apply/remove soft-taints (enforcing `PreferNoSchedule` effect)
and with a predefined key-prefix (eventually customizable with a parameter).

TODO: add more unit and e2e tests

Fixes: #1626 
