### PR TITLE
chore: log average and assessed thresholds

### DIFF
--- a/pkg/framework/plugins/nodeutilization/highnodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization.go
@@ -74,13 +74,6 @@ func NewHighNodeUtilization(
 		highThresholds[rname] = MaxResourcePercentage
 	}
 
-	// criteria is a list of thresholds that are used to determine if a node
-	// is underutilized. it is used only for logging purposes.
-	criteria := []any{}
-	for rname, rvalue := range args.Thresholds {
-		criteria = append(criteria, rname, rvalue)
-	}
-
 	podFilter, err := podutil.
 		NewOptions().
 		WithFilter(handle.Evictor().Filter).
@@ -106,7 +99,7 @@ func NewHighNodeUtilization(
 		args:           args,
 		resourceNames:  resourceNames,
 		highThresholds: highThresholds,
-		criteria:       criteria,
+		criteria:       thresholdsToKeysAndValues(args.Thresholds),
 		podFilter:      podFilter,
 		usageClient: newRequestedUsageClient(
 			resourceNames,

--- a/pkg/framework/plugins/nodeutilization/lownodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/lownodeutilization.go
@@ -92,16 +92,6 @@ func NewLowNodeUtilization(
 		)
 	}
 
-	// underCriteria and overCriteria are slices used for logging purposes.
-	// we assemble them only once.
-	underCriteria, overCriteria := []any{}, []any{}
-	for name := range args.Thresholds {
-		underCriteria = append(underCriteria, name, args.Thresholds[name])
-	}
-	for name := range args.TargetThresholds {
-		overCriteria = append(overCriteria, name, args.TargetThresholds[name])
-	}
-
 	podFilter, err := podutil.
 		NewOptions().
 		WithFilter(handle.Evictor().Filter).
@@ -127,8 +117,8 @@ func NewLowNodeUtilization(
 	return &LowNodeUtilization{
 		handle:                handle,
 		args:                  args,
-		underCriteria:         underCriteria,
-		overCriteria:          overCriteria,
+		underCriteria:         thresholdsToKeysAndValues(args.Thresholds),
+		overCriteria:          thresholdsToKeysAndValues(args.TargetThresholds),
 		resourceNames:         resourceNames,
 		extendedResourceNames: extendedResourceNames,
 		podFilter:             podFilter,


### PR DESCRIPTION
when calculating the average an applying the deviations it would be nice to also see the assessed values.

this commit makes the descheduler logs these values when using level 3.