### PR TITLE
Automated cherry pick of #1696: *1677 Allow Succeeded and Failed states in PodLifeTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,9 @@ profiles:
 This strategy evicts pods that are older than `maxPodLifeTimeSeconds`.
 
 You can also specify `states` parameter to **only** evict pods matching the following conditions:
-  - [Pod Phase](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) status of: `Running`, `Pending`, `Unknown`
+> The primary purpose for using states like `Succeeded` and `Failed` is releasing resources so that new pods can be rescheduled.
+> I.e., the main motivation is not for cleaning pods, rather to release resources.
+  - [Pod Phase](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase) status of: `Running`, `Pending`, `Succeeded`, `Failed`, `Unknown`
   - [Pod Reason](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions) reasons of: `NodeAffinity`, `NodeLost`, `Shutdown`, `UnexpectedAdmissionError`
   - [Container State Waiting](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-waiting) condition of: `PodInitializing`, `ContainerCreating`, `ImagePullBackOff`, `CrashLoopBackOff`, `CreateContainerConfigError`, `ErrImagePull`, `ImagePullBackOff`, `CreateContainerError`, `InvalidImageName`
 

--- a/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
+++ b/pkg/framework/plugins/podlifetime/pod_lifetime_test.go
@@ -578,6 +578,32 @@ func TestPodLifeTime(t *testing.T) {
 			},
 		},
 		{
+			description: "1 pod with pod status phase v1.PodSucceeded should be evicted",
+			args: &PodLifeTimeArgs{
+				MaxPodLifeTimeSeconds: &maxLifeTime,
+				States:                []string{string(v1.PodSucceeded)},
+			},
+			pods:                    []*v1.Pod{p16},
+			nodes:                   []*v1.Node{node1},
+			expectedEvictedPodCount: 1,
+			applyPodsFunc: func(pods []*v1.Pod) {
+				pods[0].Status.Phase = v1.PodSucceeded
+			},
+		},
+		{
+			description: "1 pod with pod status phase v1.PodUnknown should be evicted",
+			args: &PodLifeTimeArgs{
+				MaxPodLifeTimeSeconds: &maxLifeTime,
+				States:                []string{string(v1.PodFailed)},
+			},
+			pods:                    []*v1.Pod{p16},
+			nodes:                   []*v1.Node{node1},
+			expectedEvictedPodCount: 1,
+			applyPodsFunc: func(pods []*v1.Pod) {
+				pods[0].Status.Phase = v1.PodFailed
+			},
+		},
+		{
 			description: "1 pod with pod status phase v1.PodUnknown should be evicted",
 			args: &PodLifeTimeArgs{
 				MaxPodLifeTimeSeconds: &maxLifeTime,

--- a/pkg/framework/plugins/podlifetime/validation.go
+++ b/pkg/framework/plugins/podlifetime/validation.go
@@ -47,6 +47,8 @@ func ValidatePodLifeTimeArgs(obj runtime.Object) error {
 		// Pod Status Phase
 		string(v1.PodRunning),
 		string(v1.PodPending),
+		string(v1.PodSucceeded),
+		string(v1.PodFailed),
 		string(v1.PodUnknown),
 
 		// Pod Status Reasons

--- a/pkg/framework/plugins/podlifetime/validation_test.go
+++ b/pkg/framework/plugins/podlifetime/validation_test.go
@@ -37,6 +37,14 @@ func TestValidateRemovePodLifeTimeArgs(t *testing.T) {
 			expectError: false,
 		},
 		{
+			description: "Pod Status Reasons Succeeded or Failed",
+			args: &PodLifeTimeArgs{
+				MaxPodLifeTimeSeconds: func(i uint) *uint { return &i }(1),
+				States:                []string{string(v1.PodSucceeded), string(v1.PodFailed)},
+			},
+			expectError: false,
+		},
+		{
 			description: "Pod Status Reasons CrashLoopBackOff ",
 			args: &PodLifeTimeArgs{
 				MaxPodLifeTimeSeconds: func(i uint) *uint { return &i }(1),


### PR DESCRIPTION
Cherry pick of #1696 on release-1.33.

#1696: *1677 Allow Succeeded and Failed states in PodLifeTime

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```