### PR TITLE
feat(tsc): add ZoneAwareNodeFit to RemovePodsViolatingTopologySpreadConstraint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ verify-gen:
 
 lint:
 ifndef HAS_GOLANGCI
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./_output/bin ${GOLANGCI_VERSION}
+	GOBIN=$(CURRENT_DIR)/_output/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION}
 endif
 	./_output/bin/golangci-lint run -v
 	./_output/bin/golangci-lint fmt -v

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ARCHS = amd64 arm arm64
 
 LDFLAGS=-ldflags "-X ${LDFLAG_LOCATION}.version=${VERSION} -X ${LDFLAG_LOCATION}.buildDate=${BUILD} -X ${LDFLAG_LOCATION}.gitbranch=${BRANCH} -X ${LDFLAG_LOCATION}.gitsha1=${SHA1}"
 
-GOLANGCI_VERSION := v2.8.0
+GOLANGCI_VERSION := v2.12.2
 HAS_GOLANGCI := $(shell ls _output/bin/golangci-lint 2> /dev/null)
 
 GOFUMPT_VERSION := v0.7.0

--- a/README.md
+++ b/README.md
@@ -697,12 +697,13 @@ The `topologyBalanceNodeFit` arg is used when balancing topology domains while t
 topologyBalanceNodeFit: false
 ```
 
-The `zoneAwareNodeFit` arg (default: `false`) gates eviction on per-zone capacity: a pod is only
-evicted from an over-loaded zone if at least one specific under-loaded zone (identified by the
-constraint's `TopologyKey`) has sufficient resource capacity (CPU, memory, pod slots) to schedule
-the pod. This prevents eviction churn where a pod is evicted but immediately rescheduled back into
-the same over-loaded zone because no target zone has capacity. Works independently of
-`topologyBalanceNodeFit`; enabling both is valid.
+The `zoneAwareNodeFit` arg (default: `false`) gates eviction on per-node fit, evaluated
+zone-by-zone: a pod is only evicted if at least one specific under-loaded zone contains a
+node that can fit it (resource requests, nodeSelector, taints). It performs the same
+per-node check as `topologyBalanceNodeFit` but operates as an independent gate. When
+`topologyBalanceNodeFit: true` (the default), enabling `zoneAwareNodeFit` is redundant.
+It is most useful when `topologyBalanceNodeFit: false` and per-node fit checking should
+still apply.
 ```yaml
 zoneAwareNodeFit: true
 ```
@@ -730,7 +731,7 @@ Strategy parameter `labelSelector` is not utilized when balancing topology domai
 |`labelSelector`|(see [label filtering](#label-filtering))|
 |`constraints`|(see [whenUnsatisfiable](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core))||
 |`topologyBalanceNodeFit`|bool|default `true`. [node fit filtering](#node-fit-filtering) when balancing topology domains|
-|`zoneAwareNodeFit`|bool|default `false`. When enabled, gates eviction on per-zone capacity: pod must fit on a node within at least one specific under-loaded zone (opt-in, works independently of `topologyBalanceNodeFit`)|
+|`zoneAwareNodeFit`|bool|default `false`. When enabled, gates eviction on per-node fit evaluated per-zone: pod must fit on a node within at least one specific under-loaded zone. Independent of `topologyBalanceNodeFit`; redundant when `topologyBalanceNodeFit: true` (the default).|
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -697,6 +697,16 @@ The `topologyBalanceNodeFit` arg is used when balancing topology domains while t
 topologyBalanceNodeFit: false
 ```
 
