### PR TITLE
feat(prometheus): allow different url schemes

### DIFF
--- a/pkg/descheduler/policyconfig.go
+++ b/pkg/descheduler/policyconfig.go
@@ -172,13 +172,8 @@ func validateDeschedulerConfiguration(in api.DeschedulerPolicy, registry pluginr
 		} else {
 			if prometheusConfig.Prometheus.URL == "" {
 				errorsInPolicy = append(errorsInPolicy, fmt.Errorf("prometheus URL is required when prometheus is enabled"))
-			} else {
-				u, err := url.Parse(prometheusConfig.Prometheus.URL)
-				if err != nil {
-					errorsInPolicy = append(errorsInPolicy, fmt.Errorf("error parsing prometheus URL: %v", err))
-				} else if u.Scheme != "https" {
-					errorsInPolicy = append(errorsInPolicy, fmt.Errorf("prometheus URL's scheme is not https, got %q instead", u.Scheme))
-				}
+			} else if _, err := url.Parse(prometheusConfig.Prometheus.URL); err != nil {
+				errorsInPolicy = append(errorsInPolicy, fmt.Errorf("error parsing prometheus URL: %v", err))
 			}
 
 			if prometheusConfig.Prometheus.AuthToken != nil {

--- a/pkg/descheduler/policyconfig_test.go
+++ b/pkg/descheduler/policyconfig_test.go
@@ -260,20 +260,6 @@ func TestValidateDeschedulerConfiguration(t *testing.T) {
 			result: fmt.Errorf("error parsing prometheus URL: parse \"http://example.com:-80\": invalid port \":-80\" after host"),
 		},
 		{
-			description: "prometheus url does not have https error",
-			deschedulerPolicy: api.DeschedulerPolicy{
-				MetricsProviders: []api.MetricsProvider{
-					{
-						Source: api.PrometheusMetrics,
-						Prometheus: &api.Prometheus{
-							URL: "http://example.com:80",
-						},
-					},
-				},
-			},
-			result: fmt.Errorf("prometheus URL's scheme is not https, got \"http\" instead"),
-		},
-		{
 			description: "prometheus authtoken with no secret reference error",
 			deschedulerPolicy: api.DeschedulerPolicy{
 				MetricsProviders: []api.MetricsProvider{


### PR DESCRIPTION
As per prometheus Golang client implementation: the only url validation done is by means of an `url.Parse()` [call](https://github.com/prometheus/client_golang/blob/main/api/client.go#L90C1-L93C3). We should do the same and not enforce the usage of https scheme.

Our readme even shows an example of Descheduler config using http prometheus url scheme.