### PR TITLE
Remove reference to obsolete deschedulerPolicy fields in chart values

### DIFF
--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -95,9 +95,6 @@ deschedulerPolicy:
   # maxNoOfPodsToEvictPerNamespace: 10
   # metricsProviders:
   # - source: KubernetesMetrics
-  # ignorePvcPods: true
-  # evictLocalStoragePods: true
-  # evictDaemonSetPods: true
   # tracing:
   #   collectorEndpoint: otel-collector.observability.svc.cluster.local:4317
   #   transportCert: ""


### PR DESCRIPTION
Since the removal of v1alpha1 descheduler policy config type in https://github.com/kubernetes-sigs/descheduler/pull/1482, some values are now obsolete and shouldn't be referenced in the helm chart since they are not applied anymore