### PR TITLE
feat: introduces new node usage classification engine

### DIFF
--- a/pkg/framework/plugins/nodeutilization/classifier/classifier.go
+++ b/pkg/framework/plugins/nodeutilization/classifier/classifier.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package classifier
+
+// Classifier is a function that classifies a resource usage based on a limit.
+// The function should return true if the resource usage matches the classifier
+// intent.
+type Classifier[K comparable, V any] func(K, V, V) bool
+
+// Comparer is a function that compares two objects. This function should return
+// -1 if the first object is less than the second, 0 if they are equal, and 1 if
+// the first object is greater than the second. Of course this is a simplification
+// and any value between -1 and 1 can be returned.
+type Comparer[V any] func(V, V) int
+
+// Values is a map of values indexed by a comparable key. An example of this
+// can be a list of resources indexed by a node name.
+type Values[K comparable, V any] map[K]V
+
+// Limits is a map of list of limits indexed by a comparable key. Each limit
+// inside the list requires a classifier to evaluate.
+type Limits[K comparable, V any] map[K][]V
+
+// Classify is a function that classifies based on classifier functions. This
+// function receives Values, a list of n Limits (indexed by name), and a list
+// of n Classifiers. The classifier at n position is called to evaluate the
+// limit at n position. The first classifier to return true will receive the
+// value, at this point the loop will break and the next value will be
+// evaluated. This function returns a slice of maps, each position in the
+// returned slice correspond to one of the classifiers (e.g. if n limits
+// and classifiers are provided, the returned slice will have n maps).
+func Classify[K comparable, V any](
+	values Values[K, V], limits Limits[K, V], classifiers ...Classifier[K, V],
+) []map[K]V {
+	result := make([]map[K]V, len(classifiers))
+	for i := range classifiers {
+		result[i] = make(map[K]V)
+	}
+
+	for index, usage := range values {
+		for i, limit := range limits[index] {
+			if len(classifiers) <= i {
+				continue
+			}
+			if !classifiers[i](index, usage, limit) {
+				continue
+			}
+			result[i][index] = usage
+			break
+		}
+	}
+
+	return result
+}
+
+// ForMap is a function that returns a classifier that compares all values in a
+// map. The function receives a Comparer function that is used to compare all
+// the map values. The returned Classifier will return true only if the
+// provided Comparer function returns a value less than 0 for all the values.
+func ForMap[K, I comparable, V any, M ~map[I]V](cmp Comparer[V]) Classifier[K, M] {
+	return func(_ K, usages, limits M) bool {
+		for idx, usage := range usages {
+			if limit, ok := limits[idx]; ok {
+				if cmp(usage, limit) >= 0 {
+					return false
+				}
+			}
+		}
+		return true
+	}
+}

