### PR TITLE
nodeutilization: invoke ValidateLowNodeUtilizationArgs instead of validateLowNodeUtilizationThresholds to make the test more generic

### DIFF
--- a/pkg/framework/plugins/nodeutilization/validation_test.go
+++ b/pkg/framework/plugins/nodeutilization/validation_test.go
@@ -21,164 +21,180 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"sigs.k8s.io/descheduler/pkg/api"
 )
 
 func TestValidateLowNodeUtilizationPluginConfig(t *testing.T) {
 	extendedResource := v1.ResourceName("example.com/foo")
 	tests := []struct {
-		name             string
-		thresholds       api.ResourceThresholds
-		targetThresholds api.ResourceThresholds
-		errInfo          error
+		name    string
+		args    *LowNodeUtilizationArgs
+		errInfo error
 	}{
 		{
 			name: "passing invalid thresholds",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 120,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 120,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds config is not valid: %v", fmt.Errorf(
 				"%v threshold not in [%v, %v] range", v1.ResourceMemory, MinResourcePercentage, MaxResourcePercentage)),
 		},
 		{
 			name: "thresholds and targetThresholds configured different num of resources",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
-				v1.ResourcePods:   80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					v1.ResourcePods:   80,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds and targetThresholds configured different resources"),
 		},
 		{
 			name: "thresholds and targetThresholds configured different resources",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:  80,
-				v1.ResourcePods: 80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:  80,
+					v1.ResourcePods: 80,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds and targetThresholds configured different resources"),
 		},
 		{
 			name: "thresholds' CPU config value is greater than targetThresholds'",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    90,
-				v1.ResourceMemory: 20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    90,
+					v1.ResourceMemory: 20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds' %v percentage is greater than targetThresholds'", v1.ResourceCPU),
 		},
 		{
 			name: "only thresholds configured extended resource",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-				extendedResource:  20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds and targetThresholds configured different resources"),
 		},
 		{
 			name: "only targetThresholds configured extended resource",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
-				extendedResource:  80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  80,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds and targetThresholds configured different resources"),
 		},
 		{
 			name: "thresholds and targetThresholds configured different extended resources",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-				extendedResource:  20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
-				"example.com/bar": 80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					"example.com/bar": 80,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds and targetThresholds configured different resources"),
 		},
 		{
 			name: "thresholds' extended resource config value is greater than targetThresholds'",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-				extendedResource:  90,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
-				extendedResource:  20,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  90,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  20,
+				},
 			},
 			errInfo: fmt.Errorf("thresholds' %v percentage is greater than targetThresholds'", extendedResource),
 		},
 		{
 			name: "passing valid plugin config",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+				},
 			},
 			errInfo: nil,
 		},
 		{
 			name: "passing valid plugin config with extended resource",
-			thresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    20,
-				v1.ResourceMemory: 20,
-				extendedResource:  20,
-			},
-			targetThresholds: api.ResourceThresholds{
-				v1.ResourceCPU:    80,
-				v1.ResourceMemory: 80,
-				extendedResource:  80,
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  80,
+				},
 			},
 			errInfo: nil,
 		},
 	}
 
 	for _, testCase := range tests {
-		args := &LowNodeUtilizationArgs{
-			Thresholds:       testCase.thresholds,
-			TargetThresholds: testCase.targetThresholds,
-		}
-		validateErr := validateLowNodeUtilizationThresholds(args.Thresholds, args.TargetThresholds, false)
-
-		if validateErr == nil || testCase.errInfo == nil {
-			if validateErr != testCase.errInfo {
-				t.Errorf("expected validity of plugin config: thresholds %#v targetThresholds %#v to be %v but got %v instead",
-					testCase.thresholds, testCase.targetThresholds, testCase.errInfo, validateErr)
+		t.Run(testCase.name, func(t *testing.T) {
+			validateErr := ValidateLowNodeUtilizationArgs(runtime.Object(testCase.args))
+			if validateErr == nil || testCase.errInfo == nil {
+				if validateErr != testCase.errInfo {
+					t.Errorf("expected validity of plugin config: %v but got %v instead", testCase.errInfo, validateErr)
+				}
+			} else if validateErr.Error() != testCase.errInfo.Error() {
+				t.Errorf("expected validity of plugin config: %v but got %v instead", testCase.errInfo, validateErr)
 			}
-		} else if validateErr.Error() != testCase.errInfo.Error() {
-			t.Errorf("expected validity of plugin config: thresholds %#v targetThresholds %#v to be %v but got %v instead",
-				testCase.thresholds, testCase.targetThresholds, testCase.errInfo, validateErr)
-		}
+		})
 	}
 }


### PR DESCRIPTION
So it can be later extended with non threshold related validation tests.