+The `zoneAwareNodeFit` arg (default: `false`) gates eviction on per-zone capacity: a pod is only
+evicted from an over-loaded zone if at least one specific under-loaded zone (identified by the
+constraint's `TopologyKey`) has sufficient resource capacity (CPU, memory, pod slots) to schedule
+the pod. This prevents eviction churn where a pod is evicted but immediately rescheduled back into
+the same over-loaded zone because no target zone has capacity. Works independently of
+`topologyBalanceNodeFit`; enabling both is valid.
+```yaml
+zoneAwareNodeFit: true
+```
+
 Strategy parameter `labelSelector` is not utilized when balancing topology domains and is only applied during eviction to determine if the pod can be evicted.
 
 [Supported Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#spread-constraint-definition) fields:
@@ -720,6 +730,7 @@ Strategy parameter `labelSelector` is not utilized when balancing topology domai
 |`labelSelector`|(see [label filtering](#label-filtering))|
 |`constraints`|(see [whenUnsatisfiable](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core))||
 |`topologyBalanceNodeFit`|bool|default `true`. [node fit filtering](#node-fit-filtering) when balancing topology domains|
+|`zoneAwareNodeFit`|bool|default `false`. When enabled, gates eviction on per-zone capacity: pod must fit on a node within at least one specific under-loaded zone (opt-in, works independently of `topologyBalanceNodeFit`)|
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -725,13 +725,13 @@ Strategy parameter `labelSelector` is not utilized when balancing topology domai
 
 **Parameters:**
 
-|Name|Type|
-|---|---|
-|`namespaces`|(see [namespace filtering](#namespace-filtering))|
-|`labelSelector`|(see [label filtering](#label-filtering))|
+|Name|Type|Description|
+|---|---|---|
+|`namespaces`|(see [namespace filtering](#namespace-filtering))||
+|`labelSelector`|(see [label filtering](#label-filtering))||
 |`constraints`|(see [whenUnsatisfiable](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core))||
 |`topologyBalanceNodeFit`|bool|default `true`. [node fit filtering](#node-fit-filtering) when balancing topology domains|
-|`zoneAwareNodeFit`|bool|default `false`. When enabled, gates eviction on per-node fit evaluated per-zone: pod must fit on a node within at least one specific under-loaded zone. Independent of `topologyBalanceNodeFit`; redundant when `topologyBalanceNodeFit: true` (the default).|
+|`zoneAwareNodeFit`|bool|default `false`. When enabled, gates eviction on per-node fit evaluated per-topology-domain: pod must fit on a node within at least one specific under-loaded topology domain. Independent of `topologyBalanceNodeFit`; redundant when `topologyBalanceNodeFit: true` (the default).|
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -697,13 +697,20 @@ The `topologyBalanceNodeFit` arg is used when balancing topology domains while t
 topologyBalanceNodeFit: false
 ```
 
-The `zoneAwareNodeFit` arg (default: `false`) gates eviction on per-node fit, evaluated
-zone-by-zone: a pod is only evicted if at least one specific under-loaded zone contains a
-node that can fit it (resource requests, nodeSelector, taints). It performs the same
-per-node check as `topologyBalanceNodeFit` but operates as an independent gate. When
-`topologyBalanceNodeFit: true` (the default), enabling `zoneAwareNodeFit` is redundant.
-It is most useful when `topologyBalanceNodeFit: false` and per-node fit checking should
-still apply.
+The `zoneAwareNodeFit` arg (default: `false`) prevents over-committing a single
+under-loaded topology domain within one balancing round. For each candidate pod the
+descheduler considers evicting, it requires that at least one specific under-loaded
+domain (identified by the constraint's `topologyKey`) has both (a) a node where the pod
+fits per the scheduler's per-node predicates AND (b) sufficient remaining aggregate
+resource headroom — after subtracting pods already committed to that domain in this
+round — to absorb the pod's cpu/memory request and one pod slot.
+
+Unlike `topologyBalanceNodeFit`, which only checks per-node fit on the union of
+under-loaded domain nodes (a check that is stateless across the batch),
+`zoneAwareNodeFit` tracks per-domain cumulative state. Use it when batched eviction
+would otherwise push more pods toward an under-loaded domain than it can actually
+absorb, causing the scheduler to send the excess back to the over-loaded domain
+(eviction churn).
 ```yaml
 zoneAwareNodeFit: true
 ```
@@ -731,7 +738,7 @@ Strategy parameter `labelSelector` is not utilized when balancing topology domai
 |`labelSelector`|(see [label filtering](#label-filtering))||
 |`constraints`|(see [whenUnsatisfiable](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core))||
 |`topologyBalanceNodeFit`|bool|default `true`. [node fit filtering](#node-fit-filtering) when balancing topology domains|
-|`zoneAwareNodeFit`|bool|default `false`. When enabled, gates eviction on per-node fit evaluated per-topology-domain: pod must fit on a node within at least one specific under-loaded topology domain. Independent of `topologyBalanceNodeFit`; redundant when `topologyBalanceNodeFit: true` (the default).|
+|`zoneAwareNodeFit`|bool|default `false`. When enabled, gates eviction on cumulative per-topology-domain headroom: a candidate pod is admitted only if some specific under-loaded domain has both a node where it fits AND remaining aggregate cpu/memory/pod-slot headroom (after pods already committed to that domain in this round). Prevents over-committing a single under-loaded domain — a case `topologyBalanceNodeFit` cannot detect.|
 
 **Example:**
 

--- a/README.md
+++ b/README.md
@@ -711,6 +711,7 @@ under-loaded domain nodes (a check that is stateless across the batch),
 would otherwise push more pods toward an under-loaded domain than it can actually
 absorb, causing the scheduler to send the excess back to the over-loaded domain
 (eviction churn).
+
 ```yaml
 zoneAwareNodeFit: true
 ```

--- a/docs/proposals/zone-aware-nodefit.md
+++ b/docs/proposals/zone-aware-nodefit.md
@@ -11,30 +11,33 @@
 
 `RemovePodsViolatingTopologySpreadConstraint` evicts pods from over-loaded topology
 zones. The existing `TopologyBalanceNodeFit` flag (default: `true`) gates eviction on
-whether the pod can fit on *some* node across *all* under-loaded zones combined. This
-aggregate check has a blind spot: if under-loaded zones each individually lack capacity,
-but the check passes because a node from zone B and a node from zone C together appear
-schedulable, the pod may be evicted and then reshuffled within the same over-loaded
-cluster of zones—causing bounded eviction churn.
+whether the pod can fit on *some* node across *all* under-loaded zones combined.
+`PodFitsAnyOtherNode` evaluates each candidate node independently (resource requests,
+nodeSelector, taints, anti-affinity), so this check correctly blocks eviction when no
+individual node has sufficient capacity.
+
+However, `TopologyBalanceNodeFit` is a single binary gate. Users who need to disable
+it (e.g., to allow eviction even when no target node is currently schedulable, relying
+on cluster-autoscaler to provision capacity) lose the per-node fit check entirely.
+There is no way to say "check per-node fit, but report it with zone-level granularity."
 
 ### Illustrative scenario
 
 ```
 Zone A (over-loaded): 10 pods, nodes have 2 000 m CPU free per node
 Zone B (under-loaded by pod count): 3 pods, nodes have only 50 m CPU free
-Zone C (under-loaded by pod count): 3 pods, nodes have only 50 m CPU free
+Zone C (under-loaded by pod count): 3 pods, nodes have 2 000 m CPU free
 Pod to evict: requests 100 m CPU
 ```
 
-With `TopologyBalanceNodeFit: true`, `nodesBelowIdealAvg` contains nodes from B and C
-combined. `PodFitsAnyOtherNode(pod, B+C)` returns `false` because no individual node
-has 100 m free — the check is correct here. But if any single node in B or C had
-100 m free, the check would pass even if the ZONE-LEVEL capacity picture meant the
-pod would be rescheduled back to A after eviction.
+With `TopologyBalanceNodeFit: false`, the per-node fit gate is disabled. Eviction
+proceeds regardless of whether any target zone can actually schedule the pod. A pod
+evicted from zone A may be scheduled into zone B despite zone B being resource-saturated
+at the per-node level, because no gate is active.
 
-The subtler issue: `nodesBelowIdealAvg` is filtered by pod *count*, not by resource
-headroom. A zone can appear under-loaded (fewer pods than average) while being
-resource-saturated. Zone-level capacity validation requires per-zone independent checks.
+`ZoneAwareNodeFit: true` re-enables the per-node fit check in a zone-grouped form:
+it verifies that at least one specific under-loaded zone contains a node that can fit
+the pod, without requiring `TopologyBalanceNodeFit` to be enabled.
 
 ## Proposed Change
 
@@ -49,13 +52,13 @@ When `ZoneAwareNodeFit: true`, `balanceDomains` additionally:
    can fit the pod (resource requests, nodeSelector, taints).
 3. Skips eviction of the pod if no single target zone individually has capacity.
 
-This is **strictly more restrictive** than `TopologyBalanceNodeFit`'s existing check.
-Enabling `ZoneAwareNodeFit` prevents some evictions that `TopologyBalanceNodeFit` alone
-would permit: specifically, when no individual under-loaded zone has a node with enough
-capacity to fit the pod, but the union of nodes across all under-loaded zones contains
-a fitting node. In that case the aggregate check passes while the zone-aware check
-blocks the eviction, avoiding churn from a pod being rescheduled to a zone that cannot
-actually accommodate it independently.
+Both `ZoneAwareNodeFit` and `TopologyBalanceNodeFit` perform the same per-node capacity
+check (resource requests, nodeSelector, taints, anti-affinity via `PodFitsAnyOtherNode`),
+and when both are enabled they evaluate the same set of nodes — so they are functionally
+equivalent when `topologyBalanceNodeFit: true` (the default). The value of
+`ZoneAwareNodeFit` is as an **independent gate** that can be activated even when
+`TopologyBalanceNodeFit` is disabled, preserving node-fit checking without coupling to
+the existing flag's on/off semantics.
 
 ## API
 
@@ -82,8 +85,10 @@ profiles:
 | `topologyBalanceNodeFit` | `true` | Gate: pod must fit on *some* node across the union of all under-loaded zone nodes |
 | `zoneAwareNodeFit` | `false` | Gate: pod must fit within at least one *specific* under-loaded zone |
 
-Both gates are independent. Enabling both is valid (redundant for a single under-loaded
-zone; stricter for multiple under-loaded zones with mixed capacity).
+Both gates are independent. Enabling both is valid but redundant when
+`topologyBalanceNodeFit: true` (the default): in that case both evaluate the same node
+set with the same per-node check. `zoneAwareNodeFit` is most useful when
+`topologyBalanceNodeFit: false` is desired and per-node fit checking should still apply.
 
 ## Implementation
 
@@ -129,7 +134,7 @@ to regenerate this file; do not edit it by hand.
 ```go
 // filterNodesByZoneBelowIdealAvg groups nodes from under-loaded topology domains
 // by their domain value (e.g. zone label). Only domains with pod count strictly
-// below idealAvg are included. Returns nil if no under-loaded domains exist.
+// below idealAvg are included. Returns an empty non-nil map if no under-loaded domains exist.
 func filterNodesByZoneBelowIdealAvg(
     nodes []*v1.Node,
     sortedDomains []topology,

--- a/docs/proposals/zone-aware-nodefit.md
+++ b/docs/proposals/zone-aware-nodefit.md
@@ -1,0 +1,188 @@
+# RFC: ZoneAwareNodeFit for RemovePodsViolatingTopologySpreadConstraint
+
+**Status:** Implementable  
+**Author:** bruno.chauvet@rokt.com  
+**Date:** 2026-04-15  
+**Related issues:** kubernetes-sigs/descheduler#1534, kubernetes-sigs/descheduler#1067
+
+---
+
+## Problem
+
+`RemovePodsViolatingTopologySpreadConstraint` evicts pods from over-loaded topology
+zones. The existing `TopologyBalanceNodeFit` flag (default: `true`) gates eviction on
+whether the pod can fit on *some* node across *all* under-loaded zones combined. This
+aggregate check has a blind spot: if under-loaded zones each individually lack capacity,
+but the check passes because a node from zone B and a node from zone C together appear
+schedulable, the pod may be evicted and then reshuffled within the same over-loaded
+cluster of zones—causing bounded eviction churn.
+
+### Illustrative scenario
+
+```
+Zone A (over-loaded): 10 pods, nodes have 2 000 m CPU free per node
+Zone B (under-loaded by pod count): 3 pods, nodes have only 50 m CPU free
+Zone C (under-loaded by pod count): 3 pods, nodes have only 50 m CPU free
+Pod to evict: requests 100 m CPU
+```
+
+With `TopologyBalanceNodeFit: true`, `nodesBelowIdealAvg` contains nodes from B and C
+combined. `PodFitsAnyOtherNode(pod, B+C)` returns `false` because no individual node
+has 100 m free — the check is correct here. But if any single node in B or C had
+100 m free, the check would pass even if the ZONE-LEVEL capacity picture meant the
+pod would be rescheduled back to A after eviction.
+
+The subtler issue: `nodesBelowIdealAvg` is filtered by pod *count*, not by resource
+headroom. A zone can appear under-loaded (fewer pods than average) while being
+resource-saturated. Zone-level capacity validation requires per-zone independent checks.
+
+## Proposed Change
+
+Add a new opt-in field `ZoneAwareNodeFit *bool` to
+`RemovePodsViolatingTopologySpreadConstraintArgs` (default: `false`).
+
+When `ZoneAwareNodeFit: true`, `balanceDomains` additionally:
+
+1. Groups eligible nodes from under-loaded zones by their topology key value (zone →
+   nodes map).
+2. For each candidate pod, checks whether at least one *specific* zone has a node that
+   can fit the pod (resource requests, nodeSelector, taints).
+3. Skips eviction of the pod if no single target zone individually has capacity.
+
+This is a **strict superset** of `TopologyBalanceNodeFit`'s existing check: any pod
+that fails the zone-aware check would also fail the aggregate check (or vice versa
+only when two partial zones together sum to one fitting slot, which is not a valid
+scheduling destination).
+
+## API
+
+```yaml
+apiVersion: "descheduler/v1alpha2"
+kind: DeschedulerPolicy
+profiles:
+  - name: default
+    plugins:
+      balance:
+        enabled:
+          - name: RemovePodsViolatingTopologySpreadConstraint
+    pluginConfig:
+      - name: RemovePodsViolatingTopologySpreadConstraint
+        args:
+          topologyBalanceNodeFit: true   # unchanged — existing field
+          zoneAwareNodeFit: true         # NEW — opt-in per-zone capacity check
+```
+
+### Field semantics
+
+| Field | Default | Meaning |
+|---|---|---|
+| `topologyBalanceNodeFit` | `true` | Gate: pod must fit on *some* node across the union of all under-loaded zone nodes |
+| `zoneAwareNodeFit` | `false` | Gate: pod must fit within at least one *specific* under-loaded zone |
+
+Both gates are independent. Enabling both is valid (redundant for a single under-loaded
+zone; stricter for multiple under-loaded zones with mixed capacity).
+
+## Implementation
+
+### New types (types.go)
+
+Add `ZoneAwareNodeFit *bool` after `TopologyBalanceNodeFit`:
+
+```go
+ZoneAwareNodeFit *bool `json:"zoneAwareNodeFit,omitempty"`
+```
+
+### New helper functions (topologyspreadconstraint.go)
+
+```go
+// filterNodesByZoneBelowIdealAvg groups nodes from under-loaded topology domains
+// by their domain value (e.g. zone label). Only domains with pod count strictly
+// below idealAvg are included. Returns nil if no under-loaded domains exist.
+func filterNodesByZoneBelowIdealAvg(
+    nodes []*v1.Node,
+    sortedDomains []topology,
+    topologyKey string,
+    idealAvg float64,
+) map[string][]*v1.Node {
+    topologyNodesMap := make(map[string][]*v1.Node, len(sortedDomains))
+    for _, n := range nodes {
+        if zone, ok := n.Labels[topologyKey]; ok {
+            topologyNodesMap[zone] = append(topologyNodesMap[zone], n)
+        }
+    }
+    result := make(map[string][]*v1.Node)
+    for _, domain := range sortedDomains {
+        if float64(len(domain.pods)) < idealAvg {
+            result[domain.pair.value] = topologyNodesMap[domain.pair.value]
+        }
+    }
+    return result
+}
+
+// podFitsAnyNodeInSomeZone returns true if the pod can be scheduled on at least
+// one node within at least one zone from nodesByZone. Each zone is validated
+// independently — the pod must fit entirely within a single zone.
+func podFitsAnyNodeInSomeZone(
+    nodeIndexer podutil.GetPodsAssignedToNodeFunc,
+    pod *v1.Pod,
+    nodesByZone map[string][]*v1.Node,
+) bool {
+    for _, zoneNodes := range nodesByZone {
+        if node.PodFitsAnyOtherNode(nodeIndexer, pod, zoneNodes) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+### balanceDomains update (topologyspreadconstraint.go)
+
+In `balanceDomains`, after the existing `topologyBalanceNodeFit` declaration:
+
+```go
+zoneAwareNodeFit := utilptr.Deref(d.args.ZoneAwareNodeFit, false)
+
+var nodesByZoneBelowIdealAvg map[string][]*v1.Node
+if zoneAwareNodeFit {
+    nodesByZoneBelowIdealAvg = filterNodesByZoneBelowIdealAvg(
+        eligibleNodes, sortedDomains, tsc.TopologyKey, idealAvg)
+}
+```
+
+Inside the eviction gate loop, after the existing `topologyBalanceNodeFit` check:
+
+```go
+if zoneAwareNodeFit && !podFitsAnyNodeInSomeZone(
+    getPodsAssignedToNode, aboveToEvict[k], nodesByZoneBelowIdealAvg) {
+    d.logger.V(2).Info("ignoring pod for eviction: no target zone has sufficient capacity",
+        "pod", klog.KObj(aboveToEvict[k]))
+    continue
+}
+```
+
+## Alternatives Considered
+
+**Modify PreEvictionFilter in DefaultEvictor to be zone-aware**: requires threading zone
+context through the `EvictorPlugin` interface (`PreEvictionFilter(pod *v1.Pod) bool` has
+no zone parameter), which is a breaking API change affecting all plugins. Rejected in
+favour of a TSC-local, opt-in gate.
+
+**Change TopologyBalanceNodeFit semantics**: would be a silent behaviour change for
+existing users. Rejected in favour of a new independent field.
+
+## Test Plan
+
+1. ZoneAwareNodeFit enabled, target zone has capacity → pod evicted
+2. ZoneAwareNodeFit enabled, target zone at CPU capacity → pod NOT evicted (no churn)
+3. ZoneAwareNodeFit enabled, multiple under-loaded zones, mixed capacity → pod evicted
+   (at least one zone qualifies)
+4. ZoneAwareNodeFit disabled (default) → existing behaviour unchanged
+
+## Risk
+
+**Low.** Change is:
+- Opt-in (`false` by default)
+- Additive (existing `TopologyBalanceNodeFit` gate is unmodified)
+- Localised to `balanceDomains` inside the TSC plugin
+- No changes to framework types, eviction API, or other plugins

--- a/docs/proposals/zone-aware-nodefit.md
+++ b/docs/proposals/zone-aware-nodefit.md
@@ -49,10 +49,13 @@ When `ZoneAwareNodeFit: true`, `balanceDomains` additionally:
    can fit the pod (resource requests, nodeSelector, taints).
 3. Skips eviction of the pod if no single target zone individually has capacity.
 
-This is a **strict superset** of `TopologyBalanceNodeFit`'s existing check: any pod
-that fails the zone-aware check would also fail the aggregate check (or vice versa
-only when two partial zones together sum to one fitting slot, which is not a valid
-scheduling destination).
+This is **strictly more restrictive** than `TopologyBalanceNodeFit`'s existing check.
+Enabling `ZoneAwareNodeFit` prevents some evictions that `TopologyBalanceNodeFit` alone
+would permit: specifically, when no individual under-loaded zone has a node with enough
+capacity to fit the pod, but the union of nodes across all under-loaded zones contains
+a fitting node. In that case the aggregate check passes while the zone-aware check
+blocks the eviction, avoiding churn from a pod being rescheduled to a zone that cannot
+actually accommodate it independently.
 
 ## API
 
@@ -91,6 +94,35 @@ Add `ZoneAwareNodeFit *bool` after `TopologyBalanceNodeFit`:
 ```go
 ZoneAwareNodeFit *bool `json:"zoneAwareNodeFit,omitempty"`
 ```
+
+### Default value (defaults.go)
+
+`SetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs` must initialise the new
+field when it is nil:
+
+```go
+if args.ZoneAwareNodeFit == nil {
+    args.ZoneAwareNodeFit = utilptr.To(false)
+}
+```
+
+### Deep-copy generated file (zz_generated.deepcopy.go)
+
+Adding a `*bool` pointer field to a `+k8s:deepcopy-gen=true` struct requires
+regenerating `zz_generated.deepcopy.go`. The `DeepCopyInto` function for
+`RemovePodsViolatingTopologySpreadConstraintArgs` must include a nil-check block for
+`ZoneAwareNodeFit`, mirroring the existing block for `TopologyBalanceNodeFit`:
+
+```go
+if in.ZoneAwareNodeFit != nil {
+    in, out := &in.ZoneAwareNodeFit, &out.ZoneAwareNodeFit
+    *out = new(bool)
+    **out = **in
+}
+```
+
+Run `hack/update-generated-deepcopy.sh` (or the equivalent `controller-gen` invocation)
+to regenerate this file; do not edit it by hand.
 
 ### New helper functions (topologyspreadconstraint.go)
 
@@ -174,7 +206,7 @@ existing users. Rejected in favour of a new independent field.
 ## Test Plan
 
 1. ZoneAwareNodeFit enabled, target zone has capacity → pod evicted
-2. ZoneAwareNodeFit enabled, target zone at CPU capacity → pod NOT evicted (no churn)
+2. ZoneAwareNodeFit enabled, all target zones at CPU capacity → pod NOT evicted (no churn)
 3. ZoneAwareNodeFit enabled, multiple under-loaded zones, mixed capacity → pod evicted
    (at least one zone qualifies)
 4. ZoneAwareNodeFit disabled (default) → existing behaviour unchanged

--- a/docs/proposals/zone-aware-nodefit.md
+++ b/docs/proposals/zone-aware-nodefit.md
@@ -1,8 +1,8 @@
 # RFC: ZoneAwareNodeFit for RemovePodsViolatingTopologySpreadConstraint
 
-**Status:** Implementable  
-**Author:** bruno.chauvet@rokt.com  
-**Date:** 2026-04-15  
+**Status:** Implementable
+**Author:** bruno.chauvet@rokt.com
+**Date:** 2026-04-15 (revised 2026-05-17)
 **Related issues:** kubernetes-sigs/descheduler#1534, kubernetes-sigs/descheduler#1067
 
 ---
@@ -10,55 +10,69 @@
 ## Problem
 
 `RemovePodsViolatingTopologySpreadConstraint` evicts pods from over-loaded topology
-zones. The existing `TopologyBalanceNodeFit` flag (default: `true`) gates eviction on
-whether the pod can fit on *some* node across *all* under-loaded zones combined.
-`PodFitsAnyOtherNode` evaluates each candidate node independently (resource requests,
-nodeSelector, taints, anti-affinity), so this check correctly blocks eviction when no
-individual node has sufficient capacity.
+domains in batches: each iteration of `balanceDomains` selects N candidate pods from
+an over-loaded domain and lets the scheduler place them in under-loaded domains. The
+existing `TopologyBalanceNodeFit` gate (default `true`) checks, for each candidate,
+whether the pod can fit on at least one node in the union of all under-loaded domains.
 
-However, `TopologyBalanceNodeFit` is a single binary gate. Users who need to disable
-it (e.g., to allow eviction even when no target node is currently schedulable, relying
-on cluster-autoscaler to provision capacity) lose the per-node fit check entirely.
-There is no way to say "check per-node fit, but report it with zone-level granularity."
+The check is **stateless across the batch**: every candidate evaluates `PodFitsAnyOtherNode`
+against the same node-view (the descheduler does not simulate intermediate scheduler
+decisions). So if N candidates each individually fit on a node in the only under-loaded
+domain `B`, all N pass the gate — even though `B` may only have aggregate room for
+K ≪ N of them. After eviction, the scheduler can place only K pods in `B`; the
+remaining N − K either go back to the over-loaded domain (churn — issues #1534, #1067)
+or remain Pending.
 
 ### Illustrative scenario
 
 ```
-Zone A (over-loaded): 10 pods, nodes have 2 000 m CPU free per node
-Zone B (under-loaded by pod count): 3 pods, nodes have only 50 m CPU free
-Zone C (under-loaded by pod count): 3 pods, nodes have 2 000 m CPU free
-Pod to evict: requests 100 m CPU
+Domain A (over-loaded): 7 pods on nodes with ample CPU
+Domain B (under-loaded by pod count): 1 pod on a node with 250 m CPU allocatable
+Existing pod in B uses 100 m → 150 m of aggregate headroom remains in domain B
+Candidate pods request 100 m CPU each
+
+balanceDomains schedules 3 evictions toward domain B.
+TopologyBalanceNodeFit evaluates each candidate against the live indexer state
+(B1 still has 150 m headroom) → all 3 pass → all 3 evicted.
+The scheduler can fit at most 1 of them in B. The other 2 go back to A → churn.
 ```
 
-With `TopologyBalanceNodeFit: false`, the per-node fit gate is disabled. Eviction
-proceeds regardless of whether any target zone can actually schedule the pod. A pod
-evicted from zone A may be scheduled into zone B despite zone B being resource-saturated
-at the per-node level, because no gate is active.
-
-`ZoneAwareNodeFit: true` re-enables the per-node fit check in a zone-grouped form:
-it verifies that at least one specific under-loaded zone contains a node that can fit
-the pod, without requiring `TopologyBalanceNodeFit` to be enabled.
+The fundamental gap: `TopologyBalanceNodeFit` reasons about **per-node fit on the
+union of under-loaded domains**, which mathematically collapses to
+`OR(merge(domains))`. It cannot detect cumulative over-commit of a single under-loaded
+domain because it never tracks state across the batch.
 
 ## Proposed Change
 
-Add a new opt-in field `ZoneAwareNodeFit *bool` to
-`RemovePodsViolatingTopologySpreadConstraintArgs` (default: `false`).
+Add an opt-in field `ZoneAwareNodeFit *bool` to
+`RemovePodsViolatingTopologySpreadConstraintArgs` (default `false`).
 
-When `ZoneAwareNodeFit: true`, `balanceDomains` additionally:
+When enabled, `balanceDomains` tracks, **per under-loaded topology domain**, the
+aggregate resource headroom remaining for the current batch. Each candidate pod is
+admitted only if some specific under-loaded domain has both:
 
-1. Groups eligible nodes from under-loaded zones by their topology key value (zone →
-   nodes map).
-2. For each candidate pod, checks whether at least one *specific* zone has a node that
-   can fit the pod (resource requests, nodeSelector, taints).
-3. Skips eviction of the pod if no single target zone individually has capacity.
+- (a) at least one node where the pod fits per the scheduler's per-node predicates
+  (`PodFitsAnyOtherNode`), AND
+- (b) sufficient remaining aggregate headroom — after subtracting all pods already
+  committed to that domain in this batch — to absorb the pod's resource request and
+  one pod slot.
 
-Both `ZoneAwareNodeFit` and `TopologyBalanceNodeFit` perform the same per-node capacity
-check (resource requests, nodeSelector, taints, anti-affinity via `PodFitsAnyOtherNode`),
-and when both are enabled they evaluate the same set of nodes — so they are functionally
-equivalent when `topologyBalanceNodeFit: true` (the default). The value of
-`ZoneAwareNodeFit` is as an **independent gate** that can be activated even when
-`TopologyBalanceNodeFit` is disabled, preserving node-fit checking without coupling to
-the existing flag's on/off semantics.
+On admission, that domain's headroom is decremented. Subsequent candidates see the
+decremented state; once a domain is drained, later candidates must find another
+qualifying domain or be skipped.
+
+Per-domain headroom is initialised as `sum(allocatable) − sum(existing pod requests)`
+across the domain's nodes, for cpu, memory, and pod count.
+
+### Why this is qualitatively different from `TopologyBalanceNodeFit`
+
+The accumulator makes pod-N's decision depend on commitments 1..N-1. There is no
+equivalent stateless `OR(merge(...))` formulation, because `PodFitsAnyOtherNode` has
+no notion of "headroom remaining after prior commitments in this batch."
+
+`ZoneAwareNodeFit` is therefore **strictly stricter** than `TopologyBalanceNodeFit`:
+any pod that fails `ZoneAwareNodeFit` also fails the cumulative-correctness goal
+that `TopologyBalanceNodeFit` cannot express.
 
 ## API
 
@@ -74,36 +88,35 @@ profiles:
     pluginConfig:
       - name: RemovePodsViolatingTopologySpreadConstraint
         args:
-          topologyBalanceNodeFit: true   # unchanged — existing field
-          zoneAwareNodeFit: true         # NEW — opt-in per-zone capacity check
+          topologyBalanceNodeFit: true   # unchanged — existing flag
+          zoneAwareNodeFit: true         # NEW — cumulative per-domain gate
 ```
 
 ### Field semantics
 
-| Field | Default | Meaning |
-|---|---|---|
-| `topologyBalanceNodeFit` | `true` | Gate: pod must fit on *some* node across the union of all under-loaded zone nodes |
-| `zoneAwareNodeFit` | `false` | Gate: pod must fit within at least one *specific* under-loaded zone |
+| Field | Default | Reasoning level | Catches cumulative over-commit? |
+|---|---|---|---|
+| `topologyBalanceNodeFit` | `true` | Per-node, stateless across batch | No |
+| `zoneAwareNodeFit` | `false` | Per-domain, cumulative within batch | Yes |
 
-Both gates are independent. Enabling both is valid but redundant when
-`topologyBalanceNodeFit: true` (the default): in that case both evaluate the same node
-set with the same per-node check. `zoneAwareNodeFit` is most useful when
-`topologyBalanceNodeFit: false` is desired and per-node fit checking should still apply.
+Enabling both is valid: `TopologyBalanceNodeFit` runs first as a fast per-node pre-filter,
+then `ZoneAwareNodeFit` applies the cumulative-headroom constraint.
 
 ## Implementation
 
-### New types (types.go)
-
-Add `ZoneAwareNodeFit *bool` after `TopologyBalanceNodeFit`:
+### types.go
 
 ```go
+// ZoneAwareNodeFit, if set to true, requires that each pod evicted by topology-spread
+// balancing have, in at least one specific under-loaded topology domain (as identified
+// by the constraint's TopologyKey), (a) a node where the pod fits per the scheduler's
+// per-node predicates AND (b) sufficient remaining aggregate resource headroom — after
+// accounting for other pods already committed to that domain during the same balancing
+// round — to absorb the pod.
 ZoneAwareNodeFit *bool `json:"zoneAwareNodeFit,omitempty"`
 ```
 
-### Default value (defaults.go)
-
-`SetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs` must initialise the new
-field when it is nil:
+### defaults.go
 
 ```go
 if args.ZoneAwareNodeFit == nil {
@@ -111,115 +124,96 @@ if args.ZoneAwareNodeFit == nil {
 }
 ```
 
-### Deep-copy generated file (zz_generated.deepcopy.go)
+### topologyspreadconstraint.go
 
-Adding a `*bool` pointer field to a `+k8s:deepcopy-gen=true` struct requires
-regenerating `zz_generated.deepcopy.go`. The `DeepCopyInto` function for
-`RemovePodsViolatingTopologySpreadConstraintArgs` must include a nil-check block for
-`ZoneAwareNodeFit`, mirroring the existing block for `TopologyBalanceNodeFit`:
+Two new helpers replace the original duplicate filter + naive OR(OR) check:
 
 ```go
-if in.ZoneAwareNodeFit != nil {
-    in, out := &in.ZoneAwareNodeFit, &out.ZoneAwareNodeFit
-    *out = new(bool)
-    **out = **in
-}
-```
+// groupNodesByDomain classifies the supplied nodes (already filtered to under-loaded
+// domains) by their topology-key label value. Single pass over the same node slice
+// the existing filterNodesBelowIdealAvg returns.
+func groupNodesByDomain(nodes []*v1.Node, topologyKey string) map[string][]*v1.Node
 
-Run `hack/update-generated-deepcopy.sh` (or the equivalent `controller-gen` invocation)
-to regenerate this file; do not edit it by hand.
+// computeDomainHeadroom returns, per under-loaded domain, the aggregate remaining
+// resource headroom (allocatable − already-requested) summed across the domain's
+// nodes. Tracks cpu, memory, and pod count. Computed once per balanceDomains call.
+func computeDomainHeadroom(
+    nodesByDomain map[string][]*v1.Node,
+    nodeIndexer podutil.GetPodsAssignedToNodeFunc,
+) map[string]v1.ResourceList
 
-### New helper functions (topologyspreadconstraint.go)
-
-```go
-// filterNodesByZoneBelowIdealAvg groups nodes from under-loaded topology domains
-// by their domain value (e.g. zone label). Only domains with pod count strictly
-// below idealAvg are included. Returns an empty non-nil map if no under-loaded domains exist.
-func filterNodesByZoneBelowIdealAvg(
-    nodes []*v1.Node,
-    sortedDomains []topology,
-    topologyKey string,
-    idealAvg float64,
-) map[string][]*v1.Node {
-    topologyNodesMap := make(map[string][]*v1.Node, len(sortedDomains))
-    for _, n := range nodes {
-        if zone, ok := n.Labels[topologyKey]; ok {
-            topologyNodesMap[zone] = append(topologyNodesMap[zone], n)
-        }
-    }
-    result := make(map[string][]*v1.Node)
-    for _, domain := range sortedDomains {
-        if float64(len(domain.pods)) < idealAvg {
-            result[domain.pair.value] = topologyNodesMap[domain.pair.value]
-        }
-    }
-    return result
-}
-
-// podFitsAnyNodeInSomeZone returns true if the pod can be scheduled on at least
-// one node within at least one zone from nodesByZone. Each zone is validated
-// independently — the pod must fit entirely within a single zone.
-func podFitsAnyNodeInSomeZone(
+// podFitsSomeDomainWithHeadroom returns the topology-domain key whose remaining
+// headroom AND per-node fit both admit pod. On success it decrements that domain's
+// headroom in place and returns ok=true. Iterates domains in sorted order for
+// determinism.
+func podFitsSomeDomainWithHeadroom(
     nodeIndexer podutil.GetPodsAssignedToNodeFunc,
     pod *v1.Pod,
-    nodesByZone map[string][]*v1.Node,
-) bool {
-    for _, zoneNodes := range nodesByZone {
-        if node.PodFitsAnyOtherNode(nodeIndexer, pod, zoneNodes) {
-            return true
-        }
-    }
-    return false
-}
+    nodesByDomain map[string][]*v1.Node,
+    remainingHeadroom map[string]v1.ResourceList,
+) (string, bool)
 ```
 
-### balanceDomains update (topologyspreadconstraint.go)
-
-In `balanceDomains`, after the existing `topologyBalanceNodeFit` declaration:
+In `balanceDomains`:
 
 ```go
 zoneAwareNodeFit := utilptr.Deref(d.args.ZoneAwareNodeFit, false)
-
-var nodesByZoneBelowIdealAvg map[string][]*v1.Node
+var nodesByDomain map[string][]*v1.Node
+var remainingHeadroom map[string]v1.ResourceList
 if zoneAwareNodeFit {
-    nodesByZoneBelowIdealAvg = filterNodesByZoneBelowIdealAvg(
-        eligibleNodes, sortedDomains, tsc.TopologyKey, idealAvg)
+    nodesByDomain = groupNodesByDomain(nodesBelowIdealAvg, tsc.TopologyKey)
+    remainingHeadroom = computeDomainHeadroom(nodesByDomain, getPodsAssignedToNode)
 }
 ```
 
-Inside the eviction gate loop, after the existing `topologyBalanceNodeFit` check:
+Inside the per-pod loop, after the existing `topologyBalanceNodeFit` gate:
 
 ```go
-if zoneAwareNodeFit && !podFitsAnyNodeInSomeZone(
-    getPodsAssignedToNode, aboveToEvict[k], nodesByZoneBelowIdealAvg) {
-    d.logger.V(2).Info("ignoring pod for eviction: no target zone has sufficient capacity",
-        "pod", klog.KObj(aboveToEvict[k]))
-    continue
+if zoneAwareNodeFit {
+    if _, ok := podFitsSomeDomainWithHeadroom(
+        getPodsAssignedToNode, aboveToEvict[k], nodesByDomain, remainingHeadroom,
+    ); !ok {
+        d.logger.V(2).Info(
+            "ignoring pod for eviction: no target topology domain has fit + remaining headroom",
+            "pod", klog.KObj(aboveToEvict[k]),
+        )
+        continue
+    }
 }
 ```
 
 ## Alternatives Considered
 
-**Modify PreEvictionFilter in DefaultEvictor to be zone-aware**: requires threading zone
-context through the `EvictorPlugin` interface (`PreEvictionFilter(pod *v1.Pod) bool` has
-no zone parameter), which is a breaking API change affecting all plugins. Rejected in
-favour of a TSC-local, opt-in gate.
+**Modify `TopologyBalanceNodeFit` semantics to be cumulative.** Silent behavioural change
+for existing users. Rejected.
 
-**Change TopologyBalanceNodeFit semantics**: would be a silent behaviour change for
-existing users. Rejected in favour of a new independent field.
+**Per-node-fit-only gate, no headroom tracking.** This is what the first revision of this
+proposal shipped; review surfaced that it collapses to `OR(merge(domains))` and adds
+nothing over `TopologyBalanceNodeFit`. Rejected — see Problem section.
+
+**Threading zone context through `EvictorPlugin.PreEvictionFilter`.** Breaking API change
+across all plugins. Rejected in favour of a TSC-local gate.
 
 ## Test Plan
 
-1. ZoneAwareNodeFit enabled, target zone has capacity → pod evicted
-2. ZoneAwareNodeFit enabled, all target zones at CPU capacity → pod NOT evicted (no churn)
-3. ZoneAwareNodeFit enabled, multiple under-loaded zones, mixed capacity → pod evicted
-   (at least one zone qualifies)
-4. ZoneAwareNodeFit disabled (default) → existing behaviour unchanged
+1. **Cumulative-overflow**: 7 pods on `zoneA`, 1 pod on `zoneB` (250 m CPU node, 150 m
+   headroom). `ZoneAwareNodeFit=true, TopologyBalanceNodeFit=false, nodeFit=false`
+   → 1 eviction (only one pod fits zoneB's aggregate headroom).
+2. **Baseline contrast**: same topology, all gates off → 3 evictions; with
+   `TopologyBalanceNodeFit=true` only → still 3 evictions (the bug the new gate fixes).
+3. **Multi-domain redirection**: 3 domains, `zoneB` tight (1 pod's worth of headroom),
+   `zoneC` plenty. Evictions spread across domains; all candidates admitted.
+4. **Per-node fit still required**: `zoneB` has high aggregate headroom but no single
+   node fits the pod → 0 evictions.
+5. **Default off**: `zoneAwareNodeFit` unset → byte-for-byte identical behaviour to
+   prior versions.
+6. Unit test for `podFitsSomeDomainWithHeadroom`: deterministic ordering, headroom
+   drain, aggregate-failure rejection, per-node-failure rejection, empty input.
 
 ## Risk
 
-**Low.** Change is:
-- Opt-in (`false` by default)
-- Additive (existing `TopologyBalanceNodeFit` gate is unmodified)
-- Localised to `balanceDomains` inside the TSC plugin
-- No changes to framework types, eviction API, or other plugins
+**Low.**
+- Opt-in (`false` by default).
+- Additive: existing `TopologyBalanceNodeFit` is unchanged.
+- Localised to `balanceDomains` and a few new helpers in the TSC plugin.
+- No changes to framework types, eviction API, or other plugins.

--- a/docs/proposals/zone-aware-nodefit.md
+++ b/docs/proposals/zone-aware-nodefit.md
@@ -184,8 +184,9 @@ func computeDomainHeadroom(
 
 // podFitsSomeDomainWithHeadroom returns the topology-domain key whose remaining
 // headroom AND per-node fit both admit pod. On success it decrements that domain's
-// headroom in place and returns ok=true. Iterates domains in sorted order for
-// determinism.
+// headroom in place and returns ok=true. Iterates domains in descending remaining
+// CPU headroom order so pods spread toward the roomiest under-loaded domain first;
+// ties fall back to alphabetical for determinism.
 func podFitsSomeDomainWithHeadroom(
     nodeIndexer podutil.GetPodsAssignedToNodeFunc,
     pod *v1.Pod,
@@ -255,7 +256,8 @@ Each candidate pod requests 100 m CPU. balanceDomains schedules 3 evictions.
 | 3 | TopologyBalanceNodeFit alone does **not** cap cumulative load (the bug) | defaults (TBNF=true, ZANF=false), nodeFit=false | 3 of 3 | ❌ baseline contrast (proves the bug exists without the new gate) |
 | 4 | Drains domain by domain, caps at sum of headroom across domains (zoneB=150 m, zoneC=250 m → total headroom 400 m fits 4×100 m, but algorithm schedules 4 evictions in 2 iterations; the 4th finds both domains drained) | TBNF=false, ZANF=true, nodeFit=false | 3 of 4 | ✅ — prior impl admits 4 (zoneC always has per-node fit) |
 | 5 | Per-node fit still required when aggregate headroom is misleadingly high (zoneB has 5 × 50 m nodes = 250 m aggregate but no single node fits 100 m) | TBNF=false, ZANF=true, nodeFit=false | 0 evictions | ❌ regression — both impls reject |
-| 6 | Default off — backward compat (ZANF unset, evictor nodeFit handles it) | defaults, nodeFit=true | 0 evictions | ❌ regression — identical to prior versions |
+| 6 | Multi-node-per-domain grouping (zoneB has 2 nodes each contributing 100 m → 200 m aggregate fits 2×100 m) | TBNF=false, ZANF=true, nodeFit=false | 2 evictions | ✅ — would surface a grouping bug that mis-bucketed nodes |
+| 7 | Default off — backward compat (ZANF unset, evictor nodeFit handles it) | defaults, nodeFit=true | 0 evictions | ❌ regression — identical to prior versions |
 
 ### Helper unit tests
 
@@ -263,7 +265,9 @@ Each candidate pod requests 100 m CPU. balanceDomains schedules 3 evictions.
 |---|---|
 | `TestGroupNodesByDomain` | Classifies by `node.Labels[topologyKey]`; drops nodes missing the label |
 | `TestComputeDomainHeadroom` | Aggregates allocatable − sum-of-requests across a domain's nodes; counts cpu (millicores) and pod slots correctly |
-| `TestPodFitsSomeDomainWithHeadroom` — alphabetical commit | Inserts `zoneB` first into the map, asserts commit lands on `zoneA` (deterministic sorted iteration) |
+| `TestComputeDomainHeadroomFailsClosedOnIndexerError` | When `ListPodsOnANode` errors for a node, that node contributes zero to the domain aggregate (no allocatable, no requests) |
+| `TestPodFitsSomeDomainWithHeadroom` — roomiest first | Picks the domain with the highest remaining CPU headroom even when it sorts later alphabetically |
+| `TestPodFitsSomeDomainWithHeadroom` — alphabetical tie-break | When two domains have equal headroom, commits to the alphabetically-earlier domain (determinism) |
 | `TestPodFitsSomeDomainWithHeadroom` — drain then reject | Three sequential calls with starting headroom = 250 m; first two admit, third rejects (50 m < 100 m) |
 | `TestPodFitsSomeDomainWithHeadroom` — aggregate failure | Headroom < pod request → reject |
 | `TestPodFitsSomeDomainWithHeadroom` — per-node failure | Aggregate ample but no single node fits (occupant pod consumes capacity) → reject |

--- a/docs/proposals/zone-aware-nodefit.md
+++ b/docs/proposals/zone-aware-nodefit.md
@@ -37,6 +37,46 @@ TopologyBalanceNodeFit evaluates each candidate against the live indexer state
 The scheduler can fit at most 1 of them in B. The other 2 go back to A → churn.
 ```
 
+### Stateless vs cumulative checks, side-by-side
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant BD as balanceDomains
+    participant TBNF as topologyBalanceNodeFit gate<br/>(stateless per-node check on union of domains)
+    participant ZANF as zoneAwareNodeFit gate<br/>(cumulative per-domain headroom)
+    participant Idx as live nodeIndexer<br/>(B1 = 150 m headroom)
+    participant H as remainingHeadroom map<br/>(zoneB = 150 m initially)
+
+    Note over BD: 3 candidate pods<br/>(each requests 100 m)
+
+    BD->>TBNF: candidate 1
+    TBNF->>Idx: PodFitsAnyOtherNode([B1])
+    Idx-->>TBNF: yes (150 m ≥ 100 m)
+    TBNF-->>BD: pass
+    BD->>ZANF: candidate 1
+    ZANF->>H: zoneB headroom?
+    H-->>ZANF: 150 m
+    ZANF->>H: decrement by 100 m → 50 m
+    ZANF-->>BD: pass
+
+    BD->>TBNF: candidate 2
+    TBNF->>Idx: PodFitsAnyOtherNode([B1])
+    Idx-->>TBNF: yes — indexer is NOT mutated mid-batch
+    TBNF-->>BD: pass ← bug
+    BD->>ZANF: candidate 2
+    ZANF->>H: zoneB headroom?
+    H-->>ZANF: 50 m
+    ZANF-->>BD: reject (50 m < 100 m)
+
+    BD->>TBNF: candidate 3
+    TBNF-->>BD: pass ← bug
+    BD->>ZANF: candidate 3
+    ZANF-->>BD: reject
+
+    Note over BD: topologyBalanceNodeFit alone:<br/>3 evictions, scheduler returns 2 → churn<br/>zoneAwareNodeFit (with or without TBNF):<br/>1 eviction, no churn
+```
+
 The fundamental gap: `TopologyBalanceNodeFit` reasons about **per-node fit on the
 union of under-loaded domains**, which mathematically collapses to
 `OR(merge(domains))`. It cannot detect cumulative over-commit of a single under-loaded
@@ -196,19 +236,38 @@ across all plugins. Rejected in favour of a TSC-local gate.
 
 ## Test Plan
 
-1. **Cumulative-overflow**: 7 pods on `zoneA`, 1 pod on `zoneB` (250 m CPU node, 150 m
-   headroom). `ZoneAwareNodeFit=true, TopologyBalanceNodeFit=false, nodeFit=false`
-   → 1 eviction (only one pod fits zoneB's aggregate headroom).
-2. **Baseline contrast**: same topology, all gates off → 3 evictions; with
-   `TopologyBalanceNodeFit=true` only → still 3 evictions (the bug the new gate fixes).
-3. **Multi-domain redirection**: 3 domains, `zoneB` tight (1 pod's worth of headroom),
-   `zoneC` plenty. Evictions spread across domains; all candidates admitted.
-4. **Per-node fit still required**: `zoneB` has high aggregate headroom but no single
-   node fits the pod → 0 evictions.
-5. **Default off**: `zoneAwareNodeFit` unset → byte-for-byte identical behaviour to
-   prior versions.
-6. Unit test for `podFitsSomeDomainWithHeadroom`: deterministic ordering, headroom
-   drain, aggregate-failure rejection, per-node-failure rejection, empty input.
+The acceptance bar for this test plan: each behavioural case must produce a different
+result under the redesign than under a naive `OR(merge(domains))` per-node-fit
+implementation. Cases marked **gap-catching** would have flagged the prior revision's
+churn bug. Cases marked **regression** ensure the new gate still enforces existing
+invariants (per-node fit, default-off no-op).
+
+### Integration cases (`TestTopologySpreadConstraint` table)
+
+Shared topology unless noted: `zoneA` over-loaded (7 pods on a 2 000 m node);
+`zoneB` under-loaded (1 pod on a 250 m node → 150 m aggregate headroom).
+Each candidate pod requests 100 m CPU. balanceDomains schedules 3 evictions.
+
+| # | Scenario | Args | Expected | Catches gap? |
+|---|---|---|---|---|
+| 1 | ZoneAwareNodeFit caps cumulative load **on top of** TopologyBalanceNodeFit | TBNF=true (default), ZANF=true, evictor nodeFit=false | 1 of 3 | ✅ — prior impl admits 3 (per-node check stateless across batch) |
+| 2 | ZoneAwareNodeFit alone caps at aggregate headroom | TBNF=false, ZANF=true, evictor nodeFit=false | 1 of 3 | ✅ — prior impl admits 3 |
+| 3 | TopologyBalanceNodeFit alone does **not** cap cumulative load (the bug) | defaults (TBNF=true, ZANF=false), nodeFit=false | 3 of 3 | ❌ baseline contrast (proves the bug exists without the new gate) |
+| 4 | Drains domain by domain, caps at sum of headroom across domains (zoneB=150 m, zoneC=250 m → total headroom 400 m fits 4×100 m, but algorithm schedules 4 evictions in 2 iterations; the 4th finds both domains drained) | TBNF=false, ZANF=true, nodeFit=false | 3 of 4 | ✅ — prior impl admits 4 (zoneC always has per-node fit) |
+| 5 | Per-node fit still required when aggregate headroom is misleadingly high (zoneB has 5 × 50 m nodes = 250 m aggregate but no single node fits 100 m) | TBNF=false, ZANF=true, nodeFit=false | 0 evictions | ❌ regression — both impls reject |
+| 6 | Default off — backward compat (ZANF unset, evictor nodeFit handles it) | defaults, nodeFit=true | 0 evictions | ❌ regression — identical to prior versions |
+
+### Helper unit tests
+
+| Test | Coverage |
+|---|---|
+| `TestGroupNodesByDomain` | Classifies by `node.Labels[topologyKey]`; drops nodes missing the label |
+| `TestComputeDomainHeadroom` | Aggregates allocatable − sum-of-requests across a domain's nodes; counts cpu (millicores) and pod slots correctly |
+| `TestPodFitsSomeDomainWithHeadroom` — alphabetical commit | Inserts `zoneB` first into the map, asserts commit lands on `zoneA` (deterministic sorted iteration) |
+| `TestPodFitsSomeDomainWithHeadroom` — drain then reject | Three sequential calls with starting headroom = 250 m; first two admit, third rejects (50 m < 100 m) |
+| `TestPodFitsSomeDomainWithHeadroom` — aggregate failure | Headroom < pod request → reject |
+| `TestPodFitsSomeDomainWithHeadroom` — per-node failure | Aggregate ample but no single node fits (occupant pod consumes capacity) → reject |
+| `TestPodFitsSomeDomainWithHeadroom` — empty input | Empty `nodesByDomain` → reject without error |
 
 ## Risk
 

--- a/hack/lib/go.sh
+++ b/hack/lib/go.sh
@@ -19,7 +19,7 @@
 go::verify_version() {
   GO_VERSION=($(go version))
 
-  if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.23|go1.24|go1.25') ]]; then
+  if [[ -z $(echo "${GO_VERSION[2]}" | grep -E 'go1.24|go1.25|go1.26') ]]; then
     echo "Unknown go version '${GO_VERSION[2]}', skipping gofmt."
     exit 1
   fi

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/defaults.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/defaults.go
@@ -36,6 +36,9 @@ func SetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(obj runtime.Obj
 	if args.TopologyBalanceNodeFit == nil {
 		args.TopologyBalanceNodeFit = utilptr.To(true)
 	}
+	if args.ZoneAwareNodeFit == nil {
+		args.ZoneAwareNodeFit = utilptr.To(false)
+	}
 	if len(args.Constraints) == 0 {
 		args.Constraints = append(args.Constraints, v1.DoNotSchedule)
 	}

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/defaults_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/defaults_test.go
@@ -98,6 +98,17 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 				ZoneAwareNodeFit:       utilptr.To(false),
 			},
 		},
+		{
+			name: "RemovePodsViolatingTopologySpreadConstraintArgs with ZoneAwareNodeFit=true is not overwritten",
+			in: &RemovePodsViolatingTopologySpreadConstraintArgs{
+				ZoneAwareNodeFit: utilptr.To(true),
+			},
+			want: &RemovePodsViolatingTopologySpreadConstraintArgs{
+				TopologyBalanceNodeFit: utilptr.To(true),
+				Constraints:            []v1.UnsatisfiableConstraintAction{v1.DoNotSchedule},
+				ZoneAwareNodeFit:       utilptr.To(true),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -106,21 +117,5 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 				t.Errorf("Got unexpected defaults (-want, +got):\n%s", diff)
 			}
 		})
-	}
-}
-
-func TestZoneAwareNodeFitDefault(t *testing.T) {
-	args := &RemovePodsViolatingTopologySpreadConstraintArgs{}
-	SetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(args)
-
-	if args.ZoneAwareNodeFit == nil {
-		t.Fatal("ZoneAwareNodeFit must not be nil after SetDefaults")
-	}
-	if *args.ZoneAwareNodeFit != false {
-		t.Errorf("ZoneAwareNodeFit default: got %v, want false", *args.ZoneAwareNodeFit)
-	}
-	// Existing default must not regress
-	if args.TopologyBalanceNodeFit == nil || !*args.TopologyBalanceNodeFit {
-		t.Error("TopologyBalanceNodeFit must default to true")
 	}
 }

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/defaults_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/defaults_test.go
@@ -49,6 +49,7 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 				LabelSelector:          nil,
 				Constraints:            []v1.UnsatisfiableConstraintAction{v1.DoNotSchedule},
 				TopologyBalanceNodeFit: utilptr.To(true),
+				ZoneAwareNodeFit:       utilptr.To(false),
 			},
 		},
 		{
@@ -63,6 +64,7 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 				LabelSelector:          &metav1.LabelSelector{},
 				Constraints:            []v1.UnsatisfiableConstraintAction{v1.DoNotSchedule, v1.ScheduleAnyway},
 				TopologyBalanceNodeFit: utilptr.To(true),
+				ZoneAwareNodeFit:       utilptr.To(false),
 			},
 		},
 		{
@@ -71,6 +73,7 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 			want: &RemovePodsViolatingTopologySpreadConstraintArgs{
 				Constraints:            []v1.UnsatisfiableConstraintAction{v1.DoNotSchedule},
 				TopologyBalanceNodeFit: utilptr.To(true),
+				ZoneAwareNodeFit:       utilptr.To(false),
 			},
 		},
 		{
@@ -81,6 +84,7 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 			want: &RemovePodsViolatingTopologySpreadConstraintArgs{
 				TopologyBalanceNodeFit: utilptr.To(false),
 				Constraints:            []v1.UnsatisfiableConstraintAction{v1.DoNotSchedule},
+				ZoneAwareNodeFit:       utilptr.To(false),
 			},
 		},
 		{
@@ -91,6 +95,7 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 			want: &RemovePodsViolatingTopologySpreadConstraintArgs{
 				Constraints:            []v1.UnsatisfiableConstraintAction{v1.DoNotSchedule},
 				TopologyBalanceNodeFit: utilptr.To(true),
+				ZoneAwareNodeFit:       utilptr.To(false),
 			},
 		},
 	}
@@ -101,5 +106,21 @@ func TestSetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(t *testing.
 				t.Errorf("Got unexpected defaults (-want, +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestZoneAwareNodeFitDefault(t *testing.T) {
+	args := &RemovePodsViolatingTopologySpreadConstraintArgs{}
+	SetDefaults_RemovePodsViolatingTopologySpreadConstraintArgs(args)
+
+	if args.ZoneAwareNodeFit == nil {
+		t.Fatal("ZoneAwareNodeFit must not be nil after SetDefaults")
+	}
+	if *args.ZoneAwareNodeFit != false {
+		t.Errorf("ZoneAwareNodeFit default: got %v, want false", *args.ZoneAwareNodeFit)
+	}
+	// Existing default must not regress
+	if args.TopologyBalanceNodeFit == nil || !*args.TopologyBalanceNodeFit {
+		t.Error("TopologyBalanceNodeFit must default to true")
 	}
 }

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -315,6 +315,13 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 	eligibleNodes := filterEligibleNodes(ctx, nodes, tsc)
 	nodesBelowIdealAvg := filterNodesBelowIdealAvg(eligibleNodes, sortedDomains, tsc.TopologyKey, idealAvg)
 
+	zoneAwareNodeFit := utilptr.Deref(d.args.ZoneAwareNodeFit, false)
+
+	var nodesByZoneBelowIdealAvg map[string][]*v1.Node
+	if zoneAwareNodeFit {
+		nodesByZoneBelowIdealAvg = filterNodesByZoneBelowIdealAvg(eligibleNodes, sortedDomains, tsc.TopologyKey, idealAvg)
+	}
+
 	// i is the index for belowOrEqualAvg
 	// j is the index for aboveAvg
 	i := 0
@@ -379,6 +386,11 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 				continue
 			}
 
+			if zoneAwareNodeFit && !podFitsAnyNodeInSomeZone(getPodsAssignedToNode, aboveToEvict[k], nodesByZoneBelowIdealAvg) {
+				d.logger.V(2).Info("ignoring pod for eviction: no target zone has sufficient capacity", "pod", klog.KObj(aboveToEvict[k]))
+				continue
+			}
+
 			podsForEviction[aboveToEvict[k]] = struct{}{}
 		}
 		sortedDomains[j].pods = sortedDomains[j].pods[:len(sortedDomains[j].pods)-movePods]
@@ -403,6 +415,39 @@ func filterNodesBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, topolo
 		}
 	}
 	return nodesBelowIdealAvg
+}
+
+// filterNodesByZoneBelowIdealAvg groups nodes from topology domains whose pod count
+// is strictly below idealAvg, keyed by their domain value (e.g. zone name).
+// Unlike filterNodesBelowIdealAvg, the zone-to-nodes mapping is preserved so callers
+// can validate capacity zone-by-zone rather than across an aggregate node list.
+// Returns an empty map (not nil) when no domains are below idealAvg.
+func filterNodesByZoneBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, topologyKey string, idealAvg float64) map[string][]*v1.Node {
+	topologyNodesMap := make(map[string][]*v1.Node, len(sortedDomains))
+	for _, n := range nodes {
+		if zone, ok := n.Labels[topologyKey]; ok {
+			topologyNodesMap[zone] = append(topologyNodesMap[zone], n)
+		}
+	}
+	result := make(map[string][]*v1.Node)
+	for _, domain := range sortedDomains {
+		if float64(len(domain.pods)) < idealAvg {
+			result[domain.pair.value] = topologyNodesMap[domain.pair.value]
+		}
+	}
+	return result
+}
+
+// podFitsAnyNodeInSomeZone returns true if pod can be scheduled on at least one node
+// within at least one zone from nodesByZone. Each zone is validated independently —
+// the pod must fit entirely within a single zone, not across a mix of zone nodes.
+func podFitsAnyNodeInSomeZone(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, nodesByZone map[string][]*v1.Node) bool {
+	for _, zoneNodes := range nodesByZone {
+		if node.PodFitsAnyOtherNode(nodeIndexer, pod, zoneNodes) {
+			return true
+		}
+	}
+	return false
 }
 
 // sortDomains sorts and splits the list of topology domains based on their size

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -430,9 +430,12 @@ func filterNodesByZoneBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, 
 		}
 	}
 	result := make(map[string][]*v1.Node)
+	// TODO: validate domain.pair.key == topologyKey to guard against future mixed-key domain lists.
 	for _, domain := range sortedDomains {
 		if float64(len(domain.pods)) < idealAvg {
-			result[domain.pair.value] = topologyNodesMap[domain.pair.value]
+			if zoneNodes := topologyNodesMap[domain.pair.value]; len(zoneNodes) > 0 {
+				result[domain.pair.value] = zoneNodes
+			}
 		}
 	}
 	return result

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -317,9 +317,9 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 
 	zoneAwareNodeFit := utilptr.Deref(d.args.ZoneAwareNodeFit, false)
 
-	var nodesByZoneBelowIdealAvg map[string][]*v1.Node
+	var nodesByDomainBelowIdealAvg map[string][]*v1.Node
 	if zoneAwareNodeFit {
-		nodesByZoneBelowIdealAvg = filterNodesByZoneBelowIdealAvg(eligibleNodes, sortedDomains, tsc.TopologyKey, idealAvg)
+		nodesByDomainBelowIdealAvg = filterNodesByDomainBelowIdealAvg(eligibleNodes, sortedDomains, tsc.TopologyKey, idealAvg)
 	}
 
 	// i is the index for belowOrEqualAvg
@@ -386,7 +386,7 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 				continue
 			}
 
-			if zoneAwareNodeFit && !podFitsAnyNodeInSomeZone(getPodsAssignedToNode, aboveToEvict[k], nodesByZoneBelowIdealAvg) {
+			if zoneAwareNodeFit && !podFitsAnyNodeInSomeDomain(getPodsAssignedToNode, aboveToEvict[k], nodesByDomainBelowIdealAvg) {
 				d.logger.V(2).Info("ignoring pod for eviction: no target zone has sufficient capacity", "pod", klog.KObj(aboveToEvict[k]))
 				continue
 			}
@@ -417,36 +417,37 @@ func filterNodesBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, topolo
 	return nodesBelowIdealAvg
 }
 
-// filterNodesByZoneBelowIdealAvg groups nodes from topology domains whose pod count
-// is strictly below idealAvg, keyed by their domain value (e.g. zone name).
-// Unlike filterNodesBelowIdealAvg, the zone-to-nodes mapping is preserved so callers
-// can validate capacity zone-by-zone rather than across an aggregate node list.
-// Returns an empty map (not nil) when no domains are below idealAvg.
-func filterNodesByZoneBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, topologyKey string, idealAvg float64) map[string][]*v1.Node {
+// filterNodesByDomainBelowIdealAvg groups nodes from topology domains whose pod count
+// is strictly below idealAvg, keyed by their topology domain value (e.g. zone name).
+// Unlike filterNodesBelowIdealAvg, the domain-to-nodes mapping is preserved so callers
+// can validate capacity domain-by-domain rather than across an aggregate node list.
+// Returns an empty map (not nil) when no topology domains are below idealAvg.
+func filterNodesByDomainBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, topologyKey string, idealAvg float64) map[string][]*v1.Node {
 	topologyNodesMap := make(map[string][]*v1.Node, len(sortedDomains))
 	for _, n := range nodes {
-		if zone, ok := n.Labels[topologyKey]; ok {
-			topologyNodesMap[zone] = append(topologyNodesMap[zone], n)
+		if domainValue, ok := n.Labels[topologyKey]; ok {
+			topologyNodesMap[domainValue] = append(topologyNodesMap[domainValue], n)
 		}
 	}
 	result := make(map[string][]*v1.Node)
 	// TODO: validate domain.pair.key == topologyKey to guard against future mixed-key domain lists.
 	for _, domain := range sortedDomains {
 		if float64(len(domain.pods)) < idealAvg {
-			if zoneNodes := topologyNodesMap[domain.pair.value]; len(zoneNodes) > 0 {
-				result[domain.pair.value] = zoneNodes
+			if domainNodes := topologyNodesMap[domain.pair.value]; len(domainNodes) > 0 {
+				result[domain.pair.value] = domainNodes
 			}
 		}
 	}
 	return result
 }
 
-// podFitsAnyNodeInSomeZone returns true if pod can be scheduled on at least one node
-// within at least one zone from nodesByZone. Each zone is validated independently —
-// the pod must fit entirely within a single zone, not across a mix of zone nodes.
-func podFitsAnyNodeInSomeZone(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, nodesByZone map[string][]*v1.Node) bool {
-	for _, zoneNodes := range nodesByZone {
-		if node.PodFitsAnyOtherNode(nodeIndexer, pod, zoneNodes) {
+// podFitsAnyNodeInSomeDomain returns true if pod can be scheduled on at least one node
+// within at least one topology domain (e.g. zone) from nodesByDomain. Each topology
+// domain is validated independently — the pod must fit entirely within a single
+// topology domain, not across a mix of nodes from different domains.
+func podFitsAnyNodeInSomeDomain(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, nodesByDomain map[string][]*v1.Node) bool {
+	for _, domainNodes := range nodesByDomain {
+		if node.PodFitsAnyOtherNode(nodeIndexer, pod, domainNodes) {
 			return true
 		}
 	}

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -317,9 +318,15 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 
 	zoneAwareNodeFit := utilptr.Deref(d.args.ZoneAwareNodeFit, false)
 
-	var nodesByDomainBelowIdealAvg map[string][]*v1.Node
+	// When zoneAwareNodeFit is enabled, group the same under-loaded nodes by their
+	// topology-domain value and compute each domain's remaining aggregate headroom.
+	// The headroom map is mutated as evictions are committed within this call so that
+	// later candidate pods see headroom already consumed by earlier ones.
+	var nodesByDomain map[string][]*v1.Node
+	var remainingHeadroom map[string]v1.ResourceList
 	if zoneAwareNodeFit {
-		nodesByDomainBelowIdealAvg = filterNodesByDomainBelowIdealAvg(eligibleNodes, sortedDomains, tsc.TopologyKey, idealAvg)
+		nodesByDomain = groupNodesByDomain(nodesBelowIdealAvg, tsc.TopologyKey)
+		remainingHeadroom = computeDomainHeadroom(nodesByDomain, getPodsAssignedToNode)
 	}
 
 	// i is the index for belowOrEqualAvg
@@ -386,9 +393,11 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 				continue
 			}
 
-			if zoneAwareNodeFit && !podFitsAnyNodeInSomeDomain(getPodsAssignedToNode, aboveToEvict[k], nodesByDomainBelowIdealAvg) {
-				d.logger.V(2).Info("ignoring pod for eviction: no target zone has sufficient capacity", "pod", klog.KObj(aboveToEvict[k]))
-				continue
+			if zoneAwareNodeFit {
+				if _, ok := podFitsSomeDomainWithHeadroom(getPodsAssignedToNode, aboveToEvict[k], nodesByDomain, remainingHeadroom); !ok {
+					d.logger.V(2).Info("ignoring pod for eviction: no target topology domain has fit + remaining headroom", "pod", klog.KObj(aboveToEvict[k]))
+					continue
+				}
 			}
 
 			podsForEviction[aboveToEvict[k]] = struct{}{}
@@ -417,41 +426,114 @@ func filterNodesBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, topolo
 	return nodesBelowIdealAvg
 }
 
-// filterNodesByDomainBelowIdealAvg groups nodes from topology domains whose pod count
-// is strictly below idealAvg, keyed by their topology domain value (e.g. zone name).
-// Unlike filterNodesBelowIdealAvg, the domain-to-nodes mapping is preserved so callers
-// can validate capacity domain-by-domain rather than across an aggregate node list.
-// Returns an empty map (not nil) when no topology domains are below idealAvg.
-func filterNodesByDomainBelowIdealAvg(nodes []*v1.Node, sortedDomains []topology, topologyKey string, idealAvg float64) map[string][]*v1.Node {
-	topologyNodesMap := make(map[string][]*v1.Node, len(sortedDomains))
-	for _, n := range nodes {
-		if domainValue, ok := n.Labels[topologyKey]; ok {
-			topologyNodesMap[domainValue] = append(topologyNodesMap[domainValue], n)
-		}
-	}
+// groupNodesByDomain classifies the given nodes by their topology-domain label value.
+// Nodes missing the label are skipped. Returns an empty (non-nil) map if no nodes have the label.
+func groupNodesByDomain(nodes []*v1.Node, topologyKey string) map[string][]*v1.Node {
 	result := make(map[string][]*v1.Node)
-	// TODO: validate domain.pair.key == topologyKey to guard against future mixed-key domain lists.
-	for _, domain := range sortedDomains {
-		if float64(len(domain.pods)) < idealAvg {
-			if domainNodes := topologyNodesMap[domain.pair.value]; len(domainNodes) > 0 {
-				result[domain.pair.value] = domainNodes
-			}
+	for _, n := range nodes {
+		if v, ok := n.Labels[topologyKey]; ok {
+			result[v] = append(result[v], n)
 		}
 	}
 	return result
 }
 
-// podFitsAnyNodeInSomeDomain returns true if pod can be scheduled on at least one node
-// within at least one topology domain (e.g. zone) from nodesByDomain. Each topology
-// domain is validated independently — the pod must fit entirely within a single
-// topology domain, not across a mix of nodes from different domains.
-func podFitsAnyNodeInSomeDomain(nodeIndexer podutil.GetPodsAssignedToNodeFunc, pod *v1.Pod, nodesByDomain map[string][]*v1.Node) bool {
-	for _, domainNodes := range nodesByDomain {
-		if node.PodFitsAnyOtherNode(nodeIndexer, pod, domainNodes) {
-			return true
+// computeDomainHeadroom returns, for each topology domain, the aggregate remaining
+// resource headroom (allocatable minus already-requested) summed across the domain's
+// nodes. Tracked resources: cpu, memory, pod count. Nodes whose pod listing fails
+// contribute only their raw allocatable (best-effort, conservatively over-counting
+// rather than blocking eviction).
+func computeDomainHeadroom(nodesByDomain map[string][]*v1.Node, nodeIndexer podutil.GetPodsAssignedToNodeFunc) map[string]v1.ResourceList {
+	result := make(map[string]v1.ResourceList, len(nodesByDomain))
+	for domain, dnodes := range nodesByDomain {
+		var cpuMilli, memBytes, podSlots int64
+		for _, n := range dnodes {
+			cpuMilli += n.Status.Allocatable.Cpu().MilliValue()
+			memBytes += n.Status.Allocatable.Memory().Value()
+			podSlots += n.Status.Allocatable.Pods().Value()
+			podsOnNode, err := podutil.ListPodsOnANode(n.Name, nodeIndexer, nil)
+			if err != nil {
+				continue
+			}
+			for _, p := range podsOnNode {
+				req, _ := utils.PodRequestsAndLimits(p)
+				if q, ok := req[v1.ResourceCPU]; ok {
+					cpuMilli -= q.MilliValue()
+				}
+				if q, ok := req[v1.ResourceMemory]; ok {
+					memBytes -= q.Value()
+				}
+				podSlots--
+			}
+		}
+		result[domain] = v1.ResourceList{
+			v1.ResourceCPU:    *resource.NewMilliQuantity(cpuMilli, resource.DecimalSI),
+			v1.ResourceMemory: *resource.NewQuantity(memBytes, resource.BinarySI),
+			v1.ResourcePods:   *resource.NewQuantity(podSlots, resource.DecimalSI),
 		}
 	}
-	return false
+	return result
+}
+
+// podFitsSomeDomainWithHeadroom returns the topology-domain key whose remaining aggregate
+// headroom can absorb the pod AND whose nodes include at least one where the pod fits per
+// the scheduler's per-node predicates. On success it decrements that domain's headroom by
+// the pod's requests (cpu/mem/1 pod slot) and returns ok=true. Returns ok=false if no
+// domain qualifies. Domain keys are iterated in deterministic (sorted) order.
+func podFitsSomeDomainWithHeadroom(
+	nodeIndexer podutil.GetPodsAssignedToNodeFunc,
+	pod *v1.Pod,
+	nodesByDomain map[string][]*v1.Node,
+	remainingHeadroom map[string]v1.ResourceList,
+) (string, bool) {
+	podReq, _ := utils.PodRequestsAndLimits(pod)
+	domains := make([]string, 0, len(nodesByDomain))
+	for d := range nodesByDomain {
+		domains = append(domains, d)
+	}
+	sort.Strings(domains)
+
+	for _, domain := range domains {
+		if !headroomCoversPod(remainingHeadroom[domain], podReq) {
+			continue
+		}
+		if !node.PodFitsAnyOtherNode(nodeIndexer, pod, nodesByDomain[domain]) {
+			continue
+		}
+		subtractPodFromHeadroom(remainingHeadroom, domain, podReq)
+		return domain, true
+	}
+	return "", false
+}
+
+// headroomCoversPod reports whether the domain's remaining headroom is sufficient to
+// absorb pod's cpu/memory request plus one pod slot. Missing keys are treated as zero.
+func headroomCoversPod(headroom v1.ResourceList, podReq v1.ResourceList) bool {
+	cpuHead := headroom[v1.ResourceCPU]
+	memHead := headroom[v1.ResourceMemory]
+	podsHead := headroom[v1.ResourcePods]
+	cpuReq := podReq[v1.ResourceCPU]
+	memReq := podReq[v1.ResourceMemory]
+	return cpuHead.MilliValue() >= cpuReq.MilliValue() &&
+		memHead.Value() >= memReq.Value() &&
+		podsHead.Value() >= 1
+}
+
+// subtractPodFromHeadroom decrements remainingHeadroom[domain] by the pod's cpu/memory
+// request and one pod slot.
+func subtractPodFromHeadroom(remainingHeadroom map[string]v1.ResourceList, domain string, podReq v1.ResourceList) {
+	rl := remainingHeadroom[domain]
+	cpuReq := podReq[v1.ResourceCPU]
+	memReq := podReq[v1.ResourceMemory]
+	cpu := rl[v1.ResourceCPU]
+	cpu.Sub(cpuReq)
+	rl[v1.ResourceCPU] = cpu
+	mem := rl[v1.ResourceMemory]
+	mem.Sub(memReq)
+	rl[v1.ResourceMemory] = mem
+	pods := rl[v1.ResourcePods]
+	pods.Sub(*resource.NewQuantity(1, resource.DecimalSI))
+	rl[v1.ResourcePods] = pods
 }
 
 // sortDomains sorts and splits the list of topology domains based on their size

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -322,6 +322,15 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 	// topology-domain value and compute each domain's remaining aggregate headroom.
 	// The headroom map is mutated as evictions are committed within this call so that
 	// later candidate pods see headroom already consumed by earlier ones.
+	//
+	// The grouping and headroom snapshot are taken once at entry and are *not* recomputed
+	// as the outer (i, j) loop progresses. As pods get added to podsForEviction the
+	// effective set of below-ideal domains can shift, but the snapshot's drift is the
+	// safe (conservative) direction: a domain that becomes saturated mid-batch will stop
+	// admitting new pods once its tracked headroom is drained, and a domain that becomes
+	// further below idealAvg is simply not promoted into the gate's view. Recomputing
+	// per iteration would be more accurate but costs an extra ListPodsOnANode sweep
+	// across the domain's nodes for every (i, j) step.
 	var nodesByDomain map[string][]*v1.Node
 	var remainingHeadroom map[string]v1.ResourceList
 	if zoneAwareNodeFit {
@@ -394,10 +403,20 @@ func (d *RemovePodsViolatingTopologySpreadConstraint) balanceDomains(ctx context
 			}
 
 			if zoneAwareNodeFit {
-				if _, ok := podFitsSomeDomainWithHeadroom(getPodsAssignedToNode, aboveToEvict[k], nodesByDomain, remainingHeadroom); !ok {
+				// Note: headroom is decremented at this point, before the actual eviction
+				// is recorded in the eviction loop. If a later eviction filter (rate limit,
+				// pre-eviction predicate, eviction error) rejects this pod, the chosen
+				// domain's headroom has been consumed without an actual pod move, making
+				// the gate conservative on the next candidate. Deferring the subtraction
+				// would require restructuring the eviction loop to call back into the
+				// gate on success; the current behaviour favours safety (admit fewer
+				// pods than nominally possible) over throughput.
+				targetDomain, ok := podFitsSomeDomainWithHeadroom(getPodsAssignedToNode, aboveToEvict[k], nodesByDomain, remainingHeadroom)
+				if !ok {
 					d.logger.V(2).Info("ignoring pod for eviction: no target topology domain has fit + remaining headroom", "pod", klog.KObj(aboveToEvict[k]))
 					continue
 				}
+				d.logger.V(2).Info("ZoneAwareNodeFit admitted pod; target domain headroom decremented", "pod", klog.KObj(aboveToEvict[k]), "targetDomain", targetDomain)
 			}
 
 			podsForEviction[aboveToEvict[k]] = struct{}{}
@@ -452,6 +471,13 @@ func computeDomainHeadroom(nodesByDomain map[string][]*v1.Node, nodeIndexer podu
 	for domain, dnodes := range nodesByDomain {
 		var cpuMilli, memBytes, podSlots int64
 		for _, n := range dnodes {
+			// Filter is intentionally nil so this aggregation reasons over the same pod
+			// set as nodeAvailableResources / fitsRequest (pkg/descheduler/node/node.go),
+			// which also calls ListPodsOnANode with no filter. Diverging here would let
+			// per-node fit and per-domain headroom disagree about what counts as occupied
+			// capacity; if fitsRequest ever tightens its filter (e.g. to exclude
+			// terminal/terminating pods), this call site must be updated in the same
+			// change to keep the two halves of the gate aligned.
 			podsOnNode, err := podutil.ListPodsOnANode(n.Name, nodeIndexer, nil)
 			if err != nil {
 				klog.V(2).ErrorS(err, "ZoneAwareNodeFit: failed to list pods on node; excluding from domain headroom (fail-closed)", "node", n.Name, "domain", domain)
@@ -491,6 +517,15 @@ func computeDomainHeadroom(nodesByDomain map[string][]*v1.Node, nodeIndexer podu
 // headroom) fall back to alphabetical order for determinism. This avoids draining
 // alphabetically-earlier domains first and leaving later candidates rejected even though
 // a different domain had headroom to spare.
+//
+// The CPU-only sort key is intentional: CPU is the most commonly request-constrained
+// resource for workloads we are spreading across topology domains, and a multi-resource
+// composite scoring (e.g. normalized headroom across the pod's actual requests) would
+// add complexity without changing behaviour for the typical case. For memory-heavy pods
+// in environments with abundant CPU slack but uneven memory headroom, the alphabetical
+// fallback can pick a domain with tighter memory than another candidate; the
+// headroomCoversPod check below still rejects domains that cannot absorb the pod, so
+// this only affects ordering, not correctness.
 func podFitsSomeDomainWithHeadroom(
 	nodeIndexer podutil.GetPodsAssignedToNodeFunc,
 	pod *v1.Pod,

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -508,7 +508,7 @@ func podFitsSomeDomainWithHeadroom(
 
 // headroomCoversPod reports whether the domain's remaining headroom is sufficient to
 // absorb pod's cpu/memory request plus one pod slot. Missing keys are treated as zero.
-func headroomCoversPod(headroom v1.ResourceList, podReq v1.ResourceList) bool {
+func headroomCoversPod(headroom, podReq v1.ResourceList) bool {
 	cpuHead := headroom[v1.ResourceCPU]
 	memHead := headroom[v1.ResourceMemory]
 	podsHead := headroom[v1.ResourcePods]

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint.go
@@ -440,21 +440,26 @@ func groupNodesByDomain(nodes []*v1.Node, topologyKey string) map[string][]*v1.N
 
 // computeDomainHeadroom returns, for each topology domain, the aggregate remaining
 // resource headroom (allocatable minus already-requested) summed across the domain's
-// nodes. Tracked resources: cpu, memory, pod count. Nodes whose pod listing fails
-// contribute only their raw allocatable (best-effort, conservatively over-counting
-// rather than blocking eviction).
+// nodes. Tracked resources: cpu, memory, pod count.
+//
+// Fails closed: if the pod indexer cannot list pods on a node, that node is omitted
+// from the headroom entirely (neither its allocatable nor any requests are counted)
+// and the error is logged. Counting allocatable without subtracting requests would
+// over-state available capacity and re-introduce the eviction churn this gate is
+// meant to prevent.
 func computeDomainHeadroom(nodesByDomain map[string][]*v1.Node, nodeIndexer podutil.GetPodsAssignedToNodeFunc) map[string]v1.ResourceList {
 	result := make(map[string]v1.ResourceList, len(nodesByDomain))
 	for domain, dnodes := range nodesByDomain {
 		var cpuMilli, memBytes, podSlots int64
 		for _, n := range dnodes {
+			podsOnNode, err := podutil.ListPodsOnANode(n.Name, nodeIndexer, nil)
+			if err != nil {
+				klog.V(2).ErrorS(err, "ZoneAwareNodeFit: failed to list pods on node; excluding from domain headroom (fail-closed)", "node", n.Name, "domain", domain)
+				continue
+			}
 			cpuMilli += n.Status.Allocatable.Cpu().MilliValue()
 			memBytes += n.Status.Allocatable.Memory().Value()
 			podSlots += n.Status.Allocatable.Pods().Value()
-			podsOnNode, err := podutil.ListPodsOnANode(n.Name, nodeIndexer, nil)
-			if err != nil {
-				continue
-			}
 			for _, p := range podsOnNode {
 				req, _ := utils.PodRequestsAndLimits(p)
 				if q, ok := req[v1.ResourceCPU]; ok {
@@ -479,7 +484,13 @@ func computeDomainHeadroom(nodesByDomain map[string][]*v1.Node, nodeIndexer podu
 // headroom can absorb the pod AND whose nodes include at least one where the pod fits per
 // the scheduler's per-node predicates. On success it decrements that domain's headroom by
 // the pod's requests (cpu/mem/1 pod slot) and returns ok=true. Returns ok=false if no
-// domain qualifies. Domain keys are iterated in deterministic (sorted) order.
+// domain qualifies.
+//
+// Domain selection order: domains are iterated by descending remaining CPU headroom so
+// pods are spread toward the roomiest under-loaded domain first; ties (and zero/negative
+// headroom) fall back to alphabetical order for determinism. This avoids draining
+// alphabetically-earlier domains first and leaving later candidates rejected even though
+// a different domain had headroom to spare.
 func podFitsSomeDomainWithHeadroom(
 	nodeIndexer podutil.GetPodsAssignedToNodeFunc,
 	pod *v1.Pod,
@@ -491,7 +502,14 @@ func podFitsSomeDomainWithHeadroom(
 	for d := range nodesByDomain {
 		domains = append(domains, d)
 	}
-	sort.Strings(domains)
+	sort.Slice(domains, func(i, j int) bool {
+		ci := remainingHeadroom[domains[i]][v1.ResourceCPU]
+		cj := remainingHeadroom[domains[j]][v1.ResourceCPU]
+		if ci.MilliValue() != cj.MilliValue() {
+			return ci.MilliValue() > cj.MilliValue()
+		}
+		return domains[i] < domains[j]
+	})
 
 	for _, domain := range domains {
 		if !headroomCoversPod(remainingHeadroom[domain], podReq) {

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1481,6 +1481,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			args: RemovePodsViolatingTopologySpreadConstraintArgs{
 				ZoneAwareNodeFit: utilptr.To(true),
 			},
+			nodeFit: true,
 		},
 		{
 			name: "ZoneAwareNodeFit=true, 2 domains [4,1], all target zones at CPU capacity, should evict 0 (no churn)",
@@ -1538,10 +1539,12 @@ func TestTopologySpreadConstraint(t *testing.T) {
 					labels: map[string]string{"foo": "bar"},
 				},
 			}),
-			// idealAvg = (6+2+2)/3 = 3.33. balanceDomains runs two passes: first evicts 2 pods
-			// from zoneA toward zoneB (zoneC qualifies, so the gate passes), then evicts 1 more
-			// from zoneA toward zoneC → 3 total. zoneB's 50m CPU means it cannot receive new
-			// pods, but zoneC's 2000m CPU satisfies ZoneAwareNodeFit so eviction proceeds.
+			// idealAvg = (6+2+2)/3 = 3.33. Both zoneB (2 pods < 3.33) and zoneC (2 pods < 3.33)
+			// appear in nodesByZoneBelowIdealAvg. zoneB's node (B1, 50m CPU) cannot fit a 100m-request
+			// pod, but zoneC's node (C1, 2000m CPU) can — so podFitsAnyNodeInSomeZone returns true
+			// for every pod selected from zoneA. The topologyBalanceNodeFit gate (default true) also
+			// passes for the same reason (zoneC is in the merged nodesBelowIdealAvg flat list).
+			// balanceDomains selects ceil(6−3.33)=3 pods for eviction; all three pass both gates → 3 evicted.
 			expectedEvictedCount: 3,
 			namespaces:           []string{"ns1"},
 			args: RemovePodsViolatingTopologySpreadConstraintArgs{
@@ -1550,7 +1553,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			nodeFit: true,
 		},
 		{
-			name: "ZoneAwareNodeFit=false (default), 2 domains [4,1], target zone at CPU capacity, existing TopologyBalanceNodeFit still blocks eviction",
+			name: "ZoneAwareNodeFit omitted, nodeFit=true, target zone at CPU capacity, TopologyBalanceNodeFit=true (default) blocks eviction — backward compat",
 			nodes: []*v1.Node{
 				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
 				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1818,6 +1818,39 @@ func getDefaultTopologyConstraints(maxSkew int32, edits ...func(*v1.TopologySpre
 	return []v1.TopologySpreadConstraint{constraint}
 }
 
+func TestFilterNodesByZoneBelowIdealAvg(t *testing.T) {
+	makeNode := func(name, zone string) *v1.Node {
+		return test.BuildTestNode(name, 1000, 2000, 10, func(n *v1.Node) {
+			n.Labels["zone"] = zone
+		})
+	}
+
+	nodes := []*v1.Node{
+		makeNode("A1", "zoneA"),
+		makeNode("A2", "zoneA"),
+		makeNode("B1", "zoneB"),
+		makeNode("C1", "zoneC"),
+	}
+	sortedDomains := []topology{
+		{pair: topologyPair{"zone", "zoneA"}, pods: make([]*v1.Pod, 8)}, // above avg
+		{pair: topologyPair{"zone", "zoneB"}, pods: make([]*v1.Pod, 2)}, // below avg
+		{pair: topologyPair{"zone", "zoneC"}, pods: make([]*v1.Pod, 2)}, // below avg
+	}
+	idealAvg := 4.0
+
+	got := filterNodesByZoneBelowIdealAvg(nodes, sortedDomains, "zone", idealAvg)
+
+	if _, ok := got["zoneA"]; ok {
+		t.Error("zoneA should not be in result: it is above idealAvg")
+	}
+	if zoneB := got["zoneB"]; len(zoneB) != 1 || zoneB[0].Name != "B1" {
+		t.Errorf("zoneB: got %v, want [B1]", zoneB)
+	}
+	if zoneC := got["zoneC"]; len(zoneC) != 1 || zoneC[0].Name != "C1" {
+		t.Errorf("zoneC: got %v, want [C1]", zoneC)
+	}
+}
+
 func TestCheckIdenticalConstraints(t *testing.T) {
 	selector, _ := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}})
 

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1578,6 +1578,36 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			args:                 RemovePodsViolatingTopologySpreadConstraintArgs{},
 			nodeFit:              true,
 		},
+		{
+			// Isolated test: TopologyBalanceNodeFit=false disables the aggregate gate; ZoneAwareNodeFit=true
+			// re-enables the per-node fit check zone-by-zone. With zoneB at CPU capacity the zone-aware
+			// gate should block eviction even though TopologyBalanceNodeFit is off.
+			name: "ZoneAwareNodeFit=true, TopologyBalanceNodeFit=false, target zone at CPU capacity, should evict 0",
+			nodes: []*v1.Node{
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       4,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{
+					count:  1,
+					node:   "B1",
+					labels: map[string]string{"foo": "bar"},
+				},
+			}),
+			expectedEvictedCount: 0,
+			namespaces:           []string{"ns1"},
+			args: RemovePodsViolatingTopologySpreadConstraintArgs{
+				TopologyBalanceNodeFit: utilptr.To(false),
+				ZoneAwareNodeFit:       utilptr.To(true),
+			},
+			nodeFit: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1540,8 +1540,8 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				},
 			}),
 			// idealAvg = (6+2+2)/3 = 3.33. Both zoneB (2 pods < 3.33) and zoneC (2 pods < 3.33)
-			// appear in nodesByZoneBelowIdealAvg. zoneB's node (B1, 50m CPU) cannot fit a 100m-request
-			// pod, but zoneC's node (C1, 2000m CPU) can — so podFitsAnyNodeInSomeZone returns true
+			// appear in nodesByDomainBelowIdealAvg. zoneB's node (B1, 50m CPU) cannot fit a 100m-request
+			// pod, but zoneC's node (C1, 2000m CPU) can — so podFitsAnyNodeInSomeDomain returns true
 			// for every pod selected from zoneA. The topologyBalanceNodeFit gate (default true) also
 			// passes for the same reason (zoneC is in the merged nodesBelowIdealAvg flat list).
 			// balanceDomains selects ceil(6−3.33)=3 pods for eviction; all three pass both gates → 3 evicted.
@@ -1972,7 +1972,7 @@ func getDefaultTopologyConstraints(maxSkew int32, edits ...func(*v1.TopologySpre
 	return []v1.TopologySpreadConstraint{constraint}
 }
 
-func TestFilterNodesByZoneBelowIdealAvg(t *testing.T) {
+func TestFilterNodesByDomainBelowIdealAvg(t *testing.T) {
 	makeNode := func(name, zone string) *v1.Node {
 		return test.BuildTestNode(name, 1000, 2000, 10, func(n *v1.Node) {
 			n.Labels["zone"] = zone
@@ -1993,7 +1993,7 @@ func TestFilterNodesByZoneBelowIdealAvg(t *testing.T) {
 		}
 		idealAvg := 4.0
 
-		got := filterNodesByZoneBelowIdealAvg(nodes, sortedDomains, "zone", idealAvg)
+		got := filterNodesByDomainBelowIdealAvg(nodes, sortedDomains, "zone", idealAvg)
 
 		if _, ok := got["zoneA"]; ok {
 			t.Error("zoneA should not be in result: it is above idealAvg")
@@ -2014,7 +2014,7 @@ func TestFilterNodesByZoneBelowIdealAvg(t *testing.T) {
 		domains2 := []topology{
 			{pair: topologyPair{"zone", "zoneX"}, pods: make([]*v1.Pod, 4)}, // == idealAvg
 		}
-		got := filterNodesByZoneBelowIdealAvg(nodes2, domains2, "zone", 4.0)
+		got := filterNodesByDomainBelowIdealAvg(nodes2, domains2, "zone", 4.0)
 		if _, ok := got["zoneX"]; ok {
 			t.Error("zoneX should not be in result: pod count equals idealAvg (not strictly less)")
 		}
@@ -2026,14 +2026,14 @@ func TestFilterNodesByZoneBelowIdealAvg(t *testing.T) {
 		domains3 := []topology{
 			{pair: topologyPair{"zone", "zoneY"}, pods: make([]*v1.Pod, 1)}, // below idealAvg=4
 		}
-		got := filterNodesByZoneBelowIdealAvg(nodes3, domains3, "zone", 4.0)
+		got := filterNodesByDomainBelowIdealAvg(nodes3, domains3, "zone", 4.0)
 		if _, ok := got["zoneY"]; ok {
 			t.Error("zoneY should not appear in result: it has no eligible nodes")
 		}
 	})
 
 	t.Run("empty sortedDomains returns empty map", func(t *testing.T) {
-		got := filterNodesByZoneBelowIdealAvg([]*v1.Node{makeNode("N1", "zoneZ")}, []topology{}, "zone", 4.0)
+		got := filterNodesByDomainBelowIdealAvg([]*v1.Node{makeNode("N1", "zoneZ")}, []topology{}, "zone", 4.0)
 		if len(got) != 0 {
 			t.Errorf("expected empty map, got %v", got)
 		}

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1606,7 +1606,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				TopologyBalanceNodeFit: utilptr.To(false),
 				ZoneAwareNodeFit:       utilptr.To(true),
 			},
-			nodeFit: true,
+			nodeFit: false,
 		},
 	}
 

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1825,30 +1825,65 @@ func TestFilterNodesByZoneBelowIdealAvg(t *testing.T) {
 		})
 	}
 
-	nodes := []*v1.Node{
-		makeNode("A1", "zoneA"),
-		makeNode("A2", "zoneA"),
-		makeNode("B1", "zoneB"),
-		makeNode("C1", "zoneC"),
-	}
-	sortedDomains := []topology{
-		{pair: topologyPair{"zone", "zoneA"}, pods: make([]*v1.Pod, 8)}, // above avg
-		{pair: topologyPair{"zone", "zoneB"}, pods: make([]*v1.Pod, 2)}, // below avg
-		{pair: topologyPair{"zone", "zoneC"}, pods: make([]*v1.Pod, 2)}, // below avg
-	}
-	idealAvg := 4.0
+	t.Run("happy path - filters above-average zones", func(t *testing.T) {
+		nodes := []*v1.Node{
+			makeNode("A1", "zoneA"),
+			makeNode("A2", "zoneA"),
+			makeNode("B1", "zoneB"),
+			makeNode("C1", "zoneC"),
+		}
+		sortedDomains := []topology{
+			{pair: topologyPair{"zone", "zoneA"}, pods: make([]*v1.Pod, 8)}, // above avg
+			{pair: topologyPair{"zone", "zoneB"}, pods: make([]*v1.Pod, 2)}, // below avg
+			{pair: topologyPair{"zone", "zoneC"}, pods: make([]*v1.Pod, 2)}, // below avg
+		}
+		idealAvg := 4.0
 
-	got := filterNodesByZoneBelowIdealAvg(nodes, sortedDomains, "zone", idealAvg)
+		got := filterNodesByZoneBelowIdealAvg(nodes, sortedDomains, "zone", idealAvg)
 
-	if _, ok := got["zoneA"]; ok {
-		t.Error("zoneA should not be in result: it is above idealAvg")
-	}
-	if zoneB := got["zoneB"]; len(zoneB) != 1 || zoneB[0].Name != "B1" {
-		t.Errorf("zoneB: got %v, want [B1]", zoneB)
-	}
-	if zoneC := got["zoneC"]; len(zoneC) != 1 || zoneC[0].Name != "C1" {
-		t.Errorf("zoneC: got %v, want [C1]", zoneC)
-	}
+		if _, ok := got["zoneA"]; ok {
+			t.Error("zoneA should not be in result: it is above idealAvg")
+		}
+		if zoneB := got["zoneB"]; len(zoneB) != 1 || zoneB[0].Name != "B1" {
+			t.Errorf("zoneB: got %v, want [B1]", zoneB)
+		}
+		if zoneC := got["zoneC"]; len(zoneC) != 1 || zoneC[0].Name != "C1" {
+			t.Errorf("zoneC: got %v, want [C1]", zoneC)
+		}
+	})
+
+	t.Run("domain at exactly idealAvg is excluded", func(t *testing.T) {
+		// A zone at exactly idealAvg (not strictly less) must not appear.
+		nodes2 := []*v1.Node{
+			makeNode("X1", "zoneX"),
+		}
+		domains2 := []topology{
+			{pair: topologyPair{"zone", "zoneX"}, pods: make([]*v1.Pod, 4)}, // == idealAvg
+		}
+		got := filterNodesByZoneBelowIdealAvg(nodes2, domains2, "zone", 4.0)
+		if _, ok := got["zoneX"]; ok {
+			t.Error("zoneX should not be in result: pod count equals idealAvg (not strictly less)")
+		}
+	})
+
+	t.Run("below-average domain with no eligible nodes is not included in result", func(t *testing.T) {
+		// Zone is below average but has no nodes with the matching label.
+		nodes3 := []*v1.Node{} // no nodes
+		domains3 := []topology{
+			{pair: topologyPair{"zone", "zoneY"}, pods: make([]*v1.Pod, 1)}, // below idealAvg=4
+		}
+		got := filterNodesByZoneBelowIdealAvg(nodes3, domains3, "zone", 4.0)
+		if _, ok := got["zoneY"]; ok {
+			t.Error("zoneY should not appear in result: it has no eligible nodes")
+		}
+	})
+
+	t.Run("empty sortedDomains returns empty map", func(t *testing.T) {
+		got := filterNodesByZoneBelowIdealAvg([]*v1.Node{makeNode("N1", "zoneZ")}, []topology{}, "zone", 4.0)
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
 }
 
 func TestCheckIdenticalConstraints(t *testing.T) {

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1454,6 +1454,127 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			namespaces:           []string{"ns1"},
 			args:                 RemovePodsViolatingTopologySpreadConstraintArgs{},
 		},
+		// --- ZoneAwareNodeFit test cases ---
+		{
+			name: "ZoneAwareNodeFit=true, 2 domains [4,1], target zone has capacity, should evict 1",
+			nodes: []*v1.Node{
+				// zoneA is over-loaded (4 pods). zoneB is under-loaded (1 pod) and has plenty of CPU.
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("A2", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       4,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{
+					count:  1,
+					node:   "B1",
+					labels: map[string]string{"foo": "bar"},
+				},
+			}),
+			expectedEvictedCount: 1,
+			namespaces:           []string{"ns1"},
+			args: RemovePodsViolatingTopologySpreadConstraintArgs{
+				ZoneAwareNodeFit: utilptr.To(true),
+			},
+		},
+		{
+			name: "ZoneAwareNodeFit=true, 2 domains [4,1], all target zones at CPU capacity, should evict 0 (no churn)",
+			nodes: []*v1.Node{
+				// zoneA is over-loaded. zoneB is under-loaded by pod count BUT has only 50m CPU
+				// available — not enough for a 100m-request pod.
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("A2", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       4,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{
+					count:  1,
+					node:   "B1",
+					labels: map[string]string{"foo": "bar"},
+				},
+			}),
+			// Pod requests 100m CPU but zoneB node only has 50m → no eviction.
+			expectedEvictedCount: 0,
+			namespaces:           []string{"ns1"},
+			args: RemovePodsViolatingTopologySpreadConstraintArgs{
+				ZoneAwareNodeFit: utilptr.To(true),
+			},
+			nodeFit: true,
+		},
+		{
+			name: "ZoneAwareNodeFit=true, 3 domains [6,2,2], one under-loaded zone at capacity, other has room, should evict 3",
+			nodes: []*v1.Node{
+				// zoneA: over-loaded. zoneB: under-loaded, at CPU capacity. zoneC: under-loaded, has CPU.
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("C1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneC" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       6,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{
+					count:  2,
+					node:   "B1",
+					labels: map[string]string{"foo": "bar"},
+				},
+				{
+					count:  2,
+					node:   "C1",
+					labels: map[string]string{"foo": "bar"},
+				},
+			}),
+			// idealAvg = (6+2+2)/3 = 3.33. balanceDomains runs two passes: first evicts 2 pods
+			// from zoneA toward zoneB (zoneC qualifies, so the gate passes), then evicts 1 more
+			// from zoneA toward zoneC → 3 total. zoneB's 50m CPU means it cannot receive new
+			// pods, but zoneC's 2000m CPU satisfies ZoneAwareNodeFit so eviction proceeds.
+			expectedEvictedCount: 3,
+			namespaces:           []string{"ns1"},
+			args: RemovePodsViolatingTopologySpreadConstraintArgs{
+				ZoneAwareNodeFit: utilptr.To(true),
+			},
+			nodeFit: true,
+		},
+		{
+			name: "ZoneAwareNodeFit=false (default), 2 domains [4,1], target zone at CPU capacity, existing TopologyBalanceNodeFit still blocks eviction",
+			nodes: []*v1.Node{
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       4,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{
+					count:  1,
+					node:   "B1",
+					labels: map[string]string{"foo": "bar"},
+				},
+			}),
+			// ZoneAwareNodeFit is off, but TopologyBalanceNodeFit (default true) still prevents
+			// eviction when zoneB nodes can't fit the pod — existing behaviour is unchanged.
+			expectedEvictedCount: 0,
+			namespaces:           []string{"ns1"},
+			args:                 RemovePodsViolatingTopologySpreadConstraintArgs{},
+			nodeFit:              true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1552,8 +1552,9 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			// 3 domains, each under-loaded zone individually tight. Under the previous
 			// OR(merge) implementation, every candidate would see at least one node in some
 			// domain with per-node headroom — all candidates pass. The cumulative gate must
-			// commit pod 1 to zoneB (drains zoneB), then redirect to zoneC for 2 more pods
-			// (which drain zoneC), then reject pod 4 because BOTH domains are saturated.
+			// pick the roomiest domain first (zoneC, 250m), commit until it can no longer
+			// fit, then fall back to zoneB (150m), and reject any 4th candidate because
+			// both domains are saturated.
 			//
 			// zoneB: 250m allocatable - 100m used = 150m headroom → fits 1 × 100m pod
 			// zoneC: 350m allocatable - 100m used = 250m headroom → fits 2 × 100m pods
@@ -1572,10 +1573,11 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
 				{count: 1, node: "C1", labels: map[string]string{"foo": "bar"}},
 			}),
-			// Total batch headroom: 150 + 250 = 400m → fits 4 × 100m pods. balanceDomains
-			// would otherwise schedule 4 evictions across two iterations. The previous
-			// implementation would admit all 4; the new gate admits 3 (1 to zoneB, 2 to
-			// zoneC, the 4th rejected when both domains are drained).
+			// Total batch headroom: 150 + 250 = 400m → fits 3 × 100m pods plus 100m
+			// stranded across the two domains. The previous OR(merge) implementation
+			// would admit all 4 candidates; the new gate admits 3 (2 to zoneC, 1 to
+			// zoneB) and rejects the 4th when both domains are drained below the pod
+			// request.
 			expectedEvictedCount: 3,
 			namespaces:           []string{"ns1"},
 			args: RemovePodsViolatingTopologySpreadConstraintArgs{
@@ -2079,6 +2081,29 @@ func TestComputeDomainHeadroom(t *testing.T) {
 	}
 }
 
+func TestComputeDomainHeadroomFailsClosedOnIndexerError(t *testing.T) {
+	// If ListPodsOnANode fails for a node, that node must contribute zero — neither
+	// its allocatable nor any pod requests should land in the aggregate. Over-counting
+	// would re-introduce the eviction churn this gate prevents.
+	a1 := test.BuildTestNode("A1", 1000, 1<<30, 10, nil)
+	a2 := test.BuildTestNode("A2", 500, 1<<30, 10, nil)
+	indexer := podutil.GetPodsAssignedToNodeFunc(func(nodeName string, filter podutil.FilterFunc) ([]*v1.Pod, error) {
+		if nodeName == "A2" {
+			return nil, fmt.Errorf("simulated indexer failure")
+		}
+		return nil, nil
+	})
+
+	got := computeDomainHeadroom(map[string][]*v1.Node{"zoneA": {a1, a2}}, indexer)
+	// Only A1 (1000m, 10 pod slots) contributes; A2 is excluded fail-closed.
+	if cpu := got["zoneA"][v1.ResourceCPU]; cpu.MilliValue() != 1000 {
+		t.Errorf("aggregate CPU after fail-closed exclusion: got %dm, want 1000m", cpu.MilliValue())
+	}
+	if pods := got["zoneA"][v1.ResourcePods]; pods.Value() != 10 {
+		t.Errorf("aggregate pod slots after fail-closed exclusion: got %d, want 10", pods.Value())
+	}
+}
+
 func TestPodFitsSomeDomainWithHeadroom(t *testing.T) {
 	// Build a stub node indexer that reports the supplied pods as living on the named node.
 	makeIndexer := func(podsByNode map[string][]*v1.Pod) podutil.GetPodsAssignedToNodeFunc {
@@ -2093,7 +2118,43 @@ func TestPodFitsSomeDomainWithHeadroom(t *testing.T) {
 		})
 	}
 
-	t.Run("commits to alphabetically-first qualifying domain and decrements its headroom", func(t *testing.T) {
+	t.Run("commits to roomiest qualifying domain and decrements its headroom", func(t *testing.T) {
+		// zoneA has more CPU headroom than zoneB, so even though zoneB sorts first
+		// alphabetically, the candidate must commit to zoneA. This guards against
+		// regressing back to an alphabetical-first selection that would drain the
+		// tighter domain prematurely.
+		nodesByDomain := map[string][]*v1.Node{
+			"zoneB": {test.BuildTestNode("B1", 1000, 1<<30, 10, nil)},
+			"zoneA": {test.BuildTestNode("A1", 1000, 1<<30, 10, nil)},
+		}
+		headroom := map[string]v1.ResourceList{
+			"zoneA": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(800, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(1<<28, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(5, resource.DecimalSI),
+			},
+			"zoneB": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(1<<28, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(5, resource.DecimalSI),
+			},
+		}
+		pod := test.BuildTestPod("candidate", 100, 0, "other", nil)
+		indexer := makeIndexer(nil)
+
+		domain, ok := podFitsSomeDomainWithHeadroom(indexer, pod, nodesByDomain, headroom)
+		if !ok || domain != "zoneA" {
+			t.Fatalf("expected commit to roomiest domain zoneA, got domain=%q ok=%v", domain, ok)
+		}
+		if cpu := headroom["zoneA"][v1.ResourceCPU]; cpu.MilliValue() != 700 {
+			t.Errorf("zoneA CPU headroom after commit: got %dm, want 700m", cpu.MilliValue())
+		}
+		if cpu := headroom["zoneB"][v1.ResourceCPU]; cpu.MilliValue() != 300 {
+			t.Errorf("zoneB CPU headroom must be untouched: got %dm, want 300m", cpu.MilliValue())
+		}
+	})
+
+	t.Run("equal headroom falls back to alphabetical for determinism", func(t *testing.T) {
 		nodesByDomain := map[string][]*v1.Node{
 			"zoneB": {test.BuildTestNode("B1", 1000, 1<<30, 10, nil)},
 			"zoneA": {test.BuildTestNode("A1", 1000, 1<<30, 10, nil)},
@@ -2115,13 +2176,7 @@ func TestPodFitsSomeDomainWithHeadroom(t *testing.T) {
 
 		domain, ok := podFitsSomeDomainWithHeadroom(indexer, pod, nodesByDomain, headroom)
 		if !ok || domain != "zoneA" {
-			t.Fatalf("expected commit to zoneA, got domain=%q ok=%v", domain, ok)
-		}
-		if cpu := headroom["zoneA"][v1.ResourceCPU]; cpu.MilliValue() != 400 {
-			t.Errorf("zoneA CPU headroom after commit: got %dm, want 400m", cpu.MilliValue())
-		}
-		if cpu := headroom["zoneB"][v1.ResourceCPU]; cpu.MilliValue() != 500 {
-			t.Errorf("zoneB CPU headroom must be untouched: got %dm, want 500m", cpu.MilliValue())
+			t.Fatalf("expected alphabetical tie-break to commit to zoneA, got domain=%q ok=%v", domain, ok)
 		}
 	})
 

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -9,6 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -16,6 +17,7 @@ import (
 	utilptr "k8s.io/utils/ptr"
 
 	"sigs.k8s.io/descheduler/pkg/api"
+	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/defaultevictor"
 	frameworktesting "sigs.k8s.io/descheduler/pkg/framework/testing"
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
@@ -1455,150 +1457,117 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			args:                 RemovePodsViolatingTopologySpreadConstraintArgs{},
 		},
 		// --- ZoneAwareNodeFit test cases ---
+		// All five share the same topology: zoneA (over-loaded, 7 pods) vs zoneB (under-loaded,
+		// 1 pod). zoneB has just 250m CPU on a single node, of which 100m is already used by the
+		// existing pod — i.e. 150m of aggregate CPU headroom, enough for exactly one additional
+		// 100m-request pod. balanceDomains schedules 3 evictions toward zoneB.
+		//
+		// These cases isolate ZoneAwareNodeFit by disabling DefaultEvictor NodeFit and (where
+		// noted) TopologyBalanceNodeFit, so the only differentiator is the new gate.
 		{
-			name: "ZoneAwareNodeFit=true, 2 domains [4,1], target zone has capacity, should evict 1",
+			name: "ZoneAwareNodeFit=true alone caps evictions at zoneB's aggregate headroom (1 of 3)",
 			nodes: []*v1.Node{
-				// zoneA is over-loaded (4 pods). zoneB is under-loaded (1 pod) and has plenty of CPU.
 				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
-				test.BuildTestNode("A2", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
-				test.BuildTestNode("B1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B1", 250, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
 			},
 			pods: createTestPods([]testPodList{
 				{
-					count:       4,
+					count:       7,
 					node:        "A1",
 					labels:      map[string]string{"foo": "bar"},
 					constraints: getDefaultTopologyConstraints(1),
 				},
-				{
-					count:  1,
-					node:   "B1",
-					labels: map[string]string{"foo": "bar"},
-				},
+				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
 			}),
+			// zoneB headroom: 250m allocatable - 100m existing = 150m → fits exactly 1 more
+			// 100m-request pod. Pod 1 commits and decrements headroom to 50m. Pods 2 and 3 are
+			// rejected by the aggregate-headroom check (50m < 100m) even though per-node fit
+			// (live indexer view) still says B1 has room.
 			expectedEvictedCount: 1,
 			namespaces:           []string{"ns1"},
 			args: RemovePodsViolatingTopologySpreadConstraintArgs{
-				ZoneAwareNodeFit: utilptr.To(true),
+				TopologyBalanceNodeFit: utilptr.To(false),
+				ZoneAwareNodeFit:       utilptr.To(true),
 			},
-			nodeFit: true,
+			nodeFit: false,
 		},
 		{
-			name: "ZoneAwareNodeFit=true, 2 domains [4,1], all target zones at CPU capacity, should evict 0 (no churn)",
+			name: "TopologyBalanceNodeFit=true alone does NOT cap cumulative load (evicts 3)",
+			// Same topology and same cumulative-overflow condition as the previous case. This
+			// case shows the existing TopologyBalanceNodeFit gate cannot detect the over-commit
+			// because it evaluates each candidate pod against a stateless per-node fit check;
+			// all three candidates individually see B1 as having 150m headroom (the indexer is
+			// not mutated mid-loop), so all three pass and get evicted — the exact churn the
+			// new gate prevents.
 			nodes: []*v1.Node{
-				// zoneA is over-loaded. zoneB is under-loaded by pod count BUT has only 50m CPU
-				// available — not enough for a 100m-request pod.
 				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
-				test.BuildTestNode("A2", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
-				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B1", 250, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
 			},
 			pods: createTestPods([]testPodList{
 				{
-					count:       4,
+					count:       7,
 					node:        "A1",
 					labels:      map[string]string{"foo": "bar"},
 					constraints: getDefaultTopologyConstraints(1),
 				},
-				{
-					count:  1,
-					node:   "B1",
-					labels: map[string]string{"foo": "bar"},
-				},
+				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
 			}),
-			// Pod requests 100m CPU but zoneB node only has 50m → no eviction.
-			expectedEvictedCount: 0,
+			expectedEvictedCount: 3,
 			namespaces:           []string{"ns1"},
-			args: RemovePodsViolatingTopologySpreadConstraintArgs{
-				ZoneAwareNodeFit: utilptr.To(true),
-			},
-			nodeFit: true,
+			args:                 RemovePodsViolatingTopologySpreadConstraintArgs{}, // defaults: TBNF=true, ZANF=false
+			nodeFit:              false,
 		},
 		{
-			name: "ZoneAwareNodeFit=true, 3 domains [6,2,2], one under-loaded zone at capacity, other has room, should evict 3",
+			name: "ZoneAwareNodeFit redirects to a second under-loaded domain once the first is exhausted",
+			// 3 domains: zoneA over-loaded, zoneB tight headroom (150m → fits 1), zoneC plenty
+			// (1900m → fits many). balanceDomains runs two iterations of movePods=2: first
+			// targeting zoneB (pod 1 commits to zoneB; pod 2 redirects to zoneC after zoneB's
+			// headroom hits 50m), then targeting zoneC (pods 3 and 4 both commit to zoneC).
+			// All 4 candidates evict — the new gate spreads load across zones rather than
+			// stalling at the saturated one.
 			nodes: []*v1.Node{
-				// zoneA: over-loaded. zoneB: under-loaded, at CPU capacity. zoneC: under-loaded, has CPU.
 				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
-				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B1", 250, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
 				test.BuildTestNode("C1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneC" }),
 			},
 			pods: createTestPods([]testPodList{
 				{
-					count:       6,
+					count:       7,
 					node:        "A1",
 					labels:      map[string]string{"foo": "bar"},
 					constraints: getDefaultTopologyConstraints(1),
 				},
-				{
-					count:  2,
-					node:   "B1",
-					labels: map[string]string{"foo": "bar"},
-				},
-				{
-					count:  2,
-					node:   "C1",
-					labels: map[string]string{"foo": "bar"},
-				},
+				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
+				{count: 1, node: "C1", labels: map[string]string{"foo": "bar"}},
 			}),
-			// idealAvg = (6+2+2)/3 = 3.33. Both zoneB (2 pods < 3.33) and zoneC (2 pods < 3.33)
-			// appear in nodesByDomainBelowIdealAvg. zoneB's node (B1, 50m CPU) cannot fit a 100m-request
-			// pod, but zoneC's node (C1, 2000m CPU) can — so podFitsAnyNodeInSomeDomain returns true
-			// for every pod selected from zoneA. The topologyBalanceNodeFit gate (default true) also
-			// passes for the same reason (zoneC is in the merged nodesBelowIdealAvg flat list).
-			// balanceDomains selects ceil(6−3.33)=3 pods for eviction; all three pass both gates → 3 evicted.
-			expectedEvictedCount: 3,
+			expectedEvictedCount: 4,
 			namespaces:           []string{"ns1"},
 			args: RemovePodsViolatingTopologySpreadConstraintArgs{
-				ZoneAwareNodeFit: utilptr.To(true),
+				TopologyBalanceNodeFit: utilptr.To(false),
+				ZoneAwareNodeFit:       utilptr.To(true),
 			},
-			nodeFit: true,
+			nodeFit: false,
 		},
 		{
-			name: "ZoneAwareNodeFit omitted, nodeFit=true, target zone at CPU capacity, TopologyBalanceNodeFit=true (default) blocks eviction — backward compat",
+			name: "ZoneAwareNodeFit still requires per-node fit (aggregate headroom alone is insufficient)",
+			// zoneB has 5 nodes with 50m CPU each → 250m aggregate headroom (looks like 2 pods'
+			// worth), but no single node can host a 100m-request pod. The new gate must reject.
 			nodes: []*v1.Node{
 				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
 				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B2", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B3", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B4", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B5", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
 			},
 			pods: createTestPods([]testPodList{
 				{
-					count:       4,
+					count:       7,
 					node:        "A1",
 					labels:      map[string]string{"foo": "bar"},
 					constraints: getDefaultTopologyConstraints(1),
 				},
-				{
-					count:  1,
-					node:   "B1",
-					labels: map[string]string{"foo": "bar"},
-				},
-			}),
-			// ZoneAwareNodeFit is off, but TopologyBalanceNodeFit (default true) still prevents
-			// eviction when zoneB nodes can't fit the pod — existing behaviour is unchanged.
-			expectedEvictedCount: 0,
-			namespaces:           []string{"ns1"},
-			args:                 RemovePodsViolatingTopologySpreadConstraintArgs{},
-			nodeFit:              true,
-		},
-		{
-			// Isolated test: TopologyBalanceNodeFit=false disables the aggregate gate; ZoneAwareNodeFit=true
-			// re-enables the per-node fit check zone-by-zone. With zoneB at CPU capacity the zone-aware
-			// gate should block eviction even though TopologyBalanceNodeFit is off.
-			name: "ZoneAwareNodeFit=true, TopologyBalanceNodeFit=false, target zone at CPU capacity, should evict 0",
-			nodes: []*v1.Node{
-				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
-				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
-			},
-			pods: createTestPods([]testPodList{
-				{
-					count:       4,
-					node:        "A1",
-					labels:      map[string]string{"foo": "bar"},
-					constraints: getDefaultTopologyConstraints(1),
-				},
-				{
-					count:  1,
-					node:   "B1",
-					labels: map[string]string{"foo": "bar"},
-				},
+				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
 			}),
 			expectedEvictedCount: 0,
 			namespaces:           []string{"ns1"},
@@ -1607,6 +1576,29 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				ZoneAwareNodeFit:       utilptr.To(true),
 			},
 			nodeFit: false,
+		},
+		{
+			name: "ZoneAwareNodeFit default (false) is no-op — behaviour matches prior versions",
+			// Default args (TBNF=true, ZANF=false). With nodeFit=true on DefaultEvictor and
+			// zoneB unable to host more pods, eviction is blocked by the DefaultEvictor's own
+			// pre-filter — confirming the new flag introduces no behavioural change when off.
+			nodes: []*v1.Node{
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 50, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       4,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
+			}),
+			expectedEvictedCount: 0,
+			namespaces:           []string{"ns1"},
+			args:                 RemovePodsViolatingTopologySpreadConstraintArgs{},
+			nodeFit:              true,
 		},
 	}
 
@@ -1972,70 +1964,119 @@ func getDefaultTopologyConstraints(maxSkew int32, edits ...func(*v1.TopologySpre
 	return []v1.TopologySpreadConstraint{constraint}
 }
 
-func TestFilterNodesByDomainBelowIdealAvg(t *testing.T) {
-	makeNode := func(name, zone string) *v1.Node {
-		return test.BuildTestNode(name, 1000, 2000, 10, func(n *v1.Node) {
-			n.Labels["zone"] = zone
+func TestPodFitsSomeDomainWithHeadroom(t *testing.T) {
+	// Build a stub node indexer that reports the supplied pods as living on the named node.
+	makeIndexer := func(podsByNode map[string][]*v1.Pod) podutil.GetPodsAssignedToNodeFunc {
+		return podutil.GetPodsAssignedToNodeFunc(func(nodeName string, filter podutil.FilterFunc) ([]*v1.Pod, error) {
+			out := []*v1.Pod{}
+			for _, p := range podsByNode[nodeName] {
+				if filter == nil || filter(p) {
+					out = append(out, p)
+				}
+			}
+			return out, nil
 		})
 	}
 
-	t.Run("happy path - filters above-average zones", func(t *testing.T) {
-		nodes := []*v1.Node{
-			makeNode("A1", "zoneA"),
-			makeNode("A2", "zoneA"),
-			makeNode("B1", "zoneB"),
-			makeNode("C1", "zoneC"),
+	t.Run("commits to alphabetically-first qualifying domain and decrements its headroom", func(t *testing.T) {
+		nodesByDomain := map[string][]*v1.Node{
+			"zoneB": {test.BuildTestNode("B1", 1000, 1<<30, 10, nil)},
+			"zoneA": {test.BuildTestNode("A1", 1000, 1<<30, 10, nil)},
 		}
-		sortedDomains := []topology{
-			{pair: topologyPair{"zone", "zoneA"}, pods: make([]*v1.Pod, 8)}, // above avg
-			{pair: topologyPair{"zone", "zoneB"}, pods: make([]*v1.Pod, 2)}, // below avg
-			{pair: topologyPair{"zone", "zoneC"}, pods: make([]*v1.Pod, 2)}, // below avg
+		headroom := map[string]v1.ResourceList{
+			"zoneA": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(1<<28, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(5, resource.DecimalSI),
+			},
+			"zoneB": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(500, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(1<<28, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(5, resource.DecimalSI),
+			},
 		}
-		idealAvg := 4.0
+		pod := test.BuildTestPod("candidate", 100, 0, "other", nil)
+		indexer := makeIndexer(nil)
 
-		got := filterNodesByDomainBelowIdealAvg(nodes, sortedDomains, "zone", idealAvg)
-
-		if _, ok := got["zoneA"]; ok {
-			t.Error("zoneA should not be in result: it is above idealAvg")
+		domain, ok := podFitsSomeDomainWithHeadroom(indexer, pod, nodesByDomain, headroom)
+		if !ok || domain != "zoneA" {
+			t.Fatalf("expected commit to zoneA, got domain=%q ok=%v", domain, ok)
 		}
-		if zoneB := got["zoneB"]; len(zoneB) != 1 || zoneB[0].Name != "B1" {
-			t.Errorf("zoneB: got %v, want [B1]", zoneB)
+		if cpu := headroom["zoneA"][v1.ResourceCPU]; cpu.MilliValue() != 400 {
+			t.Errorf("zoneA CPU headroom after commit: got %dm, want 400m", cpu.MilliValue())
 		}
-		if zoneC := got["zoneC"]; len(zoneC) != 1 || zoneC[0].Name != "C1" {
-			t.Errorf("zoneC: got %v, want [C1]", zoneC)
+		if cpu := headroom["zoneB"][v1.ResourceCPU]; cpu.MilliValue() != 500 {
+			t.Errorf("zoneB CPU headroom must be untouched: got %dm, want 500m", cpu.MilliValue())
 		}
 	})
 
-	t.Run("domain at exactly idealAvg is excluded", func(t *testing.T) {
-		// A zone at exactly idealAvg (not strictly less) must not appear.
-		nodes2 := []*v1.Node{
-			makeNode("X1", "zoneX"),
+	t.Run("repeated calls drain headroom and then reject", func(t *testing.T) {
+		nodesByDomain := map[string][]*v1.Node{
+			"zoneA": {test.BuildTestNode("A1", 1000, 1<<30, 10, nil)},
 		}
-		domains2 := []topology{
-			{pair: topologyPair{"zone", "zoneX"}, pods: make([]*v1.Pod, 4)}, // == idealAvg
+		headroom := map[string]v1.ResourceList{
+			"zoneA": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(1<<28, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(5, resource.DecimalSI),
+			},
 		}
-		got := filterNodesByDomainBelowIdealAvg(nodes2, domains2, "zone", 4.0)
-		if _, ok := got["zoneX"]; ok {
-			t.Error("zoneX should not be in result: pod count equals idealAvg (not strictly less)")
+		indexer := makeIndexer(nil)
+		pod := test.BuildTestPod("p", 100, 0, "other", nil)
+
+		if _, ok := podFitsSomeDomainWithHeadroom(indexer, pod, nodesByDomain, headroom); !ok {
+			t.Fatal("first call: expected ok=true (250m >= 100m)")
+		}
+		if _, ok := podFitsSomeDomainWithHeadroom(indexer, pod, nodesByDomain, headroom); !ok {
+			t.Fatal("second call: expected ok=true (150m >= 100m)")
+		}
+		if _, ok := podFitsSomeDomainWithHeadroom(indexer, pod, nodesByDomain, headroom); ok {
+			t.Fatal("third call: expected ok=false (50m < 100m)")
 		}
 	})
 
-	t.Run("below-average domain with no eligible nodes is not included in result", func(t *testing.T) {
-		// Zone is below average but has no nodes with the matching label.
-		nodes3 := []*v1.Node{} // no nodes
-		domains3 := []topology{
-			{pair: topologyPair{"zone", "zoneY"}, pods: make([]*v1.Pod, 1)}, // below idealAvg=4
+	t.Run("returns false when no domain has aggregate headroom", func(t *testing.T) {
+		nodesByDomain := map[string][]*v1.Node{
+			"zoneA": {test.BuildTestNode("A1", 1000, 1<<30, 10, nil)},
 		}
-		got := filterNodesByDomainBelowIdealAvg(nodes3, domains3, "zone", 4.0)
-		if _, ok := got["zoneY"]; ok {
-			t.Error("zoneY should not appear in result: it has no eligible nodes")
+		headroom := map[string]v1.ResourceList{
+			"zoneA": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(50, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(1<<28, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(5, resource.DecimalSI),
+			},
+		}
+		pod := test.BuildTestPod("p", 100, 0, "other", nil)
+		if _, ok := podFitsSomeDomainWithHeadroom(makeIndexer(nil), pod, nodesByDomain, headroom); ok {
+			t.Error("expected ok=false when aggregate CPU is insufficient")
 		}
 	})
 
-	t.Run("empty sortedDomains returns empty map", func(t *testing.T) {
-		got := filterNodesByDomainBelowIdealAvg([]*v1.Node{makeNode("N1", "zoneZ")}, []topology{}, "zone", 4.0)
-		if len(got) != 0 {
-			t.Errorf("expected empty map, got %v", got)
+	t.Run("returns false when no domain node can host the pod (per-node fit fails)", func(t *testing.T) {
+		// Node has plenty of aggregate headroom by allocatable, but an existing pod on the
+		// node consumes most of it, leaving no per-node room. Aggregate headroom is supplied
+		// separately so only the per-node fit check (via fitsRequest) should reject.
+		smallNode := test.BuildTestNode("A1", 120, 1<<30, 10, nil)
+		nodesByDomain := map[string][]*v1.Node{"zoneA": {smallNode}}
+		headroom := map[string]v1.ResourceList{
+			"zoneA": {
+				v1.ResourceCPU:    *resource.NewMilliQuantity(10000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(1<<30, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(10, resource.DecimalSI),
+			},
+		}
+		occupant := test.BuildTestPod("occupant", 100, 0, "A1", nil)
+		indexer := makeIndexer(map[string][]*v1.Pod{"A1": {occupant}})
+		candidate := test.BuildTestPod("candidate", 100, 0, "other", nil)
+		if _, ok := podFitsSomeDomainWithHeadroom(indexer, candidate, nodesByDomain, headroom); ok {
+			t.Error("expected ok=false when no node has per-node room despite aggregate headroom")
+		}
+	})
+
+	t.Run("empty nodesByDomain returns false without error", func(t *testing.T) {
+		pod := test.BuildTestPod("p", 100, 0, "other", nil)
+		if _, ok := podFitsSomeDomainWithHeadroom(makeIndexer(nil), pod, map[string][]*v1.Node{}, map[string]v1.ResourceList{}); ok {
+			t.Error("expected ok=false on empty input")
 		}
 	})
 }

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1614,6 +1614,37 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			nodeFit: false,
 		},
 		{
+			name: "ZoneAwareNodeFit aggregates headroom across multiple nodes in the same below-ideal domain",
+			// Verifies grouping correctness when more than one node belongs to the same
+			// below-ideal domain. zoneB has two nodes (B1, B2) each with 200m allocatable
+			// and a 100m existing pod → 100m per-node headroom, 200m aggregate. A grouping
+			// bug that mis-bucketed nodes (e.g. counted only one B node) would yield
+			// expectedEvictedCount=1; correct multi-node aggregation yields 2 commits
+			// (cumulatively draining the domain) and a 3rd rejection.
+			nodes: []*v1.Node{
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 200, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+				test.BuildTestNode("B2", 200, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       9,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
+				{count: 1, node: "B2", labels: map[string]string{"foo": "bar"}},
+			}),
+			expectedEvictedCount: 2,
+			namespaces:           []string{"ns1"},
+			args: RemovePodsViolatingTopologySpreadConstraintArgs{
+				TopologyBalanceNodeFit: utilptr.To(false),
+				ZoneAwareNodeFit:       utilptr.To(true),
+			},
+			nodeFit: false,
+		},
+		{
 			name: "ZoneAwareNodeFit default (false) is no-op — behaviour matches prior versions",
 			// Default args (TBNF=true, ZANF=false). With nodeFit=true on DefaultEvictor and
 			// zoneB unable to host more pods, eviction is blocked by the DefaultEvictor's own

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/topologyspreadconstraint_test.go
@@ -1465,6 +1465,36 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		// These cases isolate ZoneAwareNodeFit by disabling DefaultEvictor NodeFit and (where
 		// noted) TopologyBalanceNodeFit, so the only differentiator is the new gate.
 		{
+			name: "ZoneAwareNodeFit caps cumulative load on top of TopologyBalanceNodeFit (1 of 3)",
+			// Critical regression: with the previous OR(merge) implementation of
+			// ZoneAwareNodeFit, this case would evict 3 (the stateless per-node-fit check
+			// passes for every candidate because the live indexer reports B1 at 150m
+			// throughout the loop). The cumulative-headroom gate must reduce this to 1,
+			// even when TopologyBalanceNodeFit is also enabled. This proves ZoneAwareNodeFit
+			// adds value over the existing flag — not just as a renamed alias.
+			nodes: []*v1.Node{
+				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
+				test.BuildTestNode("B1", 250, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
+			},
+			pods: createTestPods([]testPodList{
+				{
+					count:       7,
+					node:        "A1",
+					labels:      map[string]string{"foo": "bar"},
+					constraints: getDefaultTopologyConstraints(1),
+				},
+				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
+			}),
+			expectedEvictedCount: 1,
+			namespaces:           []string{"ns1"},
+			args: RemovePodsViolatingTopologySpreadConstraintArgs{
+				// TopologyBalanceNodeFit default-on; ZoneAwareNodeFit on. The new gate
+				// must still cap evictions at zoneB's 150m headroom.
+				ZoneAwareNodeFit: utilptr.To(true),
+			},
+			nodeFit: false,
+		},
+		{
 			name: "ZoneAwareNodeFit=true alone caps evictions at zoneB's aggregate headroom (1 of 3)",
 			nodes: []*v1.Node{
 				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
@@ -1518,17 +1548,19 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			nodeFit:              false,
 		},
 		{
-			name: "ZoneAwareNodeFit redirects to a second under-loaded domain once the first is exhausted",
-			// 3 domains: zoneA over-loaded, zoneB tight headroom (150m → fits 1), zoneC plenty
-			// (1900m → fits many). balanceDomains runs two iterations of movePods=2: first
-			// targeting zoneB (pod 1 commits to zoneB; pod 2 redirects to zoneC after zoneB's
-			// headroom hits 50m), then targeting zoneC (pods 3 and 4 both commit to zoneC).
-			// All 4 candidates evict — the new gate spreads load across zones rather than
-			// stalling at the saturated one.
+			name: "ZoneAwareNodeFit drains domain by domain and caps total at sum of headroom",
+			// 3 domains, each under-loaded zone individually tight. Under the previous
+			// OR(merge) implementation, every candidate would see at least one node in some
+			// domain with per-node headroom — all candidates pass. The cumulative gate must
+			// commit pod 1 to zoneB (drains zoneB), then redirect to zoneC for 2 more pods
+			// (which drain zoneC), then reject pod 4 because BOTH domains are saturated.
+			//
+			// zoneB: 250m allocatable - 100m used = 150m headroom → fits 1 × 100m pod
+			// zoneC: 350m allocatable - 100m used = 250m headroom → fits 2 × 100m pods
 			nodes: []*v1.Node{
 				test.BuildTestNode("A1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneA" }),
 				test.BuildTestNode("B1", 250, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneB" }),
-				test.BuildTestNode("C1", 2000, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneC" }),
+				test.BuildTestNode("C1", 350, 3000, 10, func(n *v1.Node) { n.Labels["zone"] = "zoneC" }),
 			},
 			pods: createTestPods([]testPodList{
 				{
@@ -1540,7 +1572,11 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				{count: 1, node: "B1", labels: map[string]string{"foo": "bar"}},
 				{count: 1, node: "C1", labels: map[string]string{"foo": "bar"}},
 			}),
-			expectedEvictedCount: 4,
+			// Total batch headroom: 150 + 250 = 400m → fits 4 × 100m pods. balanceDomains
+			// would otherwise schedule 4 evictions across two iterations. The previous
+			// implementation would admit all 4; the new gate admits 3 (1 to zoneB, 2 to
+			// zoneC, the 4th rejected when both domains are drained).
+			expectedEvictedCount: 3,
 			namespaces:           []string{"ns1"},
 			args: RemovePodsViolatingTopologySpreadConstraintArgs{
 				TopologyBalanceNodeFit: utilptr.To(false),
@@ -1962,6 +1998,54 @@ func getDefaultTopologyConstraints(maxSkew int32, edits ...func(*v1.TopologySpre
 	}
 
 	return []v1.TopologySpreadConstraint{constraint}
+}
+
+func TestGroupNodesByDomain(t *testing.T) {
+	mkNode := func(name, zone string) *v1.Node {
+		return test.BuildTestNode(name, 1000, 1<<30, 10, func(n *v1.Node) {
+			if zone != "" {
+				n.Labels["zone"] = zone
+			}
+		})
+	}
+	nodes := []*v1.Node{
+		mkNode("A1", "zoneA"),
+		mkNode("A2", "zoneA"),
+		mkNode("B1", "zoneB"),
+		mkNode("X1", ""), // missing label
+	}
+	got := groupNodesByDomain(nodes, "zone")
+	if len(got["zoneA"]) != 2 {
+		t.Errorf("zoneA: got %d nodes, want 2", len(got["zoneA"]))
+	}
+	if len(got["zoneB"]) != 1 {
+		t.Errorf("zoneB: got %d nodes, want 1", len(got["zoneB"]))
+	}
+	if _, ok := got[""]; ok {
+		t.Error("nodes missing the topology key must not produce an empty-string entry")
+	}
+}
+
+func TestComputeDomainHeadroom(t *testing.T) {
+	// zoneA has two nodes: A1 (1000m cpu, no pods), A2 (500m cpu, one 200m pod).
+	// Expected aggregate headroom: (1000 - 0) + (500 - 200) = 1300m. Pod slots: 10 + 10 - 1 = 19.
+	a1 := test.BuildTestNode("A1", 1000, 1<<30, 10, nil)
+	a2 := test.BuildTestNode("A2", 500, 1<<30, 10, nil)
+	occupant := test.BuildTestPod("occ", 200, 0, "A2", nil)
+	indexer := podutil.GetPodsAssignedToNodeFunc(func(nodeName string, filter podutil.FilterFunc) ([]*v1.Pod, error) {
+		if nodeName == "A2" {
+			return []*v1.Pod{occupant}, nil
+		}
+		return nil, nil
+	})
+
+	got := computeDomainHeadroom(map[string][]*v1.Node{"zoneA": {a1, a2}}, indexer)
+	if cpu := got["zoneA"][v1.ResourceCPU]; cpu.MilliValue() != 1300 {
+		t.Errorf("aggregate CPU: got %dm, want 1300m", cpu.MilliValue())
+	}
+	if pods := got["zoneA"][v1.ResourcePods]; pods.Value() != 19 {
+		t.Errorf("aggregate pod slots: got %d, want 19", pods.Value())
+	}
 }
 
 func TestPodFitsSomeDomainWithHeadroom(t *testing.T) {

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
@@ -33,10 +33,11 @@ type RemovePodsViolatingTopologySpreadConstraintArgs struct {
 	LabelSelector          *metav1.LabelSelector              `json:"labelSelector,omitempty"`
 	Constraints            []v1.UnsatisfiableConstraintAction `json:"constraints,omitempty"`
 	TopologyBalanceNodeFit *bool                              `json:"topologyBalanceNodeFit,omitempty"`
-	// ZoneAwareNodeFit, if set to true, gates eviction on per-zone capacity:
-	// a pod is only evicted from an over-loaded zone if at least one specific
-	// under-loaded zone (as identified by the constraint's TopologyKey) has
-	// sufficient resource capacity to schedule the pod. Defaults to false.
+	// ZoneAwareNodeFit, if set to true, gates eviction on per-topology-domain
+	// capacity: a pod is only evicted from an over-loaded topology domain
+	// (for example, a zone) if at least one specific under-loaded topology
+	// domain, as identified by the constraint's TopologyKey, has sufficient
+	// resource capacity to schedule the pod. Defaults to false.
 	// Works independently from TopologyBalanceNodeFit.
 	ZoneAwareNodeFit *bool `json:"zoneAwareNodeFit,omitempty"`
 }

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
@@ -33,4 +33,10 @@ type RemovePodsViolatingTopologySpreadConstraintArgs struct {
 	LabelSelector          *metav1.LabelSelector              `json:"labelSelector,omitempty"`
 	Constraints            []v1.UnsatisfiableConstraintAction `json:"constraints,omitempty"`
 	TopologyBalanceNodeFit *bool                              `json:"topologyBalanceNodeFit,omitempty"`
+	// ZoneAwareNodeFit, if set to true, gates eviction on per-zone capacity:
+	// a pod is only evicted from an over-loaded zone if at least one specific
+	// under-loaded zone (as identified by the constraint's TopologyKey) has
+	// sufficient resource capacity to schedule the pod. Defaults to false.
+	// Works independently from TopologyBalanceNodeFit.
+	ZoneAwareNodeFit *bool `json:"zoneAwareNodeFit,omitempty"`
 }

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/types.go
@@ -33,11 +33,19 @@ type RemovePodsViolatingTopologySpreadConstraintArgs struct {
 	LabelSelector          *metav1.LabelSelector              `json:"labelSelector,omitempty"`
 	Constraints            []v1.UnsatisfiableConstraintAction `json:"constraints,omitempty"`
 	TopologyBalanceNodeFit *bool                              `json:"topologyBalanceNodeFit,omitempty"`
-	// ZoneAwareNodeFit, if set to true, gates eviction on per-topology-domain
-	// capacity: a pod is only evicted from an over-loaded topology domain
-	// (for example, a zone) if at least one specific under-loaded topology
-	// domain, as identified by the constraint's TopologyKey, has sufficient
-	// resource capacity to schedule the pod. Defaults to false.
-	// Works independently from TopologyBalanceNodeFit.
+	// ZoneAwareNodeFit, if set to true, requires that each pod evicted by
+	// topology-spread balancing have, in at least one specific under-loaded
+	// topology domain (as identified by the constraint's TopologyKey),
+	// (a) a node where the pod fits per the scheduler's per-node predicates
+	// AND (b) sufficient remaining aggregate resource headroom — after
+	// accounting for other pods already committed to that domain during
+	// the same balancing round — to absorb the pod.
+	//
+	// Unlike TopologyBalanceNodeFit, which only checks per-node fit across
+	// the union of under-loaded domains, ZoneAwareNodeFit reasons about
+	// per-domain cumulative capacity. This prevents over-committing a single
+	// under-loaded domain within one balancing round, which would otherwise
+	// cause the scheduler to push evicted pods back to the over-loaded
+	// domain (eviction churn). Defaults to false.
 	ZoneAwareNodeFit *bool `json:"zoneAwareNodeFit,omitempty"`
 }

--- a/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/zz_generated.deepcopy.go
+++ b/pkg/framework/plugins/removepodsviolatingtopologyspreadconstraint/zz_generated.deepcopy.go
@@ -52,6 +52,11 @@ func (in *RemovePodsViolatingTopologySpreadConstraintArgs) DeepCopyInto(out *Rem
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ZoneAwareNodeFit != nil {
+		in, out := &in.ZoneAwareNodeFit, &out.ZoneAwareNodeFit
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
## Summary

- Adds `zoneAwareNodeFit` (opt-in, default `false`) to `RemovePodsViolatingTopologySpreadConstraintArgs`
- When enabled, eviction is gated on **cumulative per-topology-domain capacity**: each commit drains the target domain's remaining headroom so later candidates in the same balancing batch see the drained state
- This is behaviourally distinct from `topologyBalanceNodeFit`, which is a stateless per-node fit check — multiple candidates can all individually look like they fit on the same target node, leading to overcommit churn
- Both flags compose; either can be disabled independently

## Motivation

Upstream issues kubernetes-sigs/descheduler#1534 and kubernetes-sigs/descheduler#1067 describe eviction churn where the existing stateless gate admits more candidates than the target domain can actually absorb. This PR adds a stateful per-domain capacity gate as a non-breaking, opt-in flag.

Full design rationale, sequence diagram contrasting the two flags, and alternatives considered: [`docs/proposals/zone-aware-nodefit.md`](docs/proposals/zone-aware-nodefit.md)

## Changes

| File | Change |
|---|---|
| `types.go` | Add `ZoneAwareNodeFit *bool` field |
| `defaults.go` | Default `ZoneAwareNodeFit` to `false` |
| `zz_generated.deepcopy.go` | Deepcopy for new field |
| `topologyspreadconstraint.go` | `groupNodesByDomain`, `computeDomainHeadroom`, `podFitsSomeDomainWithHeadroom`, `headroomCoversPod`, `subtractPodFromHeadroom`, and the cumulative-headroom integration in `balanceDomains` |
| `topologyspreadconstraint_test.go` | New `TestTopologySpreadConstraint` cases for cumulative-overflow, baseline contrast, multi-domain redirection, per-node-fit still required, multi-node-per-domain aggregation, and default-off regression; plus `TestGroupNodesByDomain`, `TestComputeDomainHeadroom`, `TestPodFitsSomeDomainWithHeadroom` unit tests |
| `docs/proposals/zone-aware-nodefit.md` | RFC / design doc |
| `README.md` | User-facing documentation |
| `hack/lib/go.sh`, `Makefile` | **Tooling, unrelated to the feature** — added go1.26 to the supported version regex and bumped `golangci-lint` to v2.12.2 (built with go1.26.2) via `go install`. Required to make `pull-descheduler-verify-master` green after the prow runner upgraded to go1.26 mid-2026-05-18; the same Makefile changes are queued in #1874. Happy to split out if preferred. |

## Test Plan

- [x] `ZoneAwareNodeFit=true` + `TopologyBalanceNodeFit=true`: cumulative gate caps evictions even when stateless check would admit more (gap-catching: would have evicted 3 under prior `OR(merge)` design; now evicts 1)
- [x] `ZoneAwareNodeFit=true` alone: aggregate-headroom drain admits exactly one eviction per fitting domain (gap-catching)
- [x] `TopologyBalanceNodeFit=true` alone: baseline that does NOT cap cumulative load (contrast case — evicts 3)
- [x] Multi-domain redirection: pod 1 → zoneB, pods 2-3 → zoneC after zoneB drained, pod 4 rejected when all domains saturated
- [x] Aggregate headroom alone is insufficient — per-node fit still required (5 small nodes summing to enough CPU; no single node fits → no eviction)
- [x] Multi-node-per-domain aggregation: two nodes in the same below-ideal domain contribute additively to headroom (asserts grouping correctness beyond label-based bucketing of a single element)
- [x] `ZoneAwareNodeFit=false` (default): existing `TopologyBalanceNodeFit` behaviour unchanged
- [x] `TestGroupNodesByDomain` unit test: label-based classification, multi-node grouping, missing-label skip
- [x] `TestComputeDomainHeadroom` unit test: allocatable-minus-requested aggregation across nodes
- [x] `TestPodFitsSomeDomainWithHeadroom` unit test: deterministic domain ordering, headroom drain, per-node-fit rejection, aggregate-headroom rejection

