### PR TITLE
fix: Fix panic in descheduler when using `--secure-port=0`

### DIFF
--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -142,8 +142,10 @@ func (rs *DeschedulerServer) Apply() error {
 		return err
 	}
 
-	secureServing.DisableHTTP2 = !rs.EnableHTTP2
-	rs.SecureServingInfo = secureServing
+	if secureServing != nil {
+		secureServing.DisableHTTP2 = !rs.EnableHTTP2
+		rs.SecureServingInfo = secureServing
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fix panic in descheduler when using `--secure-port=0`:
```bash
$ ./descheduler --secure-port=0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x2a81a23]

goroutine 1 [running]:
sigs.k8s.io/descheduler/cmd/descheduler/app.NewDeschedulerCommand.func2(0xc0003a0500?, {0x2af01b3?, 0x4?, 0x2af01b7?})
	/Users/dongjiang/Documents/go/src/github.com/kubernetes-sigs/descheduler/cmd/descheduler/app/server.go:78 +0x83
github.com/spf13/cobra.(*Command).execute(0xc0002d6008, {0xc00004e150, 0x1, 0x1})
	/Users/dongjiang/Documents/go/src/github.com/kubernetes-sigs/descheduler/vendor/github.com/spf13/cobra/command.go:983 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002d6008)
	/Users/dongjiang/Documents/go/src/github.com/kubernetes-sigs/descheduler/vendor/github.com/spf13/cobra/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/dongjiang/Documents/go/src/github.com/kubernetes-sigs/descheduler/vendor/github.com/spf13/cobra/command.go:1039
k8s.io/component-base/cli.run(0xc0002d6008)
	/Users/dongjiang/Documents/go/src/github.com/kubernetes-sigs/descheduler/vendor/k8s.io/component-base/cli/run.go:146 +0x290
k8s.io/component-base/cli.Run(0xc0002d6008?)
	/Users/dongjiang/Documents/go/src/github.com/kubernetes-sigs/descheduler/vendor/k8s.io/component-base/cli/run.go:46 +0x17
main.main()
	/Users/dongjiang/Documents/go/src/github.com/kubernetes-sigs/descheduler/cmd/descheduler/descheduler.go:31 +0xa5
```

Fixed:
```bash
 $ ./descheduler --secure-port=0 
E0312 18:00:53.239630   95679 server.go:73] "failed to run descheduler server" err="unable to create config: unable to build in cluster config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"
E0312 18:00:53.240747   95679 run.go:72] "command failed" err="unable to create config: unable to build in cluster config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"
```

Close #1639 