### PR TITLE
feat: add HTTP trigger API for on-demand descheduling cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ kubectl create -f kubernetes/base/configmap.yaml
 kubectl create -f kubernetes/deployment/deployment.yaml
 ```
 
+> When running as a Deployment you can optionally enable the [Trigger API](#trigger-api) to manually trigger descheduling cycles on demand via an HTTP endpoint.
+
 ### Install Using Helm
 
 Starting with release v0.18.0 there is an official helm chart that can be used to install the
@@ -1147,6 +1149,108 @@ To get best results from HA mode some additional configurations might require:
 
 The metrics are served through https://localhost:10258/metrics by default.
 The address and port can be changed by setting `--binding-address` and `--secure-port` flags.
+
+## Trigger API
+
+The descheduler exposes an optional HTTP endpoint that allows any authorized caller to **manually trigger a descheduling cycle on demand** without waiting for the next scheduled interval or restarting the process.
+
+This is useful when:
+- A node drain or topology imbalance just occurred and eviction must run immediately, not in N minutes when the timer fires.
+- A CI/CD pipeline needs to rebalance pods after a rollout and must know the cycle has completed before proceeding.
+- An on-call engineer needs an emergency eviction pass without touching the descheduler deployment.
+- A cluster runs with a long `--descheduling-interval` to minimize churn, but requires an escape hatch for urgent situations.
+
+### Enabling the Trigger API
+
+Pass the `--enable-trigger-api` flag when starting the descheduler:
+
+```bash
+descheduler \
+  --policy-config-file=/etc/descheduler/policy.yaml \
+  --descheduling-interval=30m \
+  --enable-trigger-api
+```
+
+When using Helm, add the flag via `deschedulerCommandArguments`:
+
+```yaml
+deschedulerCommandArguments:
+  - "--enable-trigger-api"
+```
+
+The endpoint is registered on the existing HTTPS server (default port `10258`) — no additional ports, listeners, or TLS configuration is required.
+
+### Endpoint Reference
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/descheduler/run` | Synchronously trigger a full descheduling cycle |
+
+The request **blocks until the cycle completes** and returns a JSON response with the result. Only one trigger can be queued at a time; concurrent requests are rejected with `429`.
+
+#### Response codes
+
+| Code | Meaning |
+|------|---------|
+| `200 OK` | Cycle completed successfully |
+| `405 Method Not Allowed` | Non-POST request |
+| `429 Too Many Requests` | A trigger is already queued or a cycle is in progress |
+| `500 Internal Server Error` | Cycle failed; error detail in `message` field |
+| `504 Gateway Timeout` | HTTP client disconnected before the cycle finished |
+
+**Example success response:**
+```json
+{"message": "descheduling cycle completed successfully", "status": "ok"}
+```
+
+**Example rejection response (cycle already running):**
+```json
+{"message": "descheduling cycle already in progress or pending", "status": "error"}
+```
+
+### Usage Examples
+
+**Trigger from inside the cluster (exec into the descheduler pod):**
+
+```bash
+kubectl exec -n kube-system deploy/descheduler -- \
+  curl -sk -X POST https://localhost:10258/api/v1/descheduler/run
+```
+
+**Trigger via port-forward from a local machine:**
+
+```bash
+kubectl port-forward -n kube-system deploy/descheduler 10258:10258 &
+curl -sk -X POST https://localhost:10258/api/v1/descheduler/run
+```
+
+**Trigger with a timeout (useful in scripts):**
+
+```bash
+curl -sk --max-time 300 -X POST \
+  https://localhost:10258/api/v1/descheduler/run | jq .
+```
+
+**Use in a CI/CD step and assert success:**
+
+```bash
+curl -sk --max-time 300 -f -X POST \
+  https://localhost:10258/api/v1/descheduler/run \
+  | jq -e '.status == "ok"'
+```
+
+### On-Demand-Only Mode (no automatic interval)
+
+Setting `--descheduling-interval=0` together with `--enable-trigger-api` runs one cycle at startup and then keeps the process alive, responding exclusively to manual trigger requests. This is useful for environments where eviction should only happen on explicit operator request:
+
+```bash
+descheduler \
+  --policy-config-file=/etc/descheduler/policy.yaml \
+  --descheduling-interval=0 \
+  --enable-trigger-api
+```
+
+> **Note:** The trigger API is disabled by default. Existing deployments without `--enable-trigger-api` are completely unaffected.
 
 ## Compatibility Matrix
 The below compatibility matrix shows the k8s client package(client-go, apimachinery, etc) versions that descheduler

--- a/README.md
+++ b/README.md
@@ -1155,10 +1155,11 @@ The address and port can be changed by setting `--binding-address` and `--secure
 The descheduler exposes an optional HTTP endpoint that allows any authorized caller to **manually trigger a descheduling cycle on demand** without waiting for the next scheduled interval or restarting the process.
 
 This is useful when:
-- A node drain or topology imbalance just occurred and eviction must run immediately, not in N minutes when the timer fires.
-- A CI/CD pipeline needs to rebalance pods after a rollout and must know the cycle has completed before proceeding.
-- An on-call engineer needs an emergency eviction pass without touching the descheduler deployment.
-- A cluster runs with a long `--descheduling-interval` to minimize churn, but requires an escape hatch for urgent situations.
+
+* A node drain or topology imbalance just occurred and eviction must run immediately, not in N minutes when the timer fires.
+* A CI/CD pipeline needs to request a rebalance after a rollout and know the cycle was accepted.
+* An on-call engineer needs an emergency eviction pass without touching the descheduler deployment.
+* A cluster runs with a long `--descheduling-interval` to minimize churn, but requires an escape hatch for urgent situations.
 
 ### Enabling the Trigger API
 
@@ -1178,65 +1179,92 @@ deschedulerCommandArguments:
   - "--enable-trigger-api"
 ```
 
