### PR TITLE
fix(RemovePodsViolatingNodeTaints): list only active pod

### DIFF
--- a/pkg/framework/plugins/example/example.go
+++ b/pkg/framework/plugins/example/example.go
@@ -140,7 +140,7 @@ func (d *Example) Deschedule(ctx context.Context, nodes []*v1.Node) *fwtypes.Sta
 		// ListAllPodsOnANode is a helper function that retrieves all
 		// pods filtering out the ones we can't evict. We merge the
 		// default filters with the one we created above.
-		pods, err := podutil.ListAllPodsOnANode(
+		pods, err := podutil.ListPodsOnANode(
 			node.Name,
 			d.handle.GetPodsAssignedToNodeFunc(),
 			podutil.WrapFilterFuncs(d.podFilter, filter),

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -106,7 +106,7 @@ func (d *RemovePodsViolatingNodeTaints) Name() string {
 func (d *RemovePodsViolatingNodeTaints) Deschedule(ctx context.Context, nodes []*v1.Node) *frameworktypes.Status {
 	for _, node := range nodes {
 		klog.V(1).InfoS("Processing node", "node", klog.KObj(node))
-		pods, err := podutil.ListAllPodsOnANode(node.Name, d.handle.GetPodsAssignedToNodeFunc(), d.podFilter)
+		pods, err := podutil.ListPodsOnANode(node.Name, d.handle.GetPodsAssignedToNodeFunc(), d.podFilter)
 		if err != nil {
 			// no pods evicted as error encountered retrieving evictable Pods
 			return &frameworktypes.Status{


### PR DESCRIPTION
inspired by this pr: https://github.com/kubernetes-sigs/descheduler/pull/1688/files

After the two PRs are merged, the only plugins that use the `ListAllPodsOnANode` method are: `PodLifeTime` `RemoveFailedPods` `RemovePodsHavingTooManyRestarts` plugins, because these plugins will filter internally or use the pod.Status.Phase status.