### PR TITLE
docs: use podProtections args in helm chart

### DIFF
--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -108,8 +108,11 @@ deschedulerPolicy:
       pluginConfig:
         - name: DefaultEvictor
           args:
-            ignorePvcPods: true
-            evictLocalStoragePods: true
+            podProtections:
+              defaultDisabled:
+              - "PodsWithLocalStorage"
+              extraEnabled:
+              - "PodsWithPVC"
         - name: RemoveDuplicates
         - name: RemovePodsHavingTooManyRestarts
           args:
@@ -195,12 +198,11 @@ serviceAccount:
   # Specifies custom annotations for the serviceAccount
   annotations: {}
   # Opt out of API credential automounting
-  # 
-  # automountServiceAccountToken Default is not set 
+  #
+  # automountServiceAccountToken Default is not set
   # automountServiceAccountToken: true
-  
 
-# Mount the ServiceAccountToken in the Pod of a CronJob or Deployment 
+# Mount the ServiceAccountToken in the Pod of a CronJob or Deployment
 # Default is not set - but only implied by the ServiceAccount
 # automountServiceAccountToken: true
 
@@ -268,7 +270,7 @@ serviceMonitor:
     #   action: replace
 
 ## Additional Volume mounts when automountServiceAccountToken is false
-# extraServiceAccountVolumeMounts: 
+# extraServiceAccountVolumeMounts:
 # - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
 #   name: kube-api-access
 #   readOnly: true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed -->

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

we already use  podProtections in this pr https://github.com/kubernetes-sigs/descheduler/pull/1665 and mark other similar args as Deprecated

- use podProtections args instead of `ignorePvcPods ` and `evictLocalStoragePods ` in helm chart



- [ ] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [ ] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [ ] **Code Duplication**: Is there any repeated code that should be refactored?
- [ ] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [ ] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [ ] **Error Handling**: Are errors handled appropriately ?
- [ ] **Testing**: Are there sufficient unit/integration tests?
- [ ] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [ ] **Dependencies**: Are new dependencies justified ?
- [ ] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [ ] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [ ] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [ ] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [ ] **Documentation & Changelog**: Are README and docs updated if necessary?