-The endpoint is registered on the existing HTTPS server (default port `10258`) — no additional ports, listeners, or TLS configuration is required.
+The endpoint is registered on the existing HTTPS server (default port `10258`) — no additional ports, listeners, or TLS configuration is required. Requests must include a Kubernetes service account bearer token authorized to `post` the `/api/v1/descheduler/run` non-resource URL.
+
+Example caller RBAC:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: descheduler-trigger
+rules:
+- nonResourceURLs:
+  - /api/v1/descheduler/run
+  verbs:
+  - post
+```
 
 ### Endpoint Reference
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/api/v1/descheduler/run` | Synchronously trigger a full descheduling cycle |
+| `POST` | `/api/v1/descheduler/run` | Start a descheduling cycle |
 
-The request **blocks until the cycle completes** and returns a JSON response with the result. Only one trigger can be queued at a time; concurrent requests are rejected with `429`.
+The request returns once the cycle has been accepted for execution. It does not block until the cycle completes. Only one descheduling cycle can run at a time across startup, scheduled, and manually triggered cycles; concurrent trigger requests are rejected with `409`.
 
 #### Response codes
 
 | Code | Meaning |
 |------|---------|
-| `200 OK` | Cycle completed successfully |
+| `202 Accepted` | Cycle started |
+| `401 Unauthorized` | Missing or invalid bearer token |
+| `403 Forbidden` | Caller is not allowed to trigger descheduler |
 | `405 Method Not Allowed` | Non-POST request |
-| `429 Too Many Requests` | A trigger is already queued or a cycle is in progress |
-| `500 Internal Server Error` | Cycle failed; error detail in `message` field |
-| `504 Gateway Timeout` | HTTP client disconnected before the cycle finished |
+| `409 Conflict` | A cycle is already running |
+| `500 Internal Server Error` | Authentication, authorization, or trigger startup failed |
+| `503 Service Unavailable` | Descheduler is not ready to accept trigger requests |
 
-**Example success response:**
+**Example accepted response:**
+
 ```json
-{"message": "descheduling cycle completed successfully", "status": "ok"}
+{"message": "descheduling cycle started", "status": "accepted"}
 ```
 
 **Example rejection response (cycle already running):**
+
 ```json
-{"message": "descheduling cycle already in progress or pending", "status": "error"}
+{"message": "descheduling cycle already running", "status": "error"}
 ```
 
 ### Usage Examples
 
-**Trigger from inside the cluster (exec into the descheduler pod):**
+**Trigger from inside a pod using an authorized service account:**
 
 ```bash
-kubectl exec -n kube-system deploy/descheduler -- \
-  curl -sk -X POST https://localhost:10258/api/v1/descheduler/run
+TOKEN="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+curl -sk -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  https://descheduler.kube-system.svc:10258/api/v1/descheduler/run
 ```
 
 **Trigger via port-forward from a local machine:**
 
 ```bash
+TOKEN="$(kubectl -n kube-system create token descheduler-trigger)"
 kubectl port-forward -n kube-system deploy/descheduler 10258:10258 &
-curl -sk -X POST https://localhost:10258/api/v1/descheduler/run
+curl -sk -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  https://localhost:10258/api/v1/descheduler/run
 ```
+
+The `descheduler-trigger` service account in this example must be bound to a role that allows `post` on the `/api/v1/descheduler/run` non-resource URL.
 
 **Trigger with a timeout (useful in scripts):**
 
 ```bash
 curl -sk --max-time 300 -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
   https://localhost:10258/api/v1/descheduler/run | jq .
 ```
 
-**Use in a CI/CD step and assert success:**
+**Use in a CI/CD step and assert the cycle was accepted:**
 
 ```bash
 curl -sk --max-time 300 -f -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
   https://localhost:10258/api/v1/descheduler/run \
-  | jq -e '.status == "ok"'
+  | jq -e '.status == "accepted"'
 ```
 
 ### On-Demand-Only Mode (no automatic interval)

