### PR TITLE
standardize protectionEnabled param across eviction constraints

### DIFF
--- a/pkg/framework/plugins/defaultevictor/defaultevictor_test.go
+++ b/pkg/framework/plugins/defaultevictor/defaultevictor_test.go
@@ -794,7 +794,7 @@ func TestDefaultEvictorFilter(t *testing.T) {
 			result: true,
 		},
 		{
-			description: "Pod with local storage is evicted because 'withLocalStorage' is in disabledDefaultPodProtections",
+			description: "Pod with local storage is evicted because 'PodsWithLocalStorage' is in DefaultDisabled",
 			pods: []*v1.Pod{
 				test.BuildTestPod("p18", 400, 0, n1.Name, func(pod *v1.Pod) {
 					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
@@ -813,7 +813,7 @@ func TestDefaultEvictorFilter(t *testing.T) {
 			result: true,
 		},
 		{
-			description: "DaemonSet pod is evicted because 'daemonSetPods' is in disabledDefaultPodProtections",
+			description: "DaemonSet pod is evicted because 'DaemonSetPods' is in DefaultDisabled",
 			pods: []*v1.Pod{
 				test.BuildTestPod("p19", 400, 0, n1.Name, func(pod *v1.Pod) {
 					pod.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
@@ -831,7 +831,7 @@ func TestDefaultEvictorFilter(t *testing.T) {
 			result: true,
 		},
 		{
-			description: "Pod with PVC is not evicted because 'withPVC' is in extraPodProtections",
+			description: "Pod with PVC is not evicted because 'PodsWithPVC' is in ExtraEnabled",
 			pods: []*v1.Pod{
 				test.BuildTestPod("p20", 400, 0, n1.Name, func(pod *v1.Pod) {
 					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
@@ -850,7 +850,7 @@ func TestDefaultEvictorFilter(t *testing.T) {
 			result: false,
 		},
 		{
-			description: "Pod without PDB is not evicted because 'withoutPDB' is in extraPodProtections",
+			description: "Pod without PDB is not evicted because 'PodsWithoutPDB' is in ExtraEnabled",
 			pods: []*v1.Pod{
 				test.BuildTestPod("p21", 400, 0, n1.Name, func(pod *v1.Pod) {
 					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()
@@ -862,7 +862,7 @@ func TestDefaultEvictorFilter(t *testing.T) {
 			result: false,
 		},
 		{
-			description: "Pod with ResourceClaims is not evicted because 'PodsWithResourceClaims' is in extraPodProtections",
+			description: "Pod with ResourceClaims is not evicted because 'PodsWithResourceClaims' is in ExtraEnabled",
 			pods: []*v1.Pod{
 				test.BuildTestPod("p20", 400, 0, n1.Name, func(pod *v1.Pod) {
 					pod.ObjectMeta.OwnerReferences = test.GetNormalPodOwnerRefList()


### PR DESCRIPTION
fix part of : https://github.com/kubernetes-sigs/descheduler/pull/1665#pullrequestreview-3078443138

Unified the boolean argument semantics for all evictionConstraintsForXXX
functions to consistently represent whether protection is enabled.