### PR TITLE
feat(token): automountServiceAccountToken set hard to true on deployment

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -70,6 +70,9 @@ spec:
           priorityClassName: {{ .Values.priorityClassName }}
           {{- end }}
           serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
+          {{- if kindIs "bool" .Values.automountServiceAccountToken }}
+          automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+          {{- end }}
           restartPolicy: "Never"
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:
@@ -103,6 +106,9 @@ spec:
               volumeMounts:
                 - mountPath: /policy-dir
                   name: policy-volume
+                {{- if and .Values.extraServiceAccountVolumeMounts (not .Values.automountServiceAccountToken) }}
+                  {{ toYaml .Values.extraServiceAccountVolumeMounts | nindent 16 }}
+                {{- end }}
           {{- if .Values.podSecurityContext }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
@@ -111,4 +117,7 @@ spec:
           - name: policy-volume
             configMap:
               name: {{ template "descheduler.fullname" . }}
+          {{- if and .Values.extraServiceAccountVolumes (not .Values.automountServiceAccountToken) }}
+            {{ toYaml .Values.extraServiceAccountVolumes | nindent 10 }}
+          {{- end }}
 {{- end }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
       serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
+      {{- if kindIs "bool" .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 6 }}
@@ -75,6 +78,9 @@ spec:
           volumeMounts:
             - mountPath: /policy-dir
               name: policy-volume
+            {{- if and .Values.extraServiceAccountVolumeMounts (not .Values.automountServiceAccountToken) }}
+              {{ toYaml .Values.extraServiceAccountVolumeMounts | nindent 12 }}
+            {{- end }}
       {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -83,6 +89,9 @@ spec:
         - name: policy-volume
           configMap:
             name: {{ template "descheduler.fullname" . }}
+        {{- if and .Values.extraServiceAccountVolumes (not .Values.automountServiceAccountToken) }}
+          {{ toYaml .Values.extraServiceAccountVolumes | nindent 8}}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/descheduler/templates/serviceaccount.yaml
+++ b/charts/descheduler/templates/serviceaccount.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+{{- if kindIs "bool" .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
 metadata:
   name: {{ template "descheduler.serviceAccountName" . }}
   namespace: {{ include "descheduler.namespace" . }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -194,6 +194,15 @@ serviceAccount:
   name:
   # Specifies custom annotations for the serviceAccount
   annotations: {}
+  # Opt out of API credential automounting
+  # 
+  # automountServiceAccountToken Default is not set 
+  # automountServiceAccountToken: true
+  
+
+# Mount the ServiceAccountToken in the Pod of a CronJob or Deployment 
+# Default is not set - but only implied by the ServiceAccount
+# automountServiceAccountToken: true
 
 podAnnotations: {}
 
@@ -245,3 +254,30 @@ serviceMonitor:
     #   targetLabel: nodename
     #   replacement: $1
     #   action: replace
+
+## Additional Volume mounts when automountServiceAccountToken is false
+# extraServiceAccountVolumeMounts: 
+# - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+#   name: kube-api-access
+#   readOnly: true
+
+## Additional Volumes when automountServiceAccountToken is false
+# extraServiceAccountVolumes:
+# - name: kube-api-access
+#   projected:
+#     defaultMode: 0444
+#     sources:
+#     - configMap:
+#         items:
+#         - key: ca.crt
+#           path: ca.crt
+#         name: kube-root-ca.crt
+#     - downwardAPI:
+#         items:
+#         - fieldRef:
+#             apiVersion: v1
+#             fieldPath: metadata.namespace
+#           path: namespace
+#     - serviceAccountToken:
+#         expirationSeconds: 3600
+#         path: token


### PR DESCRIPTION
In our Environment all ServiceAccounta are mutatet  to automountServiceAccountToken: false 
And its only allowed to set the automountServiceAccountToken: true in a deployment.

But at the moment descheduler doesnt provide this.

automountServiceAccountToken is necessary for descheduler, for that reason i added it hard coded.

Would be nice if you can go with it.

many thanks