--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -60,6 +60,10 @@ type DeschedulerServer struct {
 	SecureServingInfo *apiserver.SecureServingInfo
 	DisableMetrics    bool
 	EnableHTTP2       bool
+	EnableTriggerAPI  bool
+	// TriggerCh is used to manually trigger a descheduling cycle via the HTTP API.
+	// Each request sends a chan error; the loop sends the cycle result back on it.
+	TriggerCh chan chan error
 	// FeatureGates enabled by the user
 	FeatureGates map[string]bool
 	// DefaultFeatureGates for internal accessing so unit tests can enable/disable specific features
@@ -121,6 +125,7 @@ func (rs *DeschedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Float64Var(&rs.Tracing.SampleRate, "otel-sample-rate", 1.0, "Sample rate to collect the Traces")
 	fs.BoolVar(&rs.Tracing.FallbackToNoOpProviderOnError, "otel-fallback-no-op-on-error", false, "Fallback to NoOp Tracer in case of error")
 	fs.BoolVar(&rs.EnableHTTP2, "enable-http2", false, "If http/2 should be enabled for the metrics and health check")
+	fs.BoolVar(&rs.EnableTriggerAPI, "enable-trigger-api", rs.EnableTriggerAPI, "Enable the /api/v1/descheduler/run endpoint for manually triggering descheduling cycles via HTTP POST.")
 	fs.Var(cliflag.NewMapStringBool(&rs.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
 		"Options are:\n"+strings.Join(features.DefaultMutableFeatureGate.KnownFeatures(), "\n"))
 

--- a/cmd/descheduler/app/options/options.go
+++ b/cmd/descheduler/app/options/options.go
@@ -39,6 +39,7 @@ import (
 
 	"sigs.k8s.io/descheduler/pkg/apis/componentconfig"
 	"sigs.k8s.io/descheduler/pkg/apis/componentconfig/v1alpha1"
+	"sigs.k8s.io/descheduler/pkg/descheduler/cycle"
 	deschedulerscheme "sigs.k8s.io/descheduler/pkg/descheduler/scheme"
 	"sigs.k8s.io/descheduler/pkg/features"
 	"sigs.k8s.io/descheduler/pkg/tracing"
@@ -54,6 +55,7 @@ type DeschedulerServer struct {
 
 	Client            clientset.Interface
 	EventClient       clientset.Interface
+	TriggerAuthClient clientset.Interface
 	MetricsClient     metricsclient.Interface
 	PrometheusClient  promapi.Client
 	SecureServing     *apiserveroptions.SecureServingOptionsWithLoopback
@@ -61,9 +63,7 @@ type DeschedulerServer struct {
 	DisableMetrics    bool
 	EnableHTTP2       bool
 	EnableTriggerAPI  bool
-	// TriggerCh is used to manually trigger a descheduling cycle via the HTTP API.
-	// Each request sends a chan error; the loop sends the cycle result back on it.
-	TriggerCh chan chan error
+	CycleManager      *cycle.Manager
 	// FeatureGates enabled by the user
 	FeatureGates map[string]bool
 	// DefaultFeatureGates for internal accessing so unit tests can enable/disable specific features
@@ -83,6 +83,7 @@ func NewDeschedulerServer() (*DeschedulerServer, error) {
 	return &DeschedulerServer{
 		DeschedulerConfiguration: *cfg,
 		SecureServing:            secureServing,
+		CycleManager:             cycle.NewManager(),
 	}, nil
 }
 

--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -19,7 +19,9 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"io"
+	"net/http"
 	"os/signal"
 	"syscall"
 	"time"
@@ -98,6 +100,12 @@ func Run(rootCtx context.Context, rs *options.DeschedulerServer) error {
 
 	healthz.InstallHandler(pathRecorderMux, healthz.NamedCheck("Descheduler", healthz.PingHealthz.Check))
 
+	if rs.EnableTriggerAPI {
+		rs.TriggerCh = make(chan chan error, 1)
+		pathRecorderMux.Handle("/api/v1/descheduler/run", newTriggerHandler(rs.TriggerCh))
+		klog.V(1).Info("Trigger API enabled at /api/v1/descheduler/run")
+	}
+
 	var stoppedCh <-chan struct{}
 	var err error
 	if rs.SecureServingInfo != nil {
@@ -136,4 +144,54 @@ func Run(rootCtx context.Context, rs *options.DeschedulerServer) error {
 	}
 
 	return nil
+}
+
+func newTriggerHandler(triggerCh chan chan error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{
+				"status":  "error",
+				"message": "method not allowed, use POST",
+			})
+			return
+		}
+
+		resultCh := make(chan error, 1)
+		select {
+		case triggerCh <- resultCh:
+			klog.V(2).Info("Descheduling cycle triggered via API")
+		default:
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{
+				"status":  "error",
+				"message": "descheduling cycle already in progress or pending",
+			})
+			return
+		}
+
+		select {
+		case err := <-resultCh:
+			if err != nil {
+				writeJSON(w, http.StatusInternalServerError, map[string]string{
+					"status":  "error",
+					"message": err.Error(),
+				})
+			} else {
+				writeJSON(w, http.StatusOK, map[string]string{
+					"status":  "ok",
+					"message": "descheduling cycle completed successfully",
+				})
+			}
+		case <-r.Context().Done():
+			writeJSON(w, http.StatusGatewayTimeout, map[string]string{
+				"status":  "error",
+				"message": "request cancelled or timed out",
+			})
+		}
+	})
+}
+
+func writeJSON(w http.ResponseWriter, statusCode int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(data) //nolint:errcheck
 }

--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -30,12 +31,18 @@ import (
 
 	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/descheduler"
+	deschedulerclient "sigs.k8s.io/descheduler/pkg/descheduler/client"
+	"sigs.k8s.io/descheduler/pkg/descheduler/cycle"
 	"sigs.k8s.io/descheduler/pkg/tracing"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
@@ -43,6 +50,8 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 )
+
+const triggerAPIPath = "/api/v1/descheduler/run"
 
 // NewDeschedulerCommand creates a *cobra.Command object with default parameters
 func NewDeschedulerCommand(out io.Writer) *cobra.Command {
@@ -101,9 +110,19 @@ func Run(rootCtx context.Context, rs *options.DeschedulerServer) error {
 	healthz.InstallHandler(pathRecorderMux, healthz.NamedCheck("Descheduler", healthz.PingHealthz.Check))
 
 	if rs.EnableTriggerAPI {
-		rs.TriggerCh = make(chan chan error, 1)
-		pathRecorderMux.Handle("/api/v1/descheduler/run", newTriggerHandler(rs.TriggerCh))
-		klog.V(1).Info("Trigger API enabled at /api/v1/descheduler/run")
+		if rs.TriggerAuthClient == nil {
+			clientConnection := rs.ClientConnection
+			if rs.KubeconfigFile != "" && clientConnection.Kubeconfig == "" {
+				clientConnection.Kubeconfig = rs.KubeconfigFile
+			}
+			triggerClient, err := deschedulerclient.CreateClient(clientConnection, "descheduler-trigger-api")
+			if err != nil {
+				return err
+			}
+			rs.TriggerAuthClient = triggerClient
+		}
+		pathRecorderMux.Handle(triggerAPIPath, newTriggerHandler(rs))
+		klog.V(1).Infof("Trigger API enabled at %s", triggerAPIPath)
 	}
 
 	var stoppedCh <-chan struct{}
@@ -146,7 +165,7 @@ func Run(rootCtx context.Context, rs *options.DeschedulerServer) error {
 	return nil
 }
 
-func newTriggerHandler(triggerCh chan chan error) http.Handler {
+func newTriggerHandler(rs *options.DeschedulerServer) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			writeJSON(w, http.StatusMethodNotAllowed, map[string]string{
@@ -156,38 +175,117 @@ func newTriggerHandler(triggerCh chan chan error) http.Handler {
 			return
 		}
 
-		resultCh := make(chan error, 1)
-		select {
-		case triggerCh <- resultCh:
-			klog.V(2).Info("Descheduling cycle triggered via API")
-		default:
-			writeJSON(w, http.StatusTooManyRequests, map[string]string{
+		if err := authorizeTriggerRequest(r.Context(), rs.TriggerAuthClient, r); err != nil {
+			writeJSON(w, err.statusCode, map[string]string{
 				"status":  "error",
-				"message": "descheduling cycle already in progress or pending",
+				"message": err.message,
 			})
 			return
 		}
 
-		select {
-		case err := <-resultCh:
-			if err != nil {
+		if rs.CycleManager == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"status":  "error",
+				"message": "descheduling cycle manager is not ready",
+			})
+			return
+		}
+
+		if err := rs.CycleManager.TryStart(); err != nil {
+			switch err {
+			case cycle.ErrAlreadyRunning:
+				writeJSON(w, http.StatusConflict, map[string]string{
+					"status":  "error",
+					"message": "descheduling cycle already running",
+				})
+			case cycle.ErrRunnerNotReady:
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+					"status":  "error",
+					"message": "descheduling cycle runner is not ready",
+				})
+			default:
 				writeJSON(w, http.StatusInternalServerError, map[string]string{
 					"status":  "error",
 					"message": err.Error(),
 				})
-			} else {
-				writeJSON(w, http.StatusOK, map[string]string{
-					"status":  "ok",
-					"message": "descheduling cycle completed successfully",
-				})
 			}
-		case <-r.Context().Done():
-			writeJSON(w, http.StatusGatewayTimeout, map[string]string{
-				"status":  "error",
-				"message": "request cancelled or timed out",
-			})
+			return
 		}
+
+		klog.V(1).Info("Descheduling cycle triggered via API")
+		writeJSON(w, http.StatusAccepted, map[string]string{
+			"status":  "accepted",
+			"message": "descheduling cycle started",
+		})
 	})
+}
+
+type triggerAuthError struct {
+	statusCode int
+	message    string
+}
+
+func authorizeTriggerRequest(ctx context.Context, client clientset.Interface, r *http.Request) *triggerAuthError {
+	if client == nil {
+		return &triggerAuthError{statusCode: http.StatusServiceUnavailable, message: "kubernetes client is not ready"}
+	}
+
+	token := bearerToken(r.Header.Get("Authorization"))
+	if token == "" {
+		return &triggerAuthError{statusCode: http.StatusUnauthorized, message: "missing bearer token"}
+	}
+
+	tokenReview, err := client.AuthenticationV1().TokenReviews().Create(ctx, &authenticationv1.TokenReview{
+		Spec: authenticationv1.TokenReviewSpec{Token: token},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Failed to authenticate trigger API request")
+		return &triggerAuthError{statusCode: http.StatusInternalServerError, message: "failed to authenticate request"}
+	}
+	if !tokenReview.Status.Authenticated {
+		return &triggerAuthError{statusCode: http.StatusUnauthorized, message: "invalid bearer token"}
+	}
+
+	subjectAccessReview, err := client.AuthorizationV1().SubjectAccessReviews().Create(ctx, &authorizationv1.SubjectAccessReview{
+		Spec: authorizationv1.SubjectAccessReviewSpec{
+			User:   tokenReview.Status.User.Username,
+			UID:    tokenReview.Status.User.UID,
+			Groups: tokenReview.Status.User.Groups,
+			Extra:  authorizationExtra(tokenReview.Status.User.Extra),
+			NonResourceAttributes: &authorizationv1.NonResourceAttributes{
+				Path: triggerAPIPath,
+				Verb: "post",
+			},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Failed to authorize trigger API request")
+		return &triggerAuthError{statusCode: http.StatusInternalServerError, message: "failed to authorize request"}
+	}
+	if !subjectAccessReview.Status.Allowed {
+		return &triggerAuthError{statusCode: http.StatusForbidden, message: "not allowed to trigger descheduler"}
+	}
+
+	return nil
+}
+
+func bearerToken(header string) string {
+	authType, token, ok := strings.Cut(header, " ")
+	if !ok || !strings.EqualFold(authType, "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(token)
+}
+
+func authorizationExtra(extra map[string]authenticationv1.ExtraValue) map[string]authorizationv1.ExtraValue {
+	if len(extra) == 0 {
+		return nil
+	}
+	converted := make(map[string]authorizationv1.ExtraValue, len(extra))
+	for key, values := range extra {
+		converted[key] = authorizationv1.ExtraValue(values)
+	}
+	return converted
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, data interface{}) {

--- a/cmd/descheduler/app/server_test.go
+++ b/cmd/descheduler/app/server_test.go
@@ -1,0 +1,194 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+
+	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
+	"sigs.k8s.io/descheduler/pkg/descheduler/cycle"
+)
+
+func TestTriggerHandlerMethodNotAllowed(t *testing.T) {
+	rs := newTriggerTestServer(t, true)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, triggerAPIPath, nil)
+
+	newTriggerHandler(rs).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", recorder.Code)
+	}
+}
+
+func TestTriggerHandlerRequiresBearerToken(t *testing.T) {
+	rs := newTriggerTestServer(t, true)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, triggerAPIPath, nil)
+
+	newTriggerHandler(rs).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", recorder.Code)
+	}
+}
+
+func TestTriggerHandlerRejectsInvalidToken(t *testing.T) {
+	rs := newTriggerTestServer(t, false)
+	recorder := httptest.NewRecorder()
+	request := triggerRequest()
+
+	newTriggerHandler(rs).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", recorder.Code)
+	}
+}
+
+func TestTriggerHandlerRejectsForbiddenUser(t *testing.T) {
+	rs := newTriggerTestServer(t, true)
+	addSubjectAccessReviewReactor(rs.TriggerAuthClient.(*fakeclientset.Clientset), false)
+	recorder := httptest.NewRecorder()
+	request := triggerRequest()
+
+	newTriggerHandler(rs).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", recorder.Code)
+	}
+}
+
+func TestTriggerHandlerStartsCycle(t *testing.T) {
+	rs := newTriggerTestServer(t, true)
+	addSubjectAccessReviewReactor(rs.TriggerAuthClient.(*fakeclientset.Clientset), true)
+	started := make(chan struct{})
+	rs.CycleManager.SetRunner(func() error {
+		close(started)
+		return nil
+	})
+	recorder := httptest.NewRecorder()
+	request := triggerRequest()
+
+	newTriggerHandler(rs).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", recorder.Code)
+	}
+	<-started
+	assertJSONStatus(t, recorder, "accepted")
+}
+
+func TestTriggerHandlerRejectsRunningCycle(t *testing.T) {
+	rs := newTriggerTestServer(t, true)
+	addSubjectAccessReviewReactor(rs.TriggerAuthClient.(*fakeclientset.Clientset), true)
+	release := make(chan struct{})
+	rs.CycleManager.SetRunner(func() error {
+		<-release
+		return nil
+	})
+	if err := rs.CycleManager.TryStart(); err != nil {
+		t.Fatalf("expected initial cycle to start, got %v", err)
+	}
+	defer close(release)
+
+	recorder := httptest.NewRecorder()
+	request := triggerRequest()
+	newTriggerHandler(rs).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", recorder.Code)
+	}
+}
+
+func newTriggerTestServer(t *testing.T, authenticated bool) *options.DeschedulerServer {
+	t.Helper()
+	client := fakeclientset.NewSimpleClientset()
+	client.PrependReactor("create", "tokenreviews", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.TokenReview{
+			Status: authenticationv1.TokenReviewStatus{
+				Authenticated: authenticated,
+				User: authenticationv1.UserInfo{
+					Username: "system:serviceaccount:kube-system:descheduler-trigger",
+					UID:      "test-uid",
+					Groups:   []string{"system:serviceaccounts", "system:serviceaccounts:kube-system"},
+				},
+			},
+		}, nil
+	})
+
+	return &options.DeschedulerServer{
+		TriggerAuthClient: client,
+		CycleManager:      cycle.NewManager(),
+	}
+}
+
+func addSubjectAccessReviewReactor(client *fakeclientset.Clientset, allowed bool) {
+	client.PrependReactor("create", "subjectaccessreviews", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &authorizationv1.SubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{
+				Allowed: allowed,
+			},
+		}, nil
+	})
+}
+
+func triggerRequest() *http.Request {
+	request := httptest.NewRequest(http.MethodPost, triggerAPIPath, nil)
+	request.Header.Set("Authorization", "Bearer test-token")
+	return request
+}
+
+func assertJSONStatus(t *testing.T, recorder *httptest.ResponseRecorder, expected string) {
+	t.Helper()
+	var response map[string]string
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if response["status"] != expected {
+		t.Fatalf("expected response status %q, got %q", expected, response["status"])
+	}
+}
+
+func TestAuthorizeTriggerRequestUsesNonResourceAttributes(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+	client.PrependReactor("create", "tokenreviews", func(action core.Action) (bool, runtime.Object, error) {
+		return true, &authenticationv1.TokenReview{
+			Status: authenticationv1.TokenReviewStatus{
+				Authenticated: true,
+				User: authenticationv1.UserInfo{
+					Username: "test-user",
+					Groups:   []string{"test-group"},
+				},
+			},
+		}, nil
+	})
+	client.PrependReactor("create", "subjectaccessreviews", func(action core.Action) (bool, runtime.Object, error) {
+		createAction := action.(core.CreateAction)
+		review := createAction.GetObject().(*authorizationv1.SubjectAccessReview)
+		if review.Spec.NonResourceAttributes == nil {
+			t.Fatalf("expected non-resource attributes")
+		}
+		if review.Spec.NonResourceAttributes.Path != triggerAPIPath {
+			t.Fatalf("expected path %q, got %q", triggerAPIPath, review.Spec.NonResourceAttributes.Path)
+		}
+		if review.Spec.NonResourceAttributes.Verb != "post" {
+			t.Fatalf("expected verb post, got %q", review.Spec.NonResourceAttributes.Verb)
+		}
+		return true, &authorizationv1.SubjectAccessReview{
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
+		}, nil
+	})
+
+	request := triggerRequest()
+	if err := authorizeTriggerRequest(context.Background(), client, request); err != nil {
+		t.Fatalf("expected authorization to succeed, got %v", err)
+	}
+}

