### PR TITLE
optimize: preserving needed fields for memory efficiency

### DIFF
--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -190,7 +190,7 @@ func initDescheduler(t *testing.T, ctx context.Context, featureGates featuregate
 	rs.DefaultFeatureGates = featureGates
 	rs.MetricsClient = metricsClient
 
-	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(rs.Client, 0, informers.WithTransform(trimManagedFields))
+	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(rs.Client, 0, informers.WithTransform(preserveNeeded))
 	eventBroadcaster, eventRecorder := utils.GetRecorderAndBroadcaster(ctx, client)
 
 	descheduler, err := newDescheduler(ctx, rs, internalDeschedulerPolicy, "v1", eventRecorder, sharedInformerFactory, nil)


### PR DESCRIPTION
fix #1737 
In production scenarios, the fields of pods are usually quite complex. Testing has shown that in our case, the descheduler's memory usage has been reduced by 2/5.