### PR TITLE
[1732] chore: add cronjob/job labels and annotations to helm chart

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -70,6 +70,10 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `serviceAccount.create`             | If `true`, create a service account for the cron job                                                                  | `true`                                    |
 | `serviceAccount.name`               | The name of the service account to use, if not set and create is true a name is generated using the fullname template | `nil`                                     |
 | `serviceAccount.annotations`        | Specifies custom annotations for the serviceAccount                                                                   | `{}`                                      |
+| `cronJobAnnotations`                | Annotations to add to the descheduler CronJob                                                                         | `{}`                                      |
+| `cronJobLabels`                     | Labels to add to the descheduler CronJob                                                                              | `{}`                                      |
+| `jobAnnotations`                    | Annotations to add to the descheduler Job resources (created by CronJob)                                              | `{}`                                      |
+| `jobLabels`                         | Labels to add to the descheduler Job resources (created by CronJob)                                                   | `{}`                                      |
 | `podAnnotations`                    | Annotations to add to the descheduler Pods                                                                            | `{}`                                      |
 | `podLabels`                         | Labels to add to the descheduler Pods                                                                                 | `{}`                                      |
 | `nodeSelector`                      | Node selectors to run the descheduler cronjob/deployment on specific nodes                                            | `nil`                                     |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -4,8 +4,15 @@ kind: CronJob
 metadata:
   name: {{ template "descheduler.fullname" . }}
   namespace: {{ include "descheduler.namespace" . }}
+  {{- if .Values.cronJobAnnotations }}
+  annotations:
+    {{- .Values.cronJobAnnotations | toYaml | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "descheduler.labels" . | nindent 4 }}
+    {{- if .Values.cronJobLabels }}
+    {{- .Values.cronJobLabels | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   schedule: {{ .Values.schedule | quote }}
   {{- if .Values.suspend }}
@@ -25,6 +32,17 @@ spec:
   timeZone: {{ .Values.timeZone }}
   {{- end }}
   jobTemplate:
+    {{- if or .Values.jobAnnotations .Values.jobLabels }}
+    metadata:
+      {{- if .Values.jobAnnotations }}
+      annotations:
+        {{- .Values.jobAnnotations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.jobLabels }}
+      labels:
+        {{- .Values.jobLabels | toYaml | nindent 8 }}
+      {{- end }}
+    {{- end }}
     spec:
       {{- if .Values.ttlSecondsAfterFinished }}
       ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}

--- a/charts/descheduler/tests/cronjob_annotations_test.yaml
+++ b/charts/descheduler/tests/cronjob_annotations_test.yaml
@@ -1,0 +1,109 @@
+suite: Test Descheduler CronJob and Job Annotations and Labels
+
+templates:
+  - "*.yaml"
+
+release:
+  name: descheduler
+
+set:
+  kind: CronJob
+
+tests:
+  - it: adds cronJob and job annotations and labels when set
+    template: templates/cronjob.yaml
+    set:
+      cronJobAnnotations:
+        monitoring.company.com/scrape: "true"
+        description: "test cronjob"
+      cronJobLabels:
+        environment: "test"
+        team: "platform"
+      jobAnnotations:
+        sidecar.istio.io/inject: "false"
+        job.company.com/retry-limit: "3"
+      jobLabels:
+        job-type: "maintenance"
+        priority: "high"
+    asserts:
+      - equal:
+          path: metadata.annotations["monitoring.company.com/scrape"]
+          value: "true"
+      - equal:
+          path: metadata.annotations.description
+          value: "test cronjob"
+      - equal:
+          path: metadata.labels.environment
+          value: "test"
+      - equal:
+          path: metadata.labels.team
+          value: "platform"
+      - equal:
+          path: spec.jobTemplate.metadata.annotations["sidecar.istio.io/inject"]
+          value: "false"
+      - equal:
+          path: spec.jobTemplate.metadata.annotations["job.company.com/retry-limit"]
+          value: "3"
+      - equal:
+          path: spec.jobTemplate.metadata.labels.job-type
+          value: "maintenance"
+      - equal:
+          path: spec.jobTemplate.metadata.labels.priority
+          value: "high"
+
+  - it: does not add cronJob and job metadata when not set
+    template: templates/cronjob.yaml
+    asserts:
+      - isNull:
+          path: metadata.annotations
+      - isNotNull:
+          path: metadata.labels
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: descheduler
+      - isNull:
+          path: spec.jobTemplate.metadata
+
+  - it: does not add job metadata when job annotations and labels are empty
+    template: templates/cronjob.yaml
+    set:
+      jobAnnotations: {}
+      jobLabels: {}
+    asserts:
+      - isNull:
+          path: spec.jobTemplate.metadata
+
+  - it: works with all annotation and label types together
+    template: templates/cronjob.yaml
+    set:
+      cronJobAnnotations:
+        cron-annotation: "cron-value"
+      cronJobLabels:
+        cron-label: "cron-value"
+      jobAnnotations:
+        job-annotation: "job-value"
+      jobLabels:
+        job-label: "job-value"
+      podAnnotations:
+        pod-annotation: "pod-value"
+      podLabels:
+        pod-label: "pod-value"
+    asserts:
+      - equal:
+          path: metadata.annotations.cron-annotation
+          value: "cron-value"
+      - equal:
+          path: metadata.labels.cron-label
+          value: "cron-value"
+      - equal:
+          path: spec.jobTemplate.metadata.annotations.job-annotation
+          value: "job-value"
+      - equal:
+          path: spec.jobTemplate.metadata.labels.job-label
+          value: "job-value"
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations.pod-annotation
+          value: "pod-value"
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.labels.pod-label
+          value: "pod-value"

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -204,6 +204,14 @@ serviceAccount:
 # Default is not set - but only implied by the ServiceAccount
 # automountServiceAccountToken: true
 
+cronJobAnnotations: {}
+
+cronJobLabels: {}
+
+jobAnnotations: {}
+
+jobLabels: {}
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
This pr implements #1732 suggestion. 

Example result of helm template with default values of new properties ` helm template descheduler . --values values.yaml `:
[output-default-values.yaml.txt](https://github.com/user-attachments/files/21949427/output-default-values.yaml.txt)



Example result of helm template with  test values of new properties ` helm template descheduler . --values test-values.yaml `:
[output-test-values.yaml.txt](https://github.com/user-attachments/files/21949441/output-test-values.yaml.txt)