--- a/docs/cli/descheduler.md
+++ b/docs/cli/descheduler.md
@@ -23,6 +23,7 @@ descheduler [flags]
       --disable-metrics                          Disables metrics. The metrics are by default served through https://localhost:10258/metrics. Secure address, resp. port can be changed through --bind-address, resp. --secure-port flags.
       --dry-run                                  Execute descheduler in dry run mode.
       --enable-http2                             If http/2 should be enabled for the metrics and health check
+      --enable-trigger-api                       Enable the /api/v1/descheduler/run endpoint for manually triggering descheduling cycles via HTTP POST.
       --feature-gates mapStringBool              A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                  AllAlpha=true|false (ALPHA - default=false)
                                                  AllBeta=true|false (BETA - default=false)

--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -38,6 +38,12 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/descheduler/cycle/manager.go
+++ b/pkg/descheduler/cycle/manager.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cycle
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	ErrAlreadyRunning = errors.New("descheduling cycle already running")
+	ErrRunnerNotReady = errors.New("descheduling cycle runner is not ready")
+)
+
+type Runner func() error
+
+type Manager struct {
+	mu      sync.Mutex
+	running bool
+	runner  Runner
+}
+
+func NewManager() *Manager {
+	return &Manager{}
+}
+
+func (m *Manager) SetRunner(runner Runner) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runner = runner
+}
+
+func (m *Manager) Run() error {
+	runner, err := m.start()
+	if err != nil {
+		return err
+	}
+	defer m.finish()
+	return runner()
+}
+
+func (m *Manager) TryStart() error {
+	runner, err := m.start()
+	if err != nil {
+		return err
+	}
+	go func() {
+		defer m.finish()
+		_ = runner()
+	}()
+	return nil
+}
+
+func (m *Manager) start() (Runner, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.runner == nil {
+		return nil, ErrRunnerNotReady
+	}
+	if m.running {
+		return nil, ErrAlreadyRunning
+	}
+	m.running = true
+	return m.runner, nil
+}
+
+func (m *Manager) finish() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.running = false
+}

