### PR TITLE
feat: rollout restart single-replica Deployments instead of evicting

### DIFF
--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -27,6 +27,12 @@ rules:
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "patch"]
 {{- if .Values.leaderElection.enabled }}
 - apiGroups: ["coordination.k8s.io"]
   resources: ["leases"]

--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -38,6 +38,12 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["get", "patch"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/descheduler/kubeclientsandbox.go
+++ b/pkg/descheduler/kubeclientsandbox.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -103,6 +104,8 @@ func newDefaultKubeClientSandbox(client clientset.Interface, sharedInformerFacto
 		schedulingv1.SchemeGroupVersion.WithResource("priorityclasses"),
 		policyv1.SchemeGroupVersion.WithResource("poddisruptionbudgets"),
 		v1.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
+		appsv1.SchemeGroupVersion.WithResource("replicasets"),
+		appsv1.SchemeGroupVersion.WithResource("deployments"),
 	)
 }
 


### PR DESCRIPTION
## Description
For Deployments with replicas=1 and RollingUpdate strategy, trigger a rollout restart (patch pod template annotation) instead of using the Pod Eviction API. This avoids downtime by letting the Deployment controller create a new pod before terminating the old one.

Falls through to normal eviction on errors, non-Deployment pods, multi-replica Deployments, or Recreate strategy.
Fixes #786 #1558
## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [ ] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [ ] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [ ] **Code Duplication**: Is there any repeated code that should be refactored?
- [ ] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [ ] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [ ] **Error Handling**: Are errors handled appropriately ?
- [ ] **Testing**: Are there sufficient unit/integration tests?
- [ ] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [ ] **Dependencies**: Are new dependencies justified ?
- [ ] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [ ] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [ ] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [ ] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [ ] **Documentation & Changelog**: Are README and docs updated if necessary?
