### PR TITLE
nominate googs1025 for descheduler reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,6 +13,7 @@ reviewers:
 - janeliul
 - knelasevero
 - jklaw90
+- googs1025
 emeritus_approvers:
 - aveshagarwal
 - k82cn


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
To become more deeply involved in community contributions, I'd like to nominate myself to the list of the descheduler reviewers:

https://github.com/kubernetes/org/issues/4921
[15 PRs merged in descheduler](https://github.com/kubernetes-sigs/descheduler/pulls?q=is%3Amerged+author%3Agoogs1025+is%3Aclosed+)