--- a/pkg/framework/plugins/nodeutilization/classifier/classifier_test.go
+++ b/pkg/framework/plugins/nodeutilization/classifier/classifier_test.go
@@ -1,0 +1,1089 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package classifier
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/descheduler/pkg/api"
+)
+
+func TestClassifySimple(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		usage       map[string]int
+		limits      map[string][]int
+		classifiers []Classifier[string, int]
+		expected    []map[string]int
+	}{
+		{
+			name:     "empty",
+			usage:    map[string]int{},
+			limits:   map[string][]int{},
+			expected: []map[string]int{},
+		},
+		{
+			name: "one under one over",
+			usage: map[string]int{
+				"node1": 2,
+				"node2": 8,
+			},
+			limits: map[string][]int{
+				"node1": {4, 6},
+				"node2": {4, 6},
+			},
+			expected: []map[string]int{
+				{"node1": 2},
+				{"node2": 8},
+			},
+			classifiers: []Classifier[string, int]{
+				func(_ string, usage, limit int) bool {
+					return usage < limit
+				},
+				func(_ string, usage, limit int) bool {
+					return usage > limit
+				},
+			},
+		},
+		{
+			name: "randomly positioned over utilized",
+			usage: map[string]int{
+				"node1": 2,
+				"node2": 8,
+				"node3": 2,
+				"node4": 8,
+				"node5": 8,
+				"node6": 2,
+				"node7": 2,
+				"node8": 8,
+				"node9": 8,
+			},
+			limits: map[string][]int{
+				"node1": {4, 6},
+				"node2": {4, 6},
+				"node3": {4, 6},
+				"node4": {4, 6},
+				"node5": {4, 6},
+				"node6": {4, 6},
+				"node7": {4, 6},
+				"node8": {4, 6},
+				"node9": {4, 6},
+			},
+			expected: []map[string]int{
+				{
+					"node1": 2,
+					"node3": 2,
+					"node6": 2,
+					"node7": 2,
+				},
+				{
+					"node2": 8,
+					"node4": 8,
+					"node5": 8,
+					"node8": 8,
+					"node9": 8,
+				},
+			},
+			classifiers: []Classifier[string, int]{
+				func(_ string, usage, limit int) bool {
+					return usage < limit
+				},
+				func(_ string, usage, limit int) bool {
+					return usage > limit
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Classify(tt.usage, tt.limits, tt.classifiers...)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Fatalf("unexpected result: %v", result)
+			}
+		})
+	}
+}
+
+func TestClassify_pointers(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		usage       map[string]map[v1.ResourceName]*resource.Quantity
+		limits      map[string][]map[v1.ResourceName]*resource.Quantity
+		classifiers []Classifier[string, map[v1.ResourceName]*resource.Quantity]
+		expected    []map[string]map[v1.ResourceName]*resource.Quantity
+	}{
+		{
+			name:     "empty",
+			usage:    map[string]map[v1.ResourceName]*resource.Quantity{},
+			limits:   map[string][]map[v1.ResourceName]*resource.Quantity{},
+			expected: []map[string]map[v1.ResourceName]*resource.Quantity{},
+		},
+		{
+			name: "single underutilized",
+			usage: map[string]map[v1.ResourceName]*resource.Quantity{
+				"node1": {
+					v1.ResourceCPU:    ptr.To(resource.MustParse("2")),
+					v1.ResourceMemory: ptr.To(resource.MustParse("2Gi")),
+				},
+			},
+			limits: map[string][]map[v1.ResourceName]*resource.Quantity{
+				"node1": {
+					{
+						v1.ResourceCPU:    ptr.To(resource.MustParse("4")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("4Gi")),
+					},
+				},
+			},
+			expected: []map[string]map[v1.ResourceName]*resource.Quantity{
+				{
+					"node1": {
+						v1.ResourceCPU:    ptr.To(resource.MustParse("2")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("2Gi")),
+					},
+				},
+			},
+			classifiers: []Classifier[string, map[v1.ResourceName]*resource.Quantity]{
+				ForMap[string, v1.ResourceName, *resource.Quantity, map[v1.ResourceName]*resource.Quantity](
+					func(usage, limit *resource.Quantity) int {
+						return usage.Cmp(*limit)
+					},
+				),
+			},
+		},
+		{
+			name: "single underutilized and properly utilized",
+			usage: map[string]map[v1.ResourceName]*resource.Quantity{
+				"node1": {
+					v1.ResourceCPU:    ptr.To(resource.MustParse("2")),
+					v1.ResourceMemory: ptr.To(resource.MustParse("2Gi")),
+				},
+				"node2": {
+					v1.ResourceCPU:    ptr.To(resource.MustParse("5")),
+					v1.ResourceMemory: ptr.To(resource.MustParse("5Gi")),
+				},
+				"node3": {
+					v1.ResourceCPU:    ptr.To(resource.MustParse("8")),
+					v1.ResourceMemory: ptr.To(resource.MustParse("8Gi")),
+				},
+			},
+			limits: map[string][]map[v1.ResourceName]*resource.Quantity{
+				"node1": {
+					{
+						v1.ResourceCPU:    ptr.To(resource.MustParse("4")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("4Gi")),
+					},
+					{
+						v1.ResourceCPU:    ptr.To(resource.MustParse("16")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("16Gi")),
+					},
+				},
+				"node2": {
+					{
+						v1.ResourceCPU:    ptr.To(resource.MustParse("4")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("4Gi")),
+					},
+					{
+						v1.ResourceCPU:    ptr.To(resource.MustParse("16")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("16Gi")),
+					},
+				},
+				"node3": {
+					{
+						v1.ResourceCPU:    ptr.To(resource.MustParse("4")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("4Gi")),
+					},
+					{
+						v1.ResourceCPU:    ptr.To(resource.MustParse("16")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("16Gi")),
+					},
+				},
+			},
+			expected: []map[string]map[v1.ResourceName]*resource.Quantity{
+				{
+					"node1": {
+						v1.ResourceCPU:    ptr.To(resource.MustParse("2")),
+						v1.ResourceMemory: ptr.To(resource.MustParse("2Gi")),
+					},
+				},
+				{},
+			},
+			classifiers: []Classifier[string, map[v1.ResourceName]*resource.Quantity]{
+				ForMap[string, v1.ResourceName, *resource.Quantity, map[v1.ResourceName]*resource.Quantity](
+					func(usage, limit *resource.Quantity) int {
+						return usage.Cmp(*limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, *resource.Quantity, map[v1.ResourceName]*resource.Quantity](
+					func(usage, limit *resource.Quantity) int {
+						return limit.Cmp(*usage)
+					},
+				),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Classify(tt.usage, tt.limits, tt.classifiers...)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Fatalf("unexpected result: %v", result)
+			}
+		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		usage       map[string]v1.ResourceList
+		limits      map[string][]v1.ResourceList
+		classifiers []Classifier[string, v1.ResourceList]
+		expected    []map[string]v1.ResourceList
+	}{
+		{
+			name:     "empty",
+			usage:    map[string]v1.ResourceList{},
+			limits:   map[string][]v1.ResourceList{},
+			expected: []map[string]v1.ResourceList{},
+		},
+		{
+			name: "single underutilized",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{
+					"node1": {
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+			},
+		},
+		{
+			name: "less classifiers than limits",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+				"node3": {
+					v1.ResourceCPU:    resource.MustParse("8"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("16"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+				"node2": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("16"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+				"node3": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("16"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{
+					"node1": {
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+			},
+		},
+		{
+			name: "more classifiers than limits",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("20"),
+					v1.ResourceMemory: resource.MustParse("20"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("50"),
+					v1.ResourceMemory: resource.MustParse("50"),
+				},
+				"node3": {
+					v1.ResourceCPU:    resource.MustParse("80"),
+					v1.ResourceMemory: resource.MustParse("80"),
+				},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{
+						v1.ResourceCPU:    resource.MustParse("30"),
+						v1.ResourceMemory: resource.MustParse("30"),
+					},
+				},
+				"node2": {
+					{
+						v1.ResourceCPU:    resource.MustParse("30"),
+						v1.ResourceMemory: resource.MustParse("30"),
+					},
+				},
+				"node3": {
+					{
+						v1.ResourceCPU:    resource.MustParse("30"),
+						v1.ResourceMemory: resource.MustParse("30"),
+					},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{
+					"node1": {
+						v1.ResourceCPU:    resource.MustParse("20"),
+						v1.ResourceMemory: resource.MustParse("20"),
+					},
+				},
+				{},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return limit.Cmp(usage)
+					},
+				),
+			},
+		},
+		{
+			name: "single underutilized and properly utilized",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("5Gi"),
+				},
+				"node3": {
+					v1.ResourceCPU:    resource.MustParse("8"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("16"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+				"node2": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("16"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+				"node3": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("16"),
+						v1.ResourceMemory: resource.MustParse("16Gi"),
+					},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{
+					"node1": {
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+				{},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return limit.Cmp(usage)
+					},
+				),
+			},
+		},
+		{
+			name: "single underutilized and multiple over utilized nodes",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("8"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				"node3": {
+					v1.ResourceCPU:    resource.MustParse("8"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("6"),
+						v1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				},
+				"node2": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("6"),
+						v1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				},
+				"node3": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("6"),
+						v1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{
+					"node1": {
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+				{
+					"node2": {
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+					"node3": {
+						v1.ResourceCPU:    resource.MustParse("8"),
+						v1.ResourceMemory: resource.MustParse("8Gi"),
+					},
+				},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return limit.Cmp(usage)
+					},
+				),
+			},
+		},
+		{
+			name: "over and under at the same time",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("6"),
+						v1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				},
+				"node2": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("6"),
+						v1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{},
+				{},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return limit.Cmp(usage)
+					},
+				),
+			},
+		},
+		{
+			name: "only memory over utilized",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("5"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+					{
+						v1.ResourceCPU:    resource.MustParse("6"),
+						v1.ResourceMemory: resource.MustParse("6Gi"),
+					},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{},
+				{},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return limit.Cmp(usage)
+					},
+				),
+			},
+		},
+		{
+			name: "randomly positioned over utilized",
+			usage: map[string]v1.ResourceList{
+				"node1": {v1.ResourceCPU: resource.MustParse("8")},
+				"node2": {v1.ResourceCPU: resource.MustParse("2")},
+				"node3": {v1.ResourceCPU: resource.MustParse("8")},
+				"node4": {v1.ResourceCPU: resource.MustParse("2")},
+				"node5": {v1.ResourceCPU: resource.MustParse("8")},
+				"node6": {v1.ResourceCPU: resource.MustParse("8")},
+				"node7": {v1.ResourceCPU: resource.MustParse("8")},
+				"node8": {v1.ResourceCPU: resource.MustParse("2")},
+				"node9": {v1.ResourceCPU: resource.MustParse("5")},
+			},
+			limits: map[string][]v1.ResourceList{
+				"node1": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node2": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node3": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node4": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node5": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node6": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node7": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node8": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+				"node9": {
+					{v1.ResourceCPU: resource.MustParse("4")},
+					{v1.ResourceCPU: resource.MustParse("6")},
+				},
+			},
+			expected: []map[string]v1.ResourceList{
+				{
+					"node2": {v1.ResourceCPU: resource.MustParse("2")},
+					"node4": {v1.ResourceCPU: resource.MustParse("2")},
+					"node8": {v1.ResourceCPU: resource.MustParse("2")},
+				},
+				{
+					"node1": {v1.ResourceCPU: resource.MustParse("8")},
+					"node3": {v1.ResourceCPU: resource.MustParse("8")},
+					"node5": {v1.ResourceCPU: resource.MustParse("8")},
+					"node6": {v1.ResourceCPU: resource.MustParse("8")},
+					"node7": {v1.ResourceCPU: resource.MustParse("8")},
+				},
+			},
+			classifiers: []Classifier[string, v1.ResourceList]{
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return usage.Cmp(limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList](
+					func(usage, limit resource.Quantity) int {
+						return limit.Cmp(usage)
+					},
+				),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Classify(tt.usage, tt.limits, tt.classifiers...)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Fatalf("unexpected result: %v", result)
+			}
+		})
+	}
+}
+
+func TestNormalizeAndClassify(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		usage       map[string]v1.ResourceList
+		totals      map[string]v1.ResourceList
+		thresholds  map[string][]api.ResourceThresholds
+		expected    []map[string]api.ResourceThresholds
+		classifiers []Classifier[string, api.ResourceThresholds]
+	}{
+		{
+			name: "happy path test",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					// underutilized on cpu and memory.
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("10"),
+				},
+				"node2": {
+					// overutilized on cpu and memory.
+					v1.ResourceCPU:    resource.MustParse("90"),
+					v1.ResourceMemory: resource.MustParse("90"),
+				},
+				"node3": {
+					// properly utilized on cpu and memory.
+					v1.ResourceCPU:    resource.MustParse("50"),
+					v1.ResourceMemory: resource.MustParse("50"),
+				},
+				"node4": {
+					// underutilized on cpu and overutilized on memory.
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("90"),
+				},
+			},
+			totals: Replicate(
+				[]string{"node1", "node2", "node3", "node4"},
+				v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100"),
+					v1.ResourceMemory: resource.MustParse("100"),
+				},
+			),
+			thresholds: Replicate(
+				[]string{"node1", "node2", "node3", "node4"},
+				[]api.ResourceThresholds{
+					{v1.ResourceCPU: 20, v1.ResourceMemory: 20},
+					{v1.ResourceCPU: 80, v1.ResourceMemory: 80},
+				},
+			),
+			expected: []map[string]api.ResourceThresholds{
+				{
+					"node1": {v1.ResourceCPU: 10, v1.ResourceMemory: 10},
+				},
+				{
+					"node2": {v1.ResourceCPU: 90, v1.ResourceMemory: 90},
+				},
+			},
+			classifiers: []Classifier[string, api.ResourceThresholds]{
+				ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+					func(usage, limit api.Percentage) int {
+						return int(usage - limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+					func(usage, limit api.Percentage) int {
+						return int(limit - usage)
+					},
+				),
+			},
+		},
+		{
+			name: "three thresholds",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					// match for the first classifier.
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("10"),
+				},
+				"node2": {
+					// match for the third classifier.
+					v1.ResourceCPU:    resource.MustParse("90"),
+					v1.ResourceMemory: resource.MustParse("90"),
+				},
+				"node3": {
+					// match fo the second classifier.
+					v1.ResourceCPU:    resource.MustParse("40"),
+					v1.ResourceMemory: resource.MustParse("40"),
+				},
+				"node4": {
+					// matches no classifier.
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("90"),
+				},
+				"node5": {
+					// match for the first classifier.
+					v1.ResourceCPU:    resource.MustParse("11"),
+					v1.ResourceMemory: resource.MustParse("18"),
+				},
+			},
+			totals: Replicate(
+				[]string{"node1", "node2", "node3", "node4", "node5"},
+				v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100"),
+					v1.ResourceMemory: resource.MustParse("100"),
+				},
+			),
+			thresholds: Replicate(
+				[]string{"node1", "node2", "node3", "node4", "node5"},
+				[]api.ResourceThresholds{
+					{v1.ResourceCPU: 20, v1.ResourceMemory: 20},
+					{v1.ResourceCPU: 50, v1.ResourceMemory: 50},
+					{v1.ResourceCPU: 80, v1.ResourceMemory: 80},
+				},
+			),
+			expected: []map[string]api.ResourceThresholds{
+				{
+					"node1": {v1.ResourceCPU: 10, v1.ResourceMemory: 10},
+					"node5": {v1.ResourceCPU: 11, v1.ResourceMemory: 18},
+				},
+				{
+					"node3": {v1.ResourceCPU: 40, v1.ResourceMemory: 40},
+				},
+				{
+					"node2": {v1.ResourceCPU: 90, v1.ResourceMemory: 90},
+				},
+			},
+			classifiers: []Classifier[string, api.ResourceThresholds]{
+				ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+					func(usage, limit api.Percentage) int {
+						return int(usage - limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+					func(usage, limit api.Percentage) int {
+						return int(usage - limit)
+					},
+				),
+				ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+					func(usage, limit api.Percentage) int {
+						return int(limit - usage)
+					},
+				),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			pct := Normalize(tt.usage, tt.totals, ResourceUsageNormalizer)
+			res := Classify(pct, tt.thresholds, tt.classifiers...)
+			if !reflect.DeepEqual(res, tt.expected) {
+				t.Fatalf("unexpected result: %v, expecting: %v", res, tt.expected)
+			}
+		})
+	}
+}
+
+// This is a test for thresholds being defined as deviations from the average
+// usage. This is expected to be a little longer test case. We are going to
+// comment the steps to make it easier to follow.
+func TestUsingDeviationThresholds(t *testing.T) {
+	// These are the two thresholds defined by the user. We are using
+	// negative values here to compute the deviation from the average.
+	// Users provide these as positive values. This needs to be taken
+	// into account. These thresholds mean that our low limit will be
+	// 5 pct points below the average and the high limit will be 5 pct
+	// points above the average.
+	userDefinedThresholds := map[string]api.ResourceThresholds{
+		"low":  {v1.ResourceCPU: -5, v1.ResourceMemory: -5},
+		"high": {v1.ResourceCPU: 5, v1.ResourceMemory: 5},
+	}
+
+	// Create a fake total amount of resources for all nodes. We define
+	// the total amount to 1000 for both memory and cpu. This is so we
+	// can easily calculate (manually) the percentage of usages here.
+	nodesTotal := Replicate(
+		[]string{"node1", "node2", "node3", "node4", "node5"},
+		v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1000"),
+			v1.ResourceMemory: resource.MustParse("1000"),
+		},
+	)
+
+	// Create a fake usage per server per resource. We are aiming to
+	// have the average of these resources in 50%. When applying the
+	// thresholds we should obtain the low threhold at 45% and the high
+	// threshold at 55%.
+	nodesUsage := map[string]v1.ResourceList{
+		"node1": {
+			v1.ResourceCPU:    resource.MustParse("100"),
+			v1.ResourceMemory: resource.MustParse("100"),
+		},
+		"node2": {
+			v1.ResourceCPU:    resource.MustParse("480"),
+			v1.ResourceMemory: resource.MustParse("480"),
+		},
+		"node3": {
+			v1.ResourceCPU:    resource.MustParse("520"),
+			v1.ResourceMemory: resource.MustParse("520"),
+		},
+		"node4": {
+			v1.ResourceCPU:    resource.MustParse("500"),
+			v1.ResourceMemory: resource.MustParse("500"),
+		},
+		"node5": {
+			v1.ResourceCPU:    resource.MustParse("900"),
+			v1.ResourceMemory: resource.MustParse("900"),
+		},
+	}
+
+	// Normalize the usage to percentages and then calculate the average
+	// among all nodes.
+	usage := Normalize(nodesUsage, nodesTotal, ResourceUsageNormalizer)
+	average := Average(usage)
+
+	// Create the thresholds by first applying the deviations and then
+	// replicating once for each node. Thresholds are supposed to be per
+	// node even though the user provides them only once. This is by
+	// design as it opens the possibility for further implementations of
+	// thresholds per node.
+	thresholds := Replicate(
+		[]string{"node1", "node2", "node3", "node4", "node5"},
+		Deviate(
+			average,
+			[]api.ResourceThresholds{
+				userDefinedThresholds["low"],
+				userDefinedThresholds["high"],
+			},
+		),
+	)
+
+	// Classify the nodes according to the thresholds. Nodes below the low
+	// threshold (45%) are underutilized, nodes above the high threshold
+	// (55%) are overutilized and nodes in between are properly utilized.
+	result := Classify(
+		usage, thresholds,
+		ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+			func(usage, limit api.Percentage) int {
+				return int(usage - limit)
+			},
+		),
+		ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+			func(usage, limit api.Percentage) int {
+				return int(limit - usage)
+			},
+		),
+	)
+
+	// we expect the node1 to be undertilized (10%), node2, node3 and node4
+	// to be properly utilized (48%, 52% and 50% respectively) and node5 to
+	// be overutilized (90%).
+	expected := []map[string]api.ResourceThresholds{
+		{"node1": {v1.ResourceCPU: 10, v1.ResourceMemory: 10}},
+		{"node5": {v1.ResourceCPU: 90, v1.ResourceMemory: 90}},
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("unexpected result: %v, expecting: %v", result, expected)
+	}
+}
+
+// This is almost a copy of TestUsingDeviationThresholds but we are using
+// pointers here. This is for making sure our generic types are in check. To
+// understand this code better read comments on TestUsingDeviationThresholds.
+func TestUsingDeviationThresholdsWithPointers(t *testing.T) {
+	userDefinedThresholds := map[string]api.ResourceThresholds{
+		"low":  {v1.ResourceCPU: -5, v1.ResourceMemory: -5},
+		"high": {v1.ResourceCPU: 5, v1.ResourceMemory: 5},
+	}
+
+	nodesTotal := Replicate(
+		[]string{"node1", "node2", "node3", "node4", "node5"},
+		map[v1.ResourceName]*resource.Quantity{
+			v1.ResourceCPU:    ptr.To(resource.MustParse("1000")),
+			v1.ResourceMemory: ptr.To(resource.MustParse("1000")),
+		},
+	)
+
+	nodesUsage := map[string]map[v1.ResourceName]*resource.Quantity{
+		"node1": {
+			v1.ResourceCPU:    ptr.To(resource.MustParse("100")),
+			v1.ResourceMemory: ptr.To(resource.MustParse("100")),
+		},
+		"node2": {
+			v1.ResourceCPU:    ptr.To(resource.MustParse("480")),
+			v1.ResourceMemory: ptr.To(resource.MustParse("480")),
+		},
+		"node3": {
+			v1.ResourceCPU:    ptr.To(resource.MustParse("520")),
+			v1.ResourceMemory: ptr.To(resource.MustParse("520")),
+		},
+		"node4": {
+			v1.ResourceCPU:    ptr.To(resource.MustParse("500")),
+			v1.ResourceMemory: ptr.To(resource.MustParse("500")),
+		},
+		"node5": {
+			v1.ResourceCPU:    ptr.To(resource.MustParse("900")),
+			v1.ResourceMemory: ptr.To(resource.MustParse("900")),
+		},
+	}
+
+	ptrNormalizer := func(
+		usages, totals map[v1.ResourceName]*resource.Quantity,
+	) api.ResourceThresholds {
+		newUsages := v1.ResourceList{}
+		for name, usage := range usages {
+			newUsages[name] = *usage
+		}
+		newTotals := v1.ResourceList{}
+		for name, total := range totals {
+			newTotals[name] = *total
+		}
+		return ResourceUsageNormalizer(newUsages, newTotals)
+	}
+
+	usage := Normalize(nodesUsage, nodesTotal, ptrNormalizer)
+	average := Average(usage)
+
+	thresholds := Replicate(
+		[]string{"node1", "node2", "node3", "node4", "node5"},
+		Deviate(
+			average,
+			[]api.ResourceThresholds{
+				userDefinedThresholds["low"],
+				userDefinedThresholds["high"],
+			},
+		),
+	)
+
+	result := Classify(
+		usage, thresholds,
+		ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+			func(usage, limit api.Percentage) int {
+				return int(usage - limit)
+			},
+		),
+		ForMap[string, v1.ResourceName, api.Percentage, api.ResourceThresholds](
+			func(usage, limit api.Percentage) int {
+				return int(limit - usage)
+			},
+		),
+	)
+
+	expected := []map[string]api.ResourceThresholds{
+		{"node1": {v1.ResourceCPU: 10, v1.ResourceMemory: 10}},
+		{"node5": {v1.ResourceCPU: 90, v1.ResourceMemory: 90}},
+	}
+
+	if !reflect.DeepEqual(result, expected) {
+		t.Fatalf("unexpected result: %v, expecting: %v", result, expected)
+	}
+}

