### PR TITLE
refactor(pkg/descheduler): create fake shared informer factory only once

### DIFF
--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -403,12 +403,6 @@ func (pe *PodEvictor) ResetCounters() {
 	pe.totalPodCount = 0
 }
 
-func (pe *PodEvictor) SetClient(client clientset.Interface) {
-	pe.mu.Lock()
-	defer pe.mu.Unlock()
-	pe.client = client
-}
-
 func (pe *PodEvictor) evictionRequestsTotal() uint {
 	if pe.featureGates.Enabled(features.EvictionsInBackground) {
 		return pe.erCache.evictionRequestsTotal()

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -43,6 +43,10 @@ import (
 // BuildTestPod creates a test pod with given parameters.
 func BuildTestPod(name string, cpu, memory int64, nodeName string, apply func(*v1.Pod)) *v1.Pod {
 	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      name,
@@ -76,6 +80,10 @@ func BuildTestPod(name string, cpu, memory int64, nodeName string, apply func(*v
 func BuildTestPDB(name, appLabel string) *policyv1.PodDisruptionBudget {
 	maxUnavailable := intstr.FromInt32(1)
 	pdb := &policyv1.PodDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "policy/v1",
+			Kind:       "PodDisruptionBudget",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      name,
@@ -94,6 +102,10 @@ func BuildTestPDB(name, appLabel string) *policyv1.PodDisruptionBudget {
 
 func BuildTestPVC(name, storageClass string) *v1.PersistentVolumeClaim {
 	pvc := &v1.PersistentVolumeClaim{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "PersistentVolumeClaim",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      name,
@@ -114,6 +126,10 @@ func BuildTestPVC(name, storageClass string) *v1.PersistentVolumeClaim {
 // BuildPodMetrics creates a test podmetrics with given parameters.
 func BuildPodMetrics(name string, millicpu, mem int64) *v1beta1.PodMetrics {
 	return &v1beta1.PodMetrics{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "metrics.k8s.io/v1beta1",
+			Kind:       "PodMetrics",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: "default",
@@ -171,6 +187,10 @@ func GetDaemonSetOwnerRefList() []metav1.OwnerReference {
 // BuildTestNode creates a node with specified capacity.
 func BuildTestNode(name string, millicpu, mem, pods int64, apply func(*v1.Node)) *v1.Node {
 	node := &v1.Node{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Node",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:     name,
 			SelfLink: fmt.Sprintf("/api/v1/nodes/%s", name),
@@ -201,6 +221,10 @@ func BuildTestNode(name string, millicpu, mem, pods int64, apply func(*v1.Node))
 
 func BuildNodeMetrics(name string, millicpu, mem int64) *v1beta1.NodeMetrics {
 	return &v1beta1.NodeMetrics{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "metrics.k8s.io/v1beta1",
+			Kind:       "NodeMetrics",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},


### PR DESCRIPTION
## Description
Instead of re-creating the fake client and factory again during each descheduling cycle (when dry mode is enable) use event handlers and restoration of locally evicted pods. This will remove the need to register indexer during each descheduling cycle as well.

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [-] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [-] **Dependencies**: Are new dependencies justified ?
- [-] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [-] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [-] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [-] **Documentation & Changelog**: Are README and docs updated if necessary?
