### PR TITLE
descheduler: handle single-node clusters gracefully

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -357,7 +357,7 @@ func (d *descheduler) runDeschedulerLoop(ctx context.Context, nodes []*v1.Node) 
 	// if len is still <= 1 error out
 	if len(nodes) <= 1 {
 		klog.InfoS("Skipping descheduling cycle: requires >=2 nodes", "found", len(nodes))
-        return nil // gracefully skip this cycle instead of aborting
+		return nil // gracefully skip this cycle instead of aborting
 	}
 
 	var client clientset.Interface


### PR DESCRIPTION
Instead of aborting and causing CrashLoopBackOff, descheduler now logs a message and skips the descheduling cycle when the cluster has 0 or 1 nodes.

Fixes #1748

## Description
This change updates the descheduler behavior to handle single-node clusters more gracefully.  
Previously, the descheduler aborted when the cluster size was 0 or 1, causing the pod to enter `CrashLoopBackOff`.  
With this fix:
- The descheduler remains running
- Logs a clear message: `Skipping descheduling cycle: requires >=2 nodes`
- Waits for the next cycle, so if more nodes join the cluster, it resumes work without restart

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [ ] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [ ] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [ ] **Code Duplication**: Is there any repeated code that should be refactored?
- [ ] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [ ] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [ ] **Error Handling**: Are errors handled appropriately ?
- [ ] **Testing**: Are there sufficient unit/integration tests?
- [ ] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [ ] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [ ] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [ ] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [ ] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [ ] **Documentation & Changelog**: Are README and docs updated if necessary?
