### PR TITLE
RemovePodsViolatingNodeTaints: list only pods that are not failed/suceeded

### DIFF
--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -106,7 +106,7 @@ func (d *RemovePodsViolatingNodeTaints) Name() string {
 func (d *RemovePodsViolatingNodeTaints) Deschedule(ctx context.Context, nodes []*v1.Node) *frameworktypes.Status {
 	for _, node := range nodes {
 		klog.V(1).InfoS("Processing node", "node", klog.KObj(node))
-		pods, err := podutil.ListAllPodsOnANode(node.Name, d.handle.GetPodsAssignedToNodeFunc(), d.podFilter)
+		pods, err := podutil.ListPodsOnANode(node.Name, d.handle.GetPodsAssignedToNodeFunc(), d.podFilter)
 		if err != nil {
 			// no pods evicted as error encountered retrieving evictable Pods
 			return &frameworktypes.Status{


### PR DESCRIPTION
Listing pods was incorrectly changed to listing all pods during code refactoring in https://github.com/kubernetes-sigs/descheduler/commit/0ff8ecb41ecf90ff2cfaa84a3e763ad0c800cb6d#diff-494cd6260fda05699f68c7da810f7814dea797a006afee5380728a6433206fefL82.