--- a/pkg/descheduler/cycle/manager_test.go
+++ b/pkg/descheduler/cycle/manager_test.go
@@ -1,0 +1,76 @@
+package cycle
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestManagerRejectsConcurrentStart(t *testing.T) {
+	manager := NewManager()
+	release := make(chan struct{})
+	manager.SetRunner(func() error {
+		<-release
+		return nil
+	})
+
+	if err := manager.TryStart(); err != nil {
+		t.Fatalf("expected first cycle to start, got %v", err)
+	}
+	if err := manager.TryStart(); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("expected already running error, got %v", err)
+	}
+
+	close(release)
+
+	deadline := time.After(time.Second)
+	for {
+		err := manager.TryStart()
+		if err == nil {
+			return
+		}
+		if !errors.Is(err, ErrAlreadyRunning) {
+			t.Fatalf("expected already running while waiting for finish, got %v", err)
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for cycle manager to release running cycle")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func TestManagerRunRejectsConcurrentTryStart(t *testing.T) {
+	manager := NewManager()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	manager.SetRunner(func() error {
+		close(started)
+		<-release
+		return nil
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- manager.Run()
+	}()
+
+	<-started
+	if err := manager.TryStart(); !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("expected already running error, got %v", err)
+	}
+
+	close(release)
+	if err := <-errCh; err != nil {
+		t.Fatalf("expected running cycle to finish successfully, got %v", err)
+	}
+}
+
+func TestManagerRejectsBeforeRunnerReady(t *testing.T) {
+	manager := NewManager()
+
+	if err := manager.TryStart(); !errors.Is(err, ErrRunnerNotReady) {
+		t.Fatalf("expected runner not ready error, got %v", err)
+	}
+}

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -532,23 +532,44 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		return err
 	}
 
