### PR TITLE
feat: introduce strict eviction policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ strategy evicts pods from `underutilized nodes` (those with usage below `thresho
 so that they can be recreated in appropriately utilized nodes.
 The strategy will abort if any number of `underutilized nodes` or `appropriately utilized nodes` is zero.
 
+To control pod eviction from underutilized nodes, use the `evictionModes`
+array. A lenient policy, which evicts pods regardless of their resource
+requests, is the default. To enable a stricter policy that only evicts pods
+with resource requests defined for the provided threshold resources, add the
+option `OnlyThresholdingResources` to the `evictionModes` configuration.
+
 **NOTE:** Node resource consumption is determined by the requests and limits of pods, not actual usage.
 This approach is chosen in order to maintain consistency with the kube-scheduler, which follows the same
 design for scheduling pods onto nodes. This means that resource usage as reported by Kubelet (or commands
@@ -417,7 +423,14 @@ actual usage metrics. Implementing metrics-based descheduling is currently TODO 
 |---|---|
 |`thresholds`|map(string:int)|
 |`numberOfNodes`|int|
+|`evictionModes`|list(string)|
 |`evictableNamespaces`|(see [namespace filtering](#namespace-filtering))|
+
+**Supported Eviction Modes:**
+
+|Name|Description|
+|---|---|
+|`OnlyThresholdingResources`|Evict only pods that have resource requests defined for the provided threshold resources.|
 
 **Example:**
 
@@ -437,6 +450,8 @@ profiles:
           exclude:
           - "kube-system"
           - "namespace1"
+        evictionModes:
+          - "OnlyThresholdingResources"
     plugins:
       balance:
         enabled:

--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	nodeutil "sigs.k8s.io/descheduler/pkg/descheduler/node"
+	"sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/nodeutilization/normalizer"
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
@@ -751,4 +752,20 @@ func assessAvailableResourceInNodes(
 	}
 
 	return available, nil
+}
+
+// withResourceRequestForAny returns a filter function that checks if a pod
+// has a resource request specified for any of the given resources names.
+func withResourceRequestForAny(names ...v1.ResourceName) pod.FilterFunc {
+	return func(pod *v1.Pod) bool {
+		all := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+		for _, name := range names {
+			for _, container := range all {
+				if _, ok := container.Resources.Requests[name]; ok {
+					return true
+				}
+			}
+		}
+		return false
+	}
 }

--- a/pkg/framework/plugins/nodeutilization/types.go
+++ b/pkg/framework/plugins/nodeutilization/types.go
@@ -18,6 +18,18 @@ import (
 	"sigs.k8s.io/descheduler/pkg/api"
 )
 
+// EvictionMode describe a mode of eviction. See the list below for the
+// available modes.
+type EvictionMode string
+
+const (
+	// EvictionModeOnlyThresholdingResources makes the descheduler evict
+	// only pods that have a resource request defined for any of the user
+	// provided thresholds. If the pod does not request the resource, it
+	// will not be evicted.
+	EvictionModeOnlyThresholdingResources EvictionMode = "OnlyThresholdingResources"
+)
+
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -47,6 +59,13 @@ type HighNodeUtilizationArgs struct {
 
 	Thresholds    api.ResourceThresholds `json:"thresholds"`
 	NumberOfNodes int                    `json:"numberOfNodes,omitempty"`
+
+	// EvictionModes is a set of modes to be taken into account when the
+	// descheduler evicts pods. For example the mode
+	// `OnlyThresholdingResources` can be used to make sure the descheduler
+	// only evicts pods who have resource requests for the defined
+	// thresholds.
+	EvictionModes []EvictionMode `json:"evictionModes,omitempty"`
 
 	// Naming this one differently since namespaces are still
 	// considered while considering resources used by pods

--- a/pkg/framework/plugins/nodeutilization/validation.go
+++ b/pkg/framework/plugins/nodeutilization/validation.go
@@ -30,7 +30,25 @@ func ValidateHighNodeUtilizationArgs(obj runtime.Object) error {
 	if err != nil {
 		return err
 	}
+	// make sure we know about the eviction modes defined by the user.
+	return validateEvictionModes(args.EvictionModes)
+}
 
+// validateEvictionModes checks if the eviction modes are valid/known
+// to the descheduler.
+func validateEvictionModes(modes []EvictionMode) error {
+	// we are using this approach to make the code more extensible
+	// in the future.
+	validModes := map[EvictionMode]bool{
+		EvictionModeOnlyThresholdingResources: true,
+	}
+
+	for _, mode := range modes {
+		if validModes[mode] {
+			continue
+		}
+		return fmt.Errorf("invalid eviction mode %s", mode)
+	}
 	return nil
 }
 

--- a/pkg/framework/plugins/nodeutilization/zz_generated.deepcopy.go
+++ b/pkg/framework/plugins/nodeutilization/zz_generated.deepcopy.go
@@ -37,6 +37,11 @@ func (in *HighNodeUtilizationArgs) DeepCopyInto(out *HighNodeUtilizationArgs) {
 			(*out)[key] = val
 		}
 	}
+	if in.EvictionModes != nil {
+		in, out := &in.EvictionModes, &out.EvictionModes
+		*out = make([]EvictionMode, len(*in))
+		copy(*out, *in)
+	}
 	if in.EvictableNamespaces != nil {
 		in, out := &in.EvictableNamespaces, &out.EvictableNamespaces
 		*out = new(api.Namespaces)


### PR DESCRIPTION
with strict eviction policy the descheduler only evict pods if the pod contains a request for the given threshold. for example, if using a threshold for an extended resource called `example.com/gpu` only pods who request such a resource will be evicted.