### PR TITLE
docs: fix incorrect gracePeriodSeconds default in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ These are top level keys in the Descheduler Policy that you can use to configure
 | `metricsCollector.enabled`         | `bool`   | `false`       | Enables Kubernetes [Metrics Server](https://kubernetes-sigs.github.io/metrics-server/) collection.                         |
 | `metricsProviders`                 | `[]object` | `nil`       | Enables various metrics providers like Kubernetes [Metrics Server](https://kubernetes-sigs.github.io/metrics-server/)      |
 | `evictionFailureEventNotification` | `bool`   | `false`       | Enables eviction failure event notification.                                                                               |
-| `gracePeriodSeconds`               | `int`    | `0`           | The duration in seconds before the object should be deleted. The value zero indicates delete immediately.                  |
+| `gracePeriodSeconds`               | `int`    | `nil`           | The duration in seconds before the object should be deleted. The value zero indicates delete immediately. If this value is nil, the default grace period for the specified type will be used.            |
 | `prometheus` |`object`| `nil` | Configures collection of Prometheus metrics for actual resource utilization |
 | `prometheus.url` |`string`| `nil` | Points to a Prometheus server url |
 | `prometheus.authToken` |`object`| `nil` | Sets Prometheus server authentication token. If not specified in cluster authentication token from the container's file system is read. |


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed -->
Update README.md to reflect the correct default value (`nil`, not `0`) for `gracePeriodSeconds`.

Fixes #1767.

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [ ] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [ ] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [ ] **Code Duplication**: Is there any repeated code that should be refactored?
- [ ] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [ ] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [ ] **Error Handling**: Are errors handled appropriately ?
- [ ] **Testing**: Are there sufficient unit/integration tests?
- [ ] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [ ] **Dependencies**: Are new dependencies justified ?
- [ ] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [ ] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [ ] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?
