### PR TITLE
fix: update the mailing list address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN VERSION=${VERSION} make build.$ARCH
 
 FROM scratch
 
-MAINTAINER Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>
+MAINTAINER Kubernetes SIG Scheduling <sig-scheduling@kubernetes.io>
 
 LABEL org.opencontainers.image.source https://github.com/kubernetes-sigs/descheduler
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,7 +13,7 @@
 # limitations under the License.
 FROM scratch
 
-MAINTAINER Kubernetes SIG Scheduling <kubernetes-sig-scheduling@googlegroups.com>
+MAINTAINER Kubernetes SIG Scheduling <sig-scheduling@kubernetes.io>
 
 USER 1000
 

--- a/charts/descheduler/Chart.yaml
+++ b/charts/descheduler/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 - https://github.com/kubernetes-sigs/descheduler
 maintainers:
 - name: Kubernetes SIG Scheduling
-  email: kubernetes-sig-scheduling@googlegroups.com
+  email: sig-scheduling@kubernetes.io

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -26,7 +26,7 @@ When the above pre-release steps are complete and the release is ready to be cut
 3. Perform the [image promotion process](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#image-promoter). [Example](https://github.com/kubernetes/k8s.io/pull/3344)
 4. Cut release branch from `master`, eg `release-1.24`
 5. Publish release using Github's release process from the git tag you created
-6. Email `kubernetes-sig-scheduling@googlegroups.com` to announce the release
+6. Email `sig-scheduling@kubernetes.io` to announce the release
 
 **Patch release**
 1. Pick relevant code change commits to the matching release branch, eg `release-1.24`
@@ -34,7 +34,7 @@ When the above pre-release steps are complete and the release is ready to be cut
 3. Merge Helm chart version update to release branch
 4. Perform the image promotion process for the patch version
 5. Publish release using Github's release process from the git tag you created
-6. Email `kubernetes-sig-scheduling@googlegroups.com` to announce the release
+6. Email `sig-scheduling@kubernetes.io` to announce the release
 
 ### Flowchart
 


### PR DESCRIPTION
kubernetes-sig-scheduling@googlegroups.com is deprecated, and a new mailing list would be sig-scheduling@kubernetes.io.

See: https://github.com/kubernetes/community/issues/8437