### PR TITLE
Remove static RunAsUser/Group ID from PSC to pass e2e tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -116,8 +116,6 @@ func deschedulerDeployment(testName string) *appsv1.Deployment {
 					ServiceAccountName: "descheduler-sa",
 					SecurityContext: &v1.PodSecurityContext{
 						RunAsNonRoot: utilptr.To(true),
-						RunAsUser:    utilptr.To[int64](1000),
-						RunAsGroup:   utilptr.To[int64](1000),
 						SeccompProfile: &v1.SeccompProfile{
 							Type: v1.SeccompProfileTypeRuntimeDefault,
 						},
@@ -318,8 +316,6 @@ func makePodSpec(priorityClassName string, gracePeriod *int64) v1.PodSpec {
 	return v1.PodSpec{
 		SecurityContext: &v1.PodSecurityContext{
 			RunAsNonRoot: utilptr.To(true),
-			RunAsUser:    utilptr.To[int64](1000),
-			RunAsGroup:   utilptr.To[int64](1000),
 			SeccompProfile: &v1.SeccompProfile{
 				Type: v1.SeccompProfileTypeRuntimeDefault,
 			},
@@ -527,8 +523,6 @@ func TestLowNodeUtilization(t *testing.T) {
 			Spec: v1.PodSpec{
 				SecurityContext: &v1.PodSecurityContext{
 					RunAsNonRoot: utilptr.To(true),
-					RunAsUser:    utilptr.To[int64](1000),
-					RunAsGroup:   utilptr.To[int64](1000),
 					SeccompProfile: &v1.SeccompProfile{
 						Type: v1.SeccompProfileTypeRuntimeDefault,
 					},
@@ -1610,8 +1604,6 @@ func createBalancedPodForNodes(
 			Spec: v1.PodSpec{
 				SecurityContext: &v1.PodSecurityContext{
 					RunAsNonRoot: utilptr.To(true),
-					RunAsUser:    utilptr.To[int64](1000),
-					RunAsGroup:   utilptr.To[int64](1000),
 					SeccompProfile: &v1.SeccompProfile{
 						Type: v1.SeccompProfileTypeRuntimeDefault,
 					},


### PR DESCRIPTION
e2e tests are failing when User & Group IDs are statically set. Removing the IDs now pass the related tests. 