--- a/pkg/framework/plugins/nodeutilization/classifier/normalizer.go
+++ b/pkg/framework/plugins/nodeutilization/classifier/normalizer.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package classifier
+
+import (
+	"golang.org/x/exp/constraints"
+)
+
+// Normalizer is a function that receives two values of the same type and
+// return an object of a different type. An usage case can be a function
+// that converts a memory usage from mb to % (the first argument would be
+// the memory usage in mb and the second argument would be the total memory
+// available in mb).
+type Normalizer[V, N any] func(V, V) N
+
+// Number is an interface that represents a number. Represents things we
+// can do math operations on.
+type Number interface {
+	constraints.Integer | constraints.Float
+}
+
+// Normalize uses a Normalizer function to normalize a set of values. For
+// example one may want to convert a set of memory usages from mb to %.
+// This function receives a set of usages, a set of totals, and a Normalizer
+// function. The function will return a map with the normalized values.
+func Normalize[K comparable, V, N any](usages, totals Values[K, V], fn Normalizer[V, N]) map[K]N {
+	result := Values[K, N]{}
+	for key, value := range usages {
+		total, ok := totals[key]
+		if !ok {
+			continue
+		}
+
+		result[key] = fn(value, total)
+	}
+	return result
+}
+
+// Replicate replicates the provide value for each key in the provided slice.
+// Returns a map with the keys and the provided value.
+func Replicate[K comparable, V any](keys []K, value V) map[K]V {
+	result := map[K]V{}
+	for _, key := range keys {
+		result[key] = value
+	}
+	return result
+}
+
+// Deviate receives an object and a list of "deviations", returns an slice with
+// returns an slice of the same input where the internal value is added to each
+// deviation. Negative deviations are allowed.
+func Deviate[K comparable, N Number, V ~map[K]N](values V, deviations []V) []V {
+	result := []V{}
+	for _, dev := range deviations {
+		current := V{}
+		for name, value := range values {
+			current[name] = value + dev[name]
+		}
+		result = append(result, current)
+	}
+	return result
+}
+
+// Average calculates the average of a set of values. This function receives
+// a map of values and returns the average of all the values. Average expects
+// the values to represent the same unit of measure. You can use this function
+// after Normalizing the values.
+func Average[J, K comparable, N Number, V ~map[J]N](values map[K]V) V {
+	result := V{}
+	for _, imap := range values {
+		for name, value := range imap {
+			result[name] += value
+		}
+	}
+
+	for name := range result {
+		result[name] /= N(len(values))
+	}
+
+	return result
+}