-	wait.NonSlidingUntil(func() {
-		// A next context is created here intentionally to avoid nesting the spans via context.
-		sCtx, sSpan := tracing.Tracer().Start(ctx, "NonSlidingUntil")
+	executeCycle := func() error {
+		sCtx, sSpan := tracing.Tracer().Start(ctx, "DeschedulingCycle")
 		defer sSpan.End()
-
 		if err := runLoop(sCtx); err != nil {
 			sSpan.AddEvent("Descheduling loop failed", trace.WithAttributes(attribute.String("err", err.Error())))
 			klog.Error(err)
-			return
+			return err
 		}
-		// If there was no interval specified, send a signal to the stopChannel to end the wait.Until loop after 1 iteration
-		if rs.DeschedulingInterval.Seconds() == 0 {
-			cancel()
-		}
-	}, rs.DeschedulingInterval, ctx.Done())
+		return nil
+	}
 
-	return nil
+	executeCycle() //nolint:errcheck
+
+	if rs.DeschedulingInterval.Seconds() == 0 && rs.TriggerCh == nil {
+		return nil
+	}
+
+	var tickerC <-chan time.Time
+	if rs.DeschedulingInterval.Seconds() > 0 {
+		ticker := time.NewTicker(rs.DeschedulingInterval)
+		defer ticker.Stop()
+		tickerC = ticker.C
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-tickerC:
+			executeCycle() //nolint:errcheck
+		case resultCh := <-rs.TriggerCh:
+			klog.V(1).Info("Descheduling cycle triggered via API")
+			err := executeCycle()
+			if resultCh != nil {
+				resultCh <- err
+			}
+		}
+	}
 }
 
 func GetPluginConfig(pluginName string, pluginConfigs []api.PluginConfig) (*api.PluginConfig, int) {

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/descheduler/metrics"
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/descheduler/client"
+	"sigs.k8s.io/descheduler/pkg/descheduler/cycle"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	eutils "sigs.k8s.io/descheduler/pkg/descheduler/evictions/utils"
 	"sigs.k8s.io/descheduler/pkg/descheduler/metricscollector"
@@ -313,12 +314,18 @@ func Run(ctx context.Context, rs *options.DeschedulerServer) error {
 	if rs.KubeconfigFile != "" && clientConnection.Kubeconfig == "" {
 		clientConnection.Kubeconfig = rs.KubeconfigFile
 	}
-	rsclient, eventClient, err := createClients(clientConnection)
-	if err != nil {
-		return err
+	if rs.Client == nil || rs.EventClient == nil {
+		rsclient, eventClient, err := createClients(clientConnection)
+		if err != nil {
+			return err
+		}
+		if rs.Client == nil {
+			rs.Client = rsclient
+		}
+		if rs.EventClient == nil {
+			rs.EventClient = eventClient
+		}
 	}
-	rs.Client = rsclient
-	rs.EventClient = eventClient
 
 	deschedulerPolicy, err := LoadPolicyConfig(rs.PolicyConfigFile, rs.Client, pluginregistry.PluginRegistry)
 	if err != nil {
@@ -360,7 +367,7 @@ func Run(ctx context.Context, rs *options.DeschedulerServer) error {
 	}
 
 	if rs.LeaderElection.LeaderElect && !rs.DryRun {
-		if err := NewLeaderElection(runFn, rsclient, &rs.LeaderElection, ctx); err != nil {
+		if err := NewLeaderElection(runFn, rs.Client, &rs.LeaderElection, ctx); err != nil {
 			span.AddEvent("Leader Election Failure", trace.WithAttributes(attribute.String("err", err.Error())))
 			return fmt.Errorf("leaderElection: %w", err)
 		}
@@ -543,9 +550,21 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		return nil
 	}
 
-	executeCycle() //nolint:errcheck
+	cycleManager := rs.CycleManager
+	if cycleManager == nil {
+		cycleManager = cycle.NewManager()
+		rs.CycleManager = cycleManager
+	}
+	cycleManager.SetRunner(executeCycle)
 
-	if rs.DeschedulingInterval.Seconds() == 0 && rs.TriggerCh == nil {
+	if err := cycleManager.Run(); err != nil {
+		if err != cycle.ErrAlreadyRunning {
+			return err
+		}
+		klog.V(2).Info("Skipping startup descheduling cycle: another cycle is already running")
+	}
+
+	if rs.DeschedulingInterval.Seconds() == 0 && !rs.EnableTriggerAPI {
 		return nil
 	}
 
@@ -561,12 +580,12 @@ func RunDeschedulerStrategies(ctx context.Context, rs *options.DeschedulerServer
 		case <-ctx.Done():
 			return nil
 		case <-tickerC:
-			executeCycle() //nolint:errcheck
-		case resultCh := <-rs.TriggerCh:
-			klog.V(1).Info("Descheduling cycle triggered via API")
-			err := executeCycle()
-			if resultCh != nil {
-				resultCh <- err
+			if err := cycleManager.Run(); err != nil {
+				if err == cycle.ErrAlreadyRunning {
+					klog.V(2).Info("Skipping scheduled descheduling cycle: another cycle is already running")
+					continue
+				}
+				klog.ErrorS(err, "Failed to start scheduled descheduling cycle")
 			}
 		}
 	}

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -461,6 +461,143 @@ func TestRootCancelWithNoInterval(t *testing.T) {
 	}
 }
 
+func TestTriggerAPIWithNoIntervalWaitsForCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	n1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
+	n2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
+	client := fakeclientset.NewSimpleClientset(n1, n2)
+	eventClient := fakeclientset.NewSimpleClientset(n1, n2)
+	dp := &api.DeschedulerPolicy{
+		Profiles: []api.DeschedulerProfile{},
+	}
+
+	rs, err := options.NewDeschedulerServer()
+	if err != nil {
+		t.Fatalf("Unable to initialize server: %v", err)
+	}
+	rs.Client = client
+	rs.EventClient = eventClient
+	rs.DeschedulingInterval = 0
+	rs.EnableTriggerAPI = true
+	rs.DefaultFeatureGates = initFeatureGates()
+	errChan := make(chan error, 1)
+	defer close(errChan)
+
+	go func() {
+		errChan <- RunDeschedulerStrategies(ctx, rs, dp, "v1")
+	}()
+
+	select {
+	case err := <-errChan:
+		t.Fatalf("expected descheduler to keep running with trigger API enabled, got %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Fatalf("Unable to run descheduler strategies: %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Root ctx should have canceled")
+	}
+}
+
+func TestDeschedulingIntervalTriggerFlagCombinations(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		deschedulingInterval time.Duration
+		enableTriggerAPI     bool
+		expectReturn         bool
+	}{
+		{
+			name:                 "zero interval trigger disabled returns after initial cycle",
+			deschedulingInterval: 0,
+			enableTriggerAPI:     false,
+			expectReturn:         true,
+		},
+		{
+			name:                 "zero interval trigger enabled waits for shutdown",
+			deschedulingInterval: 0,
+			enableTriggerAPI:     true,
+			expectReturn:         false,
+		},
+		{
+			name:                 "positive interval trigger disabled waits for shutdown",
+			deschedulingInterval: time.Hour,
+			enableTriggerAPI:     false,
+			expectReturn:         false,
+		},
+		{
+			name:                 "positive interval trigger enabled waits for shutdown",
+			deschedulingInterval: time.Hour,
+			enableTriggerAPI:     true,
+			expectReturn:         false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			n1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
+			n2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
+			client := fakeclientset.NewSimpleClientset(n1, n2)
+			eventClient := fakeclientset.NewSimpleClientset(n1, n2)
+			dp := &api.DeschedulerPolicy{
+				Profiles: []api.DeschedulerProfile{},
+			}
+
+			rs, err := options.NewDeschedulerServer()
+			if err != nil {
+				t.Fatalf("Unable to initialize server: %v", err)
+			}
+			rs.Client = client
+			rs.EventClient = eventClient
+			rs.DeschedulingInterval = tc.deschedulingInterval
+			rs.EnableTriggerAPI = tc.enableTriggerAPI
+			rs.DefaultFeatureGates = initFeatureGates()
+
+			errChan := make(chan error, 1)
+			go func() {
+				errChan <- RunDeschedulerStrategies(ctx, rs, dp, "v1")
+			}()
+
+			if tc.expectReturn {
+				select {
+				case err := <-errChan:
+					if err != nil {
+						t.Fatalf("Unable to run descheduler strategies: %v", err)
+					}
+				case <-time.After(time.Second):
+					t.Fatalf("expected descheduler to return after initial cycle")
+				}
+				return
+			}
+
+			select {
+			case err := <-errChan:
+				if err != nil {
+					t.Fatalf("Unable to run descheduler strategies: %v", err)
+				}
+				t.Fatalf("expected descheduler to keep running until shutdown")
+			case <-time.After(100 * time.Millisecond):
+				cancel()
+				select {
+				case err := <-errChan:
+					if err != nil {
+						t.Fatalf("Unable to run descheduler strategies: %v", err)
+					}
+				case <-time.After(time.Second):
+					t.Fatal("Root ctx should have canceled")
+				}
+			}
+		})
+	}
+}
+
 func TestValidateVersionCompatibility(t *testing.T) {
 	type testCase struct {
 		name               string


### PR DESCRIPTION
## Description

### Problem

The descheduler today supports two operational modes if runs in deployment mode:

1. **One-shot** (`--descheduling-interval=0`): runs a single eviction pass at startup and exits.
2. **Continuous** (`--descheduling-interval=5m`): runs passes on a fixed time interval.

Neither mode gives operators any way to **manually trigger** an eviction cycle without restarting the process or waiting for the next scheduled tick. This creates friction in several real-world scenarios:

- **Post-incident remediation**: a node drain or topology imbalance just occurred and you need eviction to run *right now*, not in 4 minutes when the timer fires.
- **CI/CD pipelines**: a deployment job wants to explicitly rebalance pods after a rollout and needs to know when descheduling is complete before proceeding.
- **Debugging & dry-run validation**: an SRE wants to trigger a dry-run pass interactively, inspect logs, and iterate — without restarting the descheduler pod.
- **Long interval + emergency**: the cluster runs descheduler with a 30-minute interval to reduce churn, but an on-call engineer needs to act immediately.

There was no escape hatch. The only workaround was to delete the descheduler pod and let it restart, which is disruptive and causes a gap in leader election.

---

### Solution

This PR introduces an optional HTTP trigger API that allows any authorized caller to **synchronously** initiate a descheduling cycle at any time via a single `curl` command.

The API is disabled by default and must be explicitly opted into with `--enable-trigger-api`, keeping backward compatibility complete.

Closes #1855

---

### Changes

#### `cmd/descheduler/app/options/options.go`

- Added `EnableTriggerAPI bool` field to `DeschedulerServer` to control the feature.
- Added `TriggerCh chan chan error` — the communication channel between the HTTP handler and the main scheduling loop. Using `chan chan error` allows the handler to receive the cycle result and propagate it synchronously to the HTTP caller.
- Registered the `--enable-trigger-api` CLI flag.

#### `cmd/descheduler/app/server.go`

- When `EnableTriggerAPI` is set, a buffered `chan chan error` is created and `POST /api/v1/descheduler/run` is registered on the existing `PathRecorderMux` (alongside `/metrics` and `/healthz`), so it is served by the same HTTPS server — no new port, no new listener, no new TLS config.
- The handler is **synchronous**: it blocks until the descheduling cycle finishes and returns the result as JSON. The caller gets a definitive success/failure signal.
- Concurrency protection: the trigger channel has a buffer of 1. If a cycle is already queued or running, a subsequent request receives **429 Too Many Requests** immediately instead of blocking indefinitely or spawning a second concurrent cycle.
- Request cancellation is respected: if the HTTP client disconnects, the handler unblocks via `r.Context().Done()` and returns **504 Gateway Timeout**.

#### `pkg/descheduler/descheduler.go`

- Replaced `wait.NonSlidingUntil` with an explicit `select`-based event loop. The loop listens on three channels simultaneously:
  - `ticker.C` — fires at `--descheduling-interval` (existing behavior, unmodified)
  - `rs.TriggerCh` — receives a manual trigger; executes the cycle and writes the result back to the caller's response channel
  - `ctx.Done()` — graceful shutdown
- When `TriggerCh` is `nil` (feature disabled), it is never selected in `select`, so the scheduler behaves exactly as before.
- When `--descheduling-interval=0` and `--enable-trigger-api` is set, the process now stays alive after the initial cycle and responds to trigger calls indefinitely — enabling a **daemon-without-tick** mode useful for purely on-demand operation.

---

### API Reference

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/v1/descheduler/run` | Trigger a descheduling cycle synchronously |

**Success (200)**
```json
{"message": "descheduling cycle completed successfully", "status": "ok"}
```

**Cycle already running (429)**
```json
{"message": "descheduling cycle already in progress or pending", "status": "error"}
```

**Internal error (500)**
```json
{"message": "failed to run descheduler loop: ...", "status": "error"}
```

**Client disconnected (504)**
```json
{"message": "request cancelled or timed out", "status": "error"}
```

---

### Usage Examples

#### Start descheduler with the trigger API enabled

```bash
descheduler \
  --policy-config-file=/etc/descheduler/policy.yaml \
  --descheduling-interval=30m \
  --enable-trigger-api
```

#### Trigger a cycle immediately from inside the cluster

```bash
kubectl exec -n kube-system deploy/descheduler -- \
  curl -sk -X POST https://localhost:10258/api/v1/descheduler/run
```

#### Trigger via port-forward from a local machine

```bash
kubectl port-forward -n kube-system deploy/descheduler 10258:10258 &
curl -sk -X POST https://localhost:10258/api/v1/descheduler/run
```

#### Use in a CI/CD step after a deployment

```bash
curl -sk --max-time 300 -X POST \
  https://descheduler.kube-system.svc.cluster.local:10258/api/v1/descheduler/run \
  | jq -e '.status == "ok"'
```

#### Daemon-without-tick mode (purely on-demand, no automatic interval)

```bash
descheduler \
  --policy-config-file=/etc/descheduler/policy.yaml \
  --descheduling-interval=0 \
  --enable-trigger-api
# The initial cycle runs at startup.
# The process stays alive and responds only to explicit POST /api/v1/descheduler/run calls.
```

---

### Backward Compatibility

- `--enable-trigger-api` defaults to `false`. Existing deployments are unaffected.
- The main scheduling loop (`select`-based replacement of `wait.NonSlidingUntil`) is functionally equivalent for all existing flag combinations when the trigger API is disabled.
- No new ports, certificates, or RBAC resources are introduced.

---

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?
