### PR TITLE
Allow `include` namespaces filtering in node utilization plugin

### DIFF
--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -304,7 +304,9 @@ func evictPods(
 	usageClient usageClient,
 ) error {
 	var excludedNamespaces sets.Set[string]
+	var includedNamespaces sets.Set[string]
 	if evictableNamespaces != nil {
+		includedNamespaces = sets.New(evictableNamespaces.Include...)
 		excludedNamespaces = sets.New(evictableNamespaces.Exclude...)
 	}
 
@@ -318,6 +320,7 @@ func evictPods(
 			preEvictionFilterWithOptions, err := podutil.NewOptions().
 				WithFilter(podEvictor.PreEvictionFilter).
 				WithoutNamespaces(excludedNamespaces).
+				WithNamespaces(includedNamespaces).
 				BuildFilterFunc()
 			if err != nil {
 				klog.ErrorS(err, "could not build preEvictionFilter with namespace exclusion")

--- a/pkg/framework/plugins/nodeutilization/validation.go
+++ b/pkg/framework/plugins/nodeutilization/validation.go
@@ -23,8 +23,8 @@ import (
 func ValidateHighNodeUtilizationArgs(obj runtime.Object) error {
 	args := obj.(*HighNodeUtilizationArgs)
 	// only exclude can be set, or not at all
-	if args.EvictableNamespaces != nil && len(args.EvictableNamespaces.Include) > 0 {
-		return fmt.Errorf("only Exclude namespaces can be set, inclusion is not supported")
+	if args.EvictableNamespaces != nil && len(args.EvictableNamespaces.Include) > 0 && len(args.EvictableNamespaces.Exclude) > 0 {
+		return fmt.Errorf("cannot set both Include and Exclude namespaces")
 	}
 	err := validateThresholds(args.Thresholds)
 	if err != nil {
@@ -37,8 +37,8 @@ func ValidateHighNodeUtilizationArgs(obj runtime.Object) error {
 func ValidateLowNodeUtilizationArgs(obj runtime.Object) error {
 	args := obj.(*LowNodeUtilizationArgs)
 	// only exclude can be set, or not at all
-	if args.EvictableNamespaces != nil && len(args.EvictableNamespaces.Include) > 0 {
-		return fmt.Errorf("only Exclude namespaces can be set, inclusion is not supported")
+	if args.EvictableNamespaces != nil && len(args.EvictableNamespaces.Include) > 0 && len(args.EvictableNamespaces.Exclude) > 0 {
+		return fmt.Errorf("cannot set both Include and Exclude namespaces")
 	}
 	err := validateLowNodeUtilizationThresholds(args.Thresholds, args.TargetThresholds, args.UseDeviationThresholds)
 	if err != nil {


### PR DESCRIPTION
The node utilization plugin currently does not allow specifying namespaces with an allowlist via `include`, preferring to filter instead with `exclude`. I could not find a technical reason for this and found other instances where both were allowed. I propose to lift this restriction in the interest of flexibility, at least until #1499/#1501 can be integrated.