### PR TITLE
docs: add histogram metric README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,10 +1029,12 @@ To get best results from HA mode some additional configurations might require:
 
 ## Metrics
 
-| name	| type	| description |
-|-------|-------|----------------|
-| build_info |	gauge |	constant 1 |
-| pods_evicted | CounterVec | total number of pods evicted |
+| name	                                 | type	        | description                                                                       |
+|---------------------------------------|--------------|-----------------------------------------------------------------------------------|
+| build_info                            | 	gauge       | 	constant 1                                                                       |
+| pods_evicted                          | CounterVec   | total number of pods evicted                                                      |
+| descheduler_loop_duration_seconds     | HistogramVec | time taken to complete a whole descheduling cycle (support _bucket, _sum, _count) |
+| descheduler_strategy_duration_seconds | HistogramVec | time taken to complete each stragtegy of descheduling operation (support _bucket, _sum, _count) |
 
 The metrics are served through https://localhost:10258/metrics by default.
 The address and port can be changed by setting `--binding-address` and `--secure-port` flags.


### PR DESCRIPTION
Im using two histrogram metric for monitoring descheduler.
But, there are no documentation of these metrics.
Thus, add "descheduler_loop_duration_seconds" and "descheduler_strategy_duration_seconds" on README.md 