--- a/pkg/framework/plugins/nodeutilization/classifier/normalizer_test.go
+++ b/pkg/framework/plugins/nodeutilization/classifier/normalizer_test.go
@@ -1,0 +1,480 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package classifier
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/descheduler/pkg/api"
+)
+
+// ResourceUsageNormalizer is an implementation of a Normalizer that converts a
+// set of resource usages and totals into percentage. Returns an error if the
+// total for a given resource is not found. This function operates on Quantity
+// Value() for all the resources except CPU, where it uses MilliValue(). This
+// is here just to be used during testing.
+func ResourceUsageNormalizer(usages, totals v1.ResourceList) api.ResourceThresholds {
+	result := api.ResourceThresholds{}
+	for rname, value := range usages {
+		total, ok := totals[rname]
+		if !ok {
+			continue
+		}
+
+		used, avail := value.Value(), total.Value()
+		if rname == v1.ResourceCPU {
+			used, avail = value.MilliValue(), total.MilliValue()
+		}
+
+		pct := math.Max(math.Min(float64(used)/float64(avail)*100, 100), 0)
+		result[rname] = api.Percentage(pct)
+	}
+	return result
+}
+
+func TestNormalizeSimple(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		usages     map[string]float64
+		totals     map[string]float64
+		expected   map[string]float64
+		normalizer Normalizer[float64, float64]
+	}{
+		{
+			name:     "single normalization",
+			usages:   map[string]float64{"cpu": 1},
+			totals:   map[string]float64{"cpu": 2},
+			expected: map[string]float64{"cpu": 0.5},
+			normalizer: func(usage, total float64) float64 {
+				return usage / total
+			},
+		},
+		{
+			name: "multiple normalizations",
+			usages: map[string]float64{
+				"cpu": 1,
+				"mem": 6,
+			},
+			totals: map[string]float64{
+				"cpu": 2,
+				"mem": 10,
+			},
+			expected: map[string]float64{
+				"cpu": 0.5,
+				"mem": 0.6,
+			},
+			normalizer: func(usage, total float64) float64 {
+				return usage / total
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Normalize(tt.usages, tt.totals, tt.normalizer)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Fatalf("unexpected result: %v", result)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		usages     map[string]v1.ResourceList
+		totals     map[string]v1.ResourceList
+		expected   map[string]api.ResourceThresholds
+		normalizer Normalizer[v1.ResourceList, api.ResourceThresholds]
+	}{
+		{
+			name: "single normalization",
+			usages: map[string]v1.ResourceList{
+				"node1": {v1.ResourceCPU: resource.MustParse("1")},
+			},
+			totals: map[string]v1.ResourceList{
+				"node1": {v1.ResourceCPU: resource.MustParse("2")},
+			},
+			expected: map[string]api.ResourceThresholds{
+				"node1": {v1.ResourceCPU: 50},
+			},
+			normalizer: ResourceUsageNormalizer,
+		},
+		{
+			name: "multiple normalization",
+			usages: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("6"),
+					v1.ResourcePods:   resource.MustParse("2"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("20"),
+					v1.ResourcePods:   resource.MustParse("30"),
+				},
+			},
+			totals: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("6"),
+					v1.ResourcePods:   resource.MustParse("100"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("100"),
+					v1.ResourceMemory: resource.MustParse("100"),
+					v1.ResourcePods:   resource.MustParse("100"),
+				},
+			},
+			expected: map[string]api.ResourceThresholds{
+				"node1": {
+					v1.ResourceCPU:    50,
+					v1.ResourceMemory: 100,
+					v1.ResourcePods:   2,
+				},
+				"node2": {
+					v1.ResourceCPU:    10,
+					v1.ResourceMemory: 20,
+					v1.ResourcePods:   30,
+				},
+			},
+			normalizer: ResourceUsageNormalizer,
+		},
+		{
+			name: "multiple normalization with over 100% usage",
+			usages: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("120"),
+					v1.ResourceMemory: resource.MustParse("130"),
+					v1.ResourcePods:   resource.MustParse("140"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("150"),
+					v1.ResourceMemory: resource.MustParse("160"),
+					v1.ResourcePods:   resource.MustParse("170"),
+				},
+			},
+			totals: Replicate(
+				[]string{"node1", "node2"},
+				v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100"),
+					v1.ResourceMemory: resource.MustParse("100"),
+					v1.ResourcePods:   resource.MustParse("100"),
+				},
+			),
+			expected: Replicate(
+				[]string{"node1", "node2"},
+				api.ResourceThresholds{
+					v1.ResourceCPU:    100,
+					v1.ResourceMemory: 100,
+					v1.ResourcePods:   100,
+				},
+			),
+			normalizer: ResourceUsageNormalizer,
+		},
+		{
+			name: "multiple normalization with over 100% usage and different totals",
+			usages: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("99"),
+					v1.ResourceMemory: resource.MustParse("99Gi"),
+				},
+				"node3": {
+					v1.ResourceCPU:    resource.MustParse("8"),
+					v1.ResourceMemory: resource.MustParse("8Gi"),
+				},
+			},
+			totals: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("100"),
+					v1.ResourceMemory: resource.MustParse("100Gi"),
+				},
+				"node3": {
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
+			expected: map[string]api.ResourceThresholds{
+				"node1": {
+					v1.ResourceCPU:    50,
+					v1.ResourceMemory: 50,
+				},
+				"node2": {
+					v1.ResourceCPU:    99,
+					v1.ResourceMemory: 99,
+				},
+				"node3": {
+					v1.ResourceCPU:    100,
+					v1.ResourceMemory: 100,
+				},
+			},
+			normalizer: ResourceUsageNormalizer,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Normalize(tt.usages, tt.totals, tt.normalizer)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Fatalf("unexpected result: %v", result)
+			}
+		})
+	}
+}
+
+func TestAverage(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		usage    map[string]v1.ResourceList
+		limits   map[string]v1.ResourceList
+		expected api.ResourceThresholds
+	}{
+		{
+			name:     "empty usage",
+			usage:    map[string]v1.ResourceList{},
+			limits:   map[string]v1.ResourceList{},
+			expected: api.ResourceThresholds{},
+		},
+		{
+			name: "fifty percent usage",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("6"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("6"),
+				},
+			},
+			limits: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("12"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("12"),
+				},
+			},
+			expected: api.ResourceThresholds{
+				v1.ResourceCPU:    50,
+				v1.ResourceMemory: 50,
+			},
+		},
+		{
+			name: "mixed percent usage",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("80"),
+					v1.ResourcePods:   resource.MustParse("20"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("20"),
+					v1.ResourceMemory: resource.MustParse("60"),
+					v1.ResourcePods:   resource.MustParse("20"),
+				},
+			},
+			limits: Replicate(
+				[]string{"node1", "node2"},
+				v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("100"),
+					v1.ResourceMemory: resource.MustParse("100"),
+					v1.ResourcePods:   resource.MustParse("10000"),
+				},
+			),
+			expected: api.ResourceThresholds{
+				v1.ResourceCPU:    15,
+				v1.ResourceMemory: 70,
+				v1.ResourcePods:   0.2,
+			},
+		},
+		{
+			name: "mixed limits",
+			usage: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("30"),
+					v1.ResourcePods:   resource.MustParse("200"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("72"),
+					v1.ResourcePods:   resource.MustParse("200"),
+				},
+			},
+			limits: map[string]v1.ResourceList{
+				"node1": {
+					v1.ResourceCPU:    resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("100"),
+					v1.ResourcePods:   resource.MustParse("1000"),
+				},
+				"node2": {
+					v1.ResourceCPU:    resource.MustParse("1000"),
+					v1.ResourceMemory: resource.MustParse("180"),
+					v1.ResourcePods:   resource.MustParse("10"),
+				},
+			},
+			expected: api.ResourceThresholds{
+				v1.ResourceCPU:    50.5,
+				v1.ResourceMemory: 35,
+				v1.ResourcePods:   60,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			average := Average(Normalize(tt.usage, tt.limits, ResourceUsageNormalizer))
+			if !reflect.DeepEqual(average, tt.expected) {
+				t.Fatalf("unexpected result: %v, expected: %v", average, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDeviate(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		data       api.ResourceThresholds
+		deviations []api.ResourceThresholds
+		expected   []api.ResourceThresholds
+	}{
+		{
+			name: "single deviation",
+			data: api.ResourceThresholds{
+				v1.ResourceCPU:    50,
+				v1.ResourceMemory: 50,
+				v1.ResourcePods:   50,
+			},
+			deviations: []api.ResourceThresholds{
+				{
+					v1.ResourceCPU:    1,
+					v1.ResourceMemory: 1,
+					v1.ResourcePods:   1,
+				},
+				{
+					v1.ResourceCPU:    2,
+					v1.ResourceMemory: 2,
+					v1.ResourcePods:   2,
+				},
+				{
+					v1.ResourceCPU:    3,
+					v1.ResourceMemory: 3,
+					v1.ResourcePods:   3,
+				},
+			},
+			expected: []api.ResourceThresholds{
+				{
+					v1.ResourceCPU:    51,
+					v1.ResourceMemory: 51,
+					v1.ResourcePods:   51,
+				},
+				{
+					v1.ResourceCPU:    52,
+					v1.ResourceMemory: 52,
+					v1.ResourcePods:   52,
+				},
+				{
+					v1.ResourceCPU:    53,
+					v1.ResourceMemory: 53,
+					v1.ResourcePods:   53,
+				},
+			},
+		},
+		{
+			name: "deviate with negative values",
+			data: api.ResourceThresholds{
+				v1.ResourceCPU:    50,
+				v1.ResourceMemory: 50,
+				v1.ResourcePods:   50,
+			},
+			deviations: []api.ResourceThresholds{
+				{
+					v1.ResourceCPU:    -2,
+					v1.ResourceMemory: -2,
+					v1.ResourcePods:   -2,
+				},
+				{
+					v1.ResourceCPU:    -1,
+					v1.ResourceMemory: -1,
+					v1.ResourcePods:   -1,
+				},
+				{
+					v1.ResourceCPU:    0,
+					v1.ResourceMemory: 0,
+					v1.ResourcePods:   0,
+				},
+				{
+					v1.ResourceCPU:    1,
+					v1.ResourceMemory: 1,
+					v1.ResourcePods:   1,
+				},
+				{
+					v1.ResourceCPU:    2,
+					v1.ResourceMemory: 2,
+					v1.ResourcePods:   2,
+				},
+			},
+			expected: []api.ResourceThresholds{
+				{
+					v1.ResourceCPU:    48,
+					v1.ResourceMemory: 48,
+					v1.ResourcePods:   48,
+				},
+				{
+					v1.ResourceCPU:    49,
+					v1.ResourceMemory: 49,
+					v1.ResourcePods:   49,
+				},
+				{
+					v1.ResourceCPU:    50,
+					v1.ResourceMemory: 50,
+					v1.ResourcePods:   50,
+				},
+				{
+					v1.ResourceCPU:    51,
+					v1.ResourceMemory: 51,
+					v1.ResourcePods:   51,
+				},
+				{
+					v1.ResourceCPU:    52,
+					v1.ResourceMemory: 52,
+					v1.ResourcePods:   52,
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Deviate(tt.data, tt.deviations)
+			if len(result) != len(tt.deviations) {
+				t.Fatalf("unexpected result: %v", result)
+			}
+			if !reflect.DeepEqual(result, tt.expected) {
+				fmt.Printf("%T, %T\n", result, tt.expected)
+				t.Fatalf("unexpected result: %v", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> [!NOTE]  
> The code introduced by this PR isn't in use yet. I will have a follow up PR to migrate the `nodeutilization` plugin to start using this new engine. Raising this now so I can have others looking into it. 

Implements a new node usage classifier. This new classifier works with two maps of any data types. Maps are indexed by an arbitrary string.

As an usage example this is how one can filter out for usages using a list of thresholds:

```go
result, err := classifier.Classify(
	// first argument is a list of arbitrary usages.
	map[string]v1.ResourceList{
		"node1": {
			v1.ResourceCPU:    ptr.To(resource.MustParse("2")),
			v1.ResourceMemory: ptr.To(resource.MustParse("2Gi")),
		},
		...
	},
	// second argument is a list of thresholds, also indexed by an
	// arbitrary string. both collected usage and the thresholds
	// must be of the same time (on this case v1.ResourceList).
	map[string][]v1.ResourceList{
		"node1": {
			{
				v1.ResourceCPU:    ptr.To(resource.MustParse("4")),
				v1.ResourceMemory: ptr.To(resource.MustParse("4Gi")),
			},
			{
				v1.ResourceCPU:    ptr.To(resource.MustParse("16")),
				v1.ResourceMemory: ptr.To(resource.MustParse("16Gi")),
			},
		},
		...
	},
	// the third (and subsequent) argument is a list of classifiers.
	// one classifier must be provided for each threshold present in
	// each of the thresholds.
	classifier.ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList(
		func(usage, limit resource.Quantity) int {
			return usage.Cmp(limit)
		},
	),
	classifier.ForMap[string, v1.ResourceName, resource.Quantity, v1.ResourceList(
		func(usage, limit resource.Quantity) int {
			return limit.Cmp(usage)
		},
	),
)
```

Classify() returns a slice of maps. Each position in the returned slice correspond to one of the provided Classifiers. i.e. if n classifiers were provided then the returned value will contain n positions.

## Generic Data Types

Everything must start with a list of values we want to classify. `Values` is a map of "values" (e.g. node cpu usages) indexed by an arbitrary key (e.g. node names):

```go
type Values[K comparable, V any] map[K]V
```

With the values at hand we now need some limits to operate upon (e.g. cpu thresholds for a node). We may have different thresholds as well (e.g. a bottom and a top limits for cpu usage). `Limits` is a list of one or more limits (e.g. cpu load thresholds) indexed by an arbitrary key:

```go
type Limits[K comparable, V any] map[K][]V
```

Now with values and limits defined we need to define a function that classify the values. `Classifier` is defined as a function that upon receiving an index and two arguments (the `Value` and the `Limit`) of the same type return a boolean. If the returned value is `true` then the item has been classified by the function and so belongs to that specific group.

```go
type Classifier[K comparable, V any] func(K, V, V) bool
```

> [!IMPORTANT]
> `Values` are compared against `Limits` using the index key. Multiple `Limits` may exist for a given `Value` but for each `Limit` a `Classifier` is expected to be passed in.

## Notes

- This new classification engine supports different thresholds per Node.
- This new classification engine supports more than two thresholds (today we only use `low` and `high`).
- For a good usage example please look at the [TestUsingDeviationThresholds](https://github.com/kubernetes-sigs/descheduler/pull/1648/files#diff-6d7cff398892b6b18ef7e4bd379d7fa0356f73d89a8c74798c8ac5d60c09daacR898) test.