### PR TITLE
fix(ci): pin helm-unittest plugin version and bump chart-testing-action

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -38,13 +38,13 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.8.0
         with:
           version: v3.11.0
 
       - name: Install Helm Unit Test Plugin
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest
+          helm plugin install --version 1.0.3 https://github.com/helm-unittest/helm-unittest
 
       - name: Run Helm Unit Tests
         run: |


### PR DESCRIPTION
## Description

The `Install Helm Unit Test Plugin` step in the Helm CI workflow is [failing](https://github.com/kubernetes-sigs/descheduler/actions/runs/22174634411/job/64147071893) with:

```
error unmarshaling JSON: while decoding JSON: json: unknown field "platformHooks"
```

This is caused by an incompatible change in the latest helm-unittest plugin release. This PR:
- Pins `helm-unittest` to **v1.0.3** to avoid the breaking `platformHooks` field
- Bumps `helm/chart-testing-action` from **v2.6.1** to **v2.8.0**

## Checklist

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?