### PR TITLE
feat(test/e2e): introduce new flags to override RunAsUser and RunAsGroup security context setting

### DIFF
--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -105,4 +105,4 @@ kubectl patch -n kube-system deployment metrics-server --type=json \
   -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
 
 PRJ_PREFIX="sigs.k8s.io/descheduler"
-go test ${PRJ_PREFIX}/test/e2e/ -v -timeout 0
+go test ${PRJ_PREFIX}/test/e2e/ -v -timeout 0 --args --descheduler-image ${DESCHEDULER_IMAGE} --pod-run-as-user-id 1000 --pod-run-as-group-id 1000


### PR DESCRIPTION
So RunAsUser and RunAsGroup can be either omitted and set to different values.