### PR TITLE
Extend plugin's New with a context.Context

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -415,6 +415,7 @@ func (d *descheduler) runProfiles(ctx context.Context, client clientset.Interfac
 	var profileRunners []profileRunner
 	for _, profile := range d.deschedulerPolicy.Profiles {
 		currProfile, err := frameworkprofile.NewProfile(
+			ctx,
 			profile,
 			pluginregistry.PluginRegistry,
 			frameworkprofile.WithClientSet(client),

--- a/pkg/framework/fake/plugin/fake.go
+++ b/pkg/framework/fake/plugin/fake.go
@@ -60,7 +60,7 @@ type FakePlugin struct {
 }
 
 func NewPluginFncFromFake(fp *FakePlugin) pluginregistry.PluginBuilder {
-	return func(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+	return func(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 		fakePluginArgs, ok := args.(*FakePluginArgs)
 		if !ok {
 			return nil, fmt.Errorf("want args to be of type FakePluginArgs, got %T", args)
@@ -74,7 +74,7 @@ func NewPluginFncFromFake(fp *FakePlugin) pluginregistry.PluginBuilder {
 }
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	fakePluginArgs, ok := args.(*FakePluginArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type FakePluginArgs, got %T", args)
@@ -165,7 +165,7 @@ type FakeDeschedulePlugin struct {
 }
 
 func NewFakeDeschedulePluginFncFromFake(fp *FakeDeschedulePlugin) pluginregistry.PluginBuilder {
-	return func(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+	return func(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 		fakePluginArgs, ok := args.(*FakeDeschedulePluginArgs)
 		if !ok {
 			return nil, fmt.Errorf("want args to be of type FakeDeschedulePluginArgs, got %T", args)
@@ -252,7 +252,7 @@ type FakeBalancePlugin struct {
 }
 
 func NewFakeBalancePluginFncFromFake(fp *FakeBalancePlugin) pluginregistry.PluginBuilder {
-	return func(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+	return func(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 		fakePluginArgs, ok := args.(*FakeBalancePluginArgs)
 		if !ok {
 			return nil, fmt.Errorf("want args to be of type FakeBalancePluginArgs, got %T", args)
@@ -339,7 +339,7 @@ type FakeFilterPlugin struct {
 }
 
 func NewFakeFilterPluginFncFromFake(fp *FakeFilterPlugin) pluginregistry.PluginBuilder {
-	return func(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+	return func(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 		fakePluginArgs, ok := args.(*FakeFilterPluginArgs)
 		if !ok {
 			return nil, fmt.Errorf("want args to be of type FakeFilterPluginArgs, got %T", args)

--- a/pkg/framework/pluginregistry/pluginregistry.go
+++ b/pkg/framework/pluginregistry/pluginregistry.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pluginregistry
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
@@ -35,7 +37,7 @@ type PluginUtilities struct {
 	PluginArgDefaulter PluginArgDefaulter
 }
 
-type PluginBuilder = func(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error)
+type PluginBuilder = func(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error)
 
 type (
 	PluginArgValidator = func(args runtime.Object) error

--- a/pkg/framework/plugins/defaultevictor/defaultevictor.go
+++ b/pkg/framework/plugins/defaultevictor/defaultevictor.go
@@ -66,7 +66,7 @@ func HaveEvictAnnotation(pod *v1.Pod) bool {
 
 // New builds plugin from its arguments while passing a handle
 // nolint: gocyclo
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	defaultEvictorArgs, ok := args.(*DefaultEvictorArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type defaultEvictorFilterArgs, got %T", args)

--- a/pkg/framework/plugins/defaultevictor/defaultevictor_test.go
+++ b/pkg/framework/plugins/defaultevictor/defaultevictor_test.go
@@ -858,7 +858,7 @@ func TestReinitialization(t *testing.T) {
 			if !ok {
 				t.Fatalf("Unable to initialize as a DefaultEvictor plugin")
 			}
-			_, err = New(defaultEvictor.args, defaultEvictor.handle)
+			_, err = New(ctx, defaultEvictor.args, defaultEvictor.handle)
 			if err != nil {
 				t.Fatalf("Unable to reinitialize the plugin: %v", err)
 			}
@@ -907,6 +907,7 @@ func initializePlugin(ctx context.Context, test testCase) (frameworktypes.Plugin
 	}
 
 	evictorPlugin, err := New(
+		ctx,
 		defaultEvictorArgs,
 		&frameworkfake.HandleImpl{
 			ClientsetImpl:                 fakeClient,

--- a/pkg/framework/plugins/example/example.go
+++ b/pkg/framework/plugins/example/example.go
@@ -55,7 +55,7 @@ type Example struct {
 // a runtime.Object. Handle is used by plugins to retrieve a kubernetes client
 // set, evictor interface, shared informer factory and other instruments shared
 // across different plugins.
-func New(args runtime.Object, handle fwtypes.Handle) (fwtypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle fwtypes.Handle) (fwtypes.Plugin, error) {
 	// make sure we are receiving the right argument type.
 	exampleArgs, ok := args.(*ExampleArgs)
 	if !ok {

--- a/pkg/framework/plugins/nodeutilization/highnodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization.go
@@ -55,7 +55,7 @@ type HighNodeUtilization struct {
 
 // NewHighNodeUtilization builds plugin from its arguments while passing a handle.
 func NewHighNodeUtilization(
-	genericArgs runtime.Object, handle frameworktypes.Handle,
+	ctx context.Context, genericArgs runtime.Object, handle frameworktypes.Handle,
 ) (frameworktypes.Plugin, error) {
 	args, ok := genericArgs.(*HighNodeUtilizationArgs)
 	if !ok {

--- a/pkg/framework/plugins/nodeutilization/highnodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/highnodeutilization_test.go
@@ -523,6 +523,7 @@ func TestHighNodeUtilization(t *testing.T) {
 			}
 
 			plugin, err := NewHighNodeUtilization(
+				ctx,
 				&HighNodeUtilizationArgs{
 					Thresholds:    testCase.thresholds,
 					EvictionModes: testCase.evictionModes,
@@ -637,7 +638,7 @@ func TestHighNodeUtilizationWithTaints(t *testing.T) {
 				t.Fatalf("Unable to initialize a framework handle: %v", err)
 			}
 
-			plugin, err := NewHighNodeUtilization(&HighNodeUtilizationArgs{
+			plugin, err := NewHighNodeUtilization(ctx, &HighNodeUtilizationArgs{
 				Thresholds: api.ResourceThresholds{
 					v1.ResourceCPU: 40,
 				},

--- a/pkg/framework/plugins/nodeutilization/lownodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/lownodeutilization.go
@@ -57,7 +57,7 @@ type LowNodeUtilization struct {
 // handle. this plugin aims to move workload from overutilized nodes to
 // underutilized nodes.
 func NewLowNodeUtilization(
-	genericArgs runtime.Object, handle frameworktypes.Handle,
+	ctx context.Context, genericArgs runtime.Object, handle frameworktypes.Handle,
 ) (frameworktypes.Plugin, error) {
 	args, ok := genericArgs.(*LowNodeUtilizationArgs)
 	if !ok {

--- a/pkg/framework/plugins/nodeutilization/lownodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/lownodeutilization_test.go
@@ -1391,7 +1391,7 @@ func TestLowNodeUtilization(t *testing.T) {
 					metricsUtilization = &MetricsUtilization{Source: api.KubernetesMetrics}
 				}
 
-				plugin, err := NewLowNodeUtilization(&LowNodeUtilizationArgs{
+				plugin, err := NewLowNodeUtilization(ctx, &LowNodeUtilizationArgs{
 					Thresholds:             tc.thresholds,
 					TargetThresholds:       tc.targetThresholds,
 					UseDeviationThresholds: tc.useDeviationThresholds,
@@ -1551,7 +1551,7 @@ func TestLowNodeUtilizationWithTaints(t *testing.T) {
 				t.Fatalf("Unable to initialize a framework handle: %v", err)
 			}
 
-			plugin, err := NewLowNodeUtilization(&LowNodeUtilizationArgs{
+			plugin, err := NewLowNodeUtilization(ctx, &LowNodeUtilizationArgs{
 				Thresholds: api.ResourceThresholds{
 					v1.ResourcePods: 20,
 				},
@@ -1824,7 +1824,7 @@ func TestLowNodeUtilizationWithPrometheusMetrics(t *testing.T) {
 					result:   tc.samples,
 					dataType: model.ValVector,
 				}
-				plugin, err := NewLowNodeUtilization(tc.args, handle)
+				plugin, err := NewLowNodeUtilization(ctx, tc.args, handle)
 				if err != nil {
 					t.Fatalf("Unable to initialize the plugin: %v", err)
 				}

--- a/pkg/framework/plugins/podlifetime/pod_lifetime.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime.go
@@ -44,7 +44,7 @@ type PodLifeTime struct {
 }
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	podLifeTimeArgs, ok := args.(*PodLifeTimeArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type PodLifeTimeArgs, got %T", args)

--- a/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
@@ -643,7 +643,7 @@ func TestPodLifeTime(t *testing.T) {
 				t.Fatalf("Unable to initialize a framework handle: %v", err)
 			}
 
-			plugin, err := New(tc.args, handle)
+			plugin, err := New(ctx, tc.args, handle)
 			if err != nil {
 				t.Fatalf("Unable to initialize the plugin: %v", err)
 			}

--- a/pkg/framework/plugins/removeduplicates/removeduplicates.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates.go
@@ -62,7 +62,7 @@ func (po podOwner) String() string {
 }
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	removeDuplicatesArgs, ok := args.(*RemoveDuplicatesArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type RemoveDuplicatesArgs, got %T", args)

--- a/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
+++ b/pkg/framework/plugins/removeduplicates/removeduplicates_test.go
@@ -299,7 +299,7 @@ func TestFindDuplicatePods(t *testing.T) {
 				t.Fatalf("Unable to initialize a framework handle: %v", err)
 			}
 
-			plugin, err := New(&RemoveDuplicatesArgs{
+			plugin, err := New(ctx, &RemoveDuplicatesArgs{
 				ExcludeOwnerKinds: testCase.excludeOwnerKinds,
 			},
 				handle,
@@ -702,7 +702,7 @@ func TestRemoveDuplicatesUniformly(t *testing.T) {
 				t.Fatalf("Unable to initialize a framework handle: %v", err)
 			}
 
-			plugin, err := New(&RemoveDuplicatesArgs{},
+			plugin, err := New(ctx, &RemoveDuplicatesArgs{},
 				handle,
 			)
 			if err != nil {

--- a/pkg/framework/plugins/removefailedpods/failedpods.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods.go
@@ -44,7 +44,7 @@ type RemoveFailedPods struct {
 var _ frameworktypes.DeschedulePlugin = &RemoveFailedPods{}
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	failedPodsArgs, ok := args.(*RemoveFailedPodsArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type RemoveFailedPodsArgs, got %T", args)

--- a/pkg/framework/plugins/removefailedpods/failedpods_test.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods_test.go
@@ -362,7 +362,7 @@ func TestRemoveFailedPods(t *testing.T) {
 				t.Fatalf("Unable to initialize a framework handle: %v", err)
 			}
 
-			plugin, err := New(&RemoveFailedPodsArgs{
+			plugin, err := New(ctx, &RemoveFailedPodsArgs{
 				Reasons:                 tc.args.Reasons,
 				ExitCodes:               tc.args.ExitCodes,
 				MinPodLifetimeSeconds:   tc.args.MinPodLifetimeSeconds,

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts.go
@@ -45,7 +45,7 @@ type RemovePodsHavingTooManyRestarts struct {
 var _ frameworktypes.DeschedulePlugin = &RemovePodsHavingTooManyRestarts{}
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	tooManyRestartsArgs, ok := args.(*RemovePodsHavingTooManyRestartsArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type RemovePodsHavingTooManyRestartsArgs, got %T", args)

--- a/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts_test.go
+++ b/pkg/framework/plugins/removepodshavingtoomanyrestarts/toomanyrestarts_test.go
@@ -341,6 +341,7 @@ func TestRemovePodsHavingTooManyRestarts(t *testing.T) {
 			}
 
 			plugin, err := New(
+				ctx,
 				&tc.args,
 				handle)
 			if err != nil {

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity.go
@@ -43,7 +43,7 @@ type RemovePodsViolatingInterPodAntiAffinity struct {
 var _ frameworktypes.DeschedulePlugin = &RemovePodsViolatingInterPodAntiAffinity{}
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	interPodAntiAffinityArgs, ok := args.(*RemovePodsViolatingInterPodAntiAffinityArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type RemovePodsViolatingInterPodAntiAffinityArgs, got %T", args)

--- a/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatinginterpodantiaffinity/pod_antiaffinity_test.go
@@ -240,6 +240,7 @@ func TestPodAntiAffinity(t *testing.T) {
 			}
 
 			plugin, err := New(
+				ctx,
 				&RemovePodsViolatingInterPodAntiAffinityArgs{},
 				handle,
 			)

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity.go
@@ -41,7 +41,7 @@ type RemovePodsViolatingNodeAffinity struct {
 var _ frameworktypes.DeschedulePlugin = &RemovePodsViolatingNodeAffinity{}
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	nodeAffinityArgs, ok := args.(*RemovePodsViolatingNodeAffinityArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type RemovePodsViolatingNodeAffinityArgs, got %T", args)

--- a/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodeaffinity/node_affinity_test.go
@@ -369,6 +369,7 @@ func TestRemovePodsViolatingNodeAffinity(t *testing.T) {
 			}
 
 			plugin, err := New(
+				ctx,
 				&RemovePodsViolatingNodeAffinityArgs{
 					NodeAffinityType: tc.args.NodeAffinityType,
 				},

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint.go
@@ -44,7 +44,7 @@ type RemovePodsViolatingNodeTaints struct {
 var _ frameworktypes.DeschedulePlugin = &RemovePodsViolatingNodeTaints{}
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	nodeTaintsArgs, ok := args.(*RemovePodsViolatingNodeTaintsArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type RemovePodsViolatingNodeTaintsArgs, got %T", args)

--- a/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingnodetaints/node_taint_test.go
@@ -425,7 +425,7 @@ func TestDeletePodsViolatingNodeTaints(t *testing.T) {
 				t.Fatalf("Unable to initialize a framework handle: %v", err)
 			}
 
-			plugin, err := New(&RemovePodsViolatingNodeTaintsArgs{
+			plugin, err := New(ctx, &RemovePodsViolatingNodeTaintsArgs{
 				IncludePreferNoSchedule: tc.includePreferNoSchedule,
 				ExcludedTaints:          tc.excludedTaints,
 				IncludedTaints:          tc.includedTaints,

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -74,7 +74,7 @@ type RemovePodsViolatingTopologySpreadConstraint struct {
 var _ frameworktypes.BalancePlugin = &RemovePodsViolatingTopologySpreadConstraint{}
 
 // New builds plugin from its arguments while passing a handle
-func New(args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
+func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle) (frameworktypes.Plugin, error) {
 	pluginArgs, ok := args.(*RemovePodsViolatingTopologySpreadConstraintArgs)
 	if !ok {
 		return nil, fmt.Errorf("want args to be of type RemovePodsViolatingTopologySpreadConstraintArgs, got %T", args)

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1449,6 +1449,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			SetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(&tc.args)
 
 			plugin, err := New(
+				ctx,
 				&tc.args,
 				handle,
 			)

--- a/pkg/framework/profile/profile.go
+++ b/pkg/framework/profile/profile.go
@@ -191,7 +191,7 @@ func getPluginConfig(pluginName string, pluginConfigs []api.PluginConfig) (*api.
 	return nil, 0
 }
 
-func buildPlugin(config api.DeschedulerProfile, pluginName string, handle *handleImpl, reg pluginregistry.Registry) (frameworktypes.Plugin, error) {
+func buildPlugin(ctx context.Context, config api.DeschedulerProfile, pluginName string, handle *handleImpl, reg pluginregistry.Registry) (frameworktypes.Plugin, error) {
 	pc, _ := getPluginConfig(pluginName, config.PluginConfigs)
 	if pc == nil {
 		klog.ErrorS(fmt.Errorf("unable to get plugin config"), "skipping plugin", "plugin", pluginName, "profile", config.Name)
@@ -203,7 +203,7 @@ func buildPlugin(config api.DeschedulerProfile, pluginName string, handle *handl
 		klog.ErrorS(fmt.Errorf("unable to find plugin in the pluginsMap"), "skipping plugin", "plugin", pluginName)
 		return nil, fmt.Errorf("unable to find %q plugin in the pluginsMap", pluginName)
 	}
-	pg, err := registryPlugin.PluginBuilder(pc.Args, handle)
+	pg, err := registryPlugin.PluginBuilder(ctx, pc.Args, handle)
 	if err != nil {
 		klog.ErrorS(err, "unable to initialize a plugin", "pluginName", pluginName)
 		return nil, fmt.Errorf("unable to initialize %q plugin: %v", pluginName, err)
@@ -231,7 +231,7 @@ func (p *profileImpl) registryToExtensionPoints(registry pluginregistry.Registry
 	}
 }
 
-func NewProfile(config api.DeschedulerProfile, reg pluginregistry.Registry, opts ...Option) (*profileImpl, error) {
+func NewProfile(ctx context.Context, config api.DeschedulerProfile, reg pluginregistry.Registry, opts ...Option) (*profileImpl, error) {
 	hOpts := &handleImplOpts{}
 	for _, optFnc := range opts {
 		optFnc(hOpts)
@@ -290,7 +290,7 @@ func NewProfile(config api.DeschedulerProfile, reg pluginregistry.Registry, opts
 
 	plugins := make(map[string]frameworktypes.Plugin)
 	for _, plugin := range sets.New(pluginNames...).UnsortedList() {
-		pg, err := buildPlugin(config, plugin, handle, reg)
+		pg, err := buildPlugin(ctx, config, plugin, handle, reg)
 		if err != nil {
 			return nil, fmt.Errorf("unable to build %v plugin: %v", plugin, err)
 		}

--- a/pkg/framework/profile/profile_test.go
+++ b/pkg/framework/profile/profile_test.go
@@ -242,6 +242,7 @@ func TestProfileDescheduleBalanceExtensionPointsEviction(t *testing.T) {
 			}
 
 			prfl, err := NewProfile(
+				ctx,
 				test.config,
 				pluginregistry.PluginRegistry,
 				WithClientSet(client),
@@ -385,6 +386,7 @@ func TestProfileExtensionPoints(t *testing.T) {
 	}
 
 	prfl, err := NewProfile(
+		ctx,
 		api.DeschedulerProfile{
 			Name: "strategy-test-profile",
 			PluginConfigs: []api.PluginConfig{
@@ -592,6 +594,7 @@ func TestProfileExtensionPointOrdering(t *testing.T) {
 	}
 
 	prfl, err := NewProfile(
+		ctx,
 		api.DeschedulerProfile{
 			Name: "strategy-test-profile",
 			PluginConfigs: []api.PluginConfig{

--- a/pkg/framework/testing/utils.go
+++ b/pkg/framework/testing/utils.go
@@ -55,6 +55,7 @@ func InitFrameworkHandle(
 		return nil, nil, fmt.Errorf("Unable to initialize pod evictor: %v", err)
 	}
 	evictorFilter, err := defaultevictor.New(
+		ctx,
 		&defaultEvictorArgs,
 		&frameworkfake.HandleImpl{
 			ClientsetImpl:                 client,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -451,7 +451,7 @@ func runPodLifetimePlugin(
 
 	maxPodLifeTimeSeconds := uint(1)
 
-	plugin, err := podlifetime.New(&podlifetime.PodLifeTimeArgs{
+	plugin, err := podlifetime.New(ctx, &podlifetime.PodLifeTimeArgs{
 		MaxPodLifeTimeSeconds: &maxPodLifeTimeSeconds,
 		LabelSelector:         labelSelector,
 		Namespaces:            namespaces,
@@ -615,7 +615,7 @@ func TestLowNodeUtilization(t *testing.T) {
 	podsBefore := len(podsOnMosttUtilizedNode)
 
 	t.Log("Running LowNodeUtilization plugin")
-	plugin, err := nodeutilization.NewLowNodeUtilization(&nodeutilization.LowNodeUtilizationArgs{
+	plugin, err := nodeutilization.NewLowNodeUtilization(ctx, &nodeutilization.LowNodeUtilizationArgs{
 		Thresholds: api.ResourceThresholds{
 			v1.ResourceCPU: 70,
 		},


### PR DESCRIPTION
The new context.Context can be later used for passing a contextualized logger. Or, other initialization steps that require the context.