### PR TITLE
nodeutilization: make the node classification more generic

### DIFF
--- a/pkg/framework/plugins/nodeutilization/nodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization_test.go
@@ -57,8 +57,13 @@ var (
 )
 
 func TestResourceUsagePercentages(t *testing.T) {
-	resourceUsagePercentage := resourceUsagePercentages(NodeUsage{
-		node: &v1.Node{
+	resourceUsagePercentage := resourceUsagePercentages(
+		api.ReferencedResourceList{
+			v1.ResourceCPU:    resource.NewMilliQuantity(1220, resource.DecimalSI),
+			v1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
+			v1.ResourcePods:   resource.NewQuantity(11, resource.BinarySI),
+		},
+		&v1.Node{
 			Status: v1.NodeStatus{
 				Capacity: v1.ResourceList{
 					v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
@@ -72,12 +77,8 @@ func TestResourceUsagePercentages(t *testing.T) {
 				},
 			},
 		},
-		usage: api.ReferencedResourceList{
-			v1.ResourceCPU:    resource.NewMilliQuantity(1220, resource.DecimalSI),
-			v1.ResourceMemory: resource.NewQuantity(3038982964, resource.BinarySI),
-			v1.ResourcePods:   resource.NewQuantity(11, resource.BinarySI),
-		},
-	})
+		true,
+	)
 
 	expectedUsageInIntPercentage := map[v1.ResourceName]float64{
 		v1.ResourceCPU:    63,
@@ -86,7 +87,7 @@ func TestResourceUsagePercentages(t *testing.T) {
 	}
 
 	for resourceName, percentage := range expectedUsageInIntPercentage {
-		if math.Floor(resourceUsagePercentage[resourceName]) != percentage {
+		if math.Floor(float64(resourceUsagePercentage[resourceName])) != percentage {
 			t.Errorf("Incorrect percentange computation, expected %v, got math.Floor(%v) instead", percentage, resourceUsagePercentage[resourceName])
 		}
 	}


### PR DESCRIPTION
Classify the nodes based on comparing percentages/thresholds rather then quantities to make the classification more generic. While still keeping the original way of computation available resources for eviction.

Noticeable changes:
- make computation of dynamic thresholds (deviation) separate from the user provided thresholds (static)
- classify nodes based on comparison of thresholds while translating actual node usages into percentages (the original thresholds used for available resource computation are still kept as quantities)