### PR TITLE
test/e2e: migrate TestDeschedulingInterval to run descheduler as an image

### DIFF
--- a/test/e2e/e2e_deschedulinginterval_test.go
+++ b/test/e2e/e2e_deschedulinginterval_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientset "k8s.io/client-go/kubernetes"
+	componentbaseconfig "k8s.io/component-base/config"
+
+	apiv1alpha2 "sigs.k8s.io/descheduler/pkg/api/v1alpha2"
+	"sigs.k8s.io/descheduler/pkg/descheduler/client"
+)
+
+// TestDeschedulingInterval verifies that with `--descheduling-interval` set to
+// 0 (the default), the descheduler binary runs a single pass and then exits
+// cleanly.
+func TestDeschedulingInterval(t *testing.T) {
+	ctx := context.Background()
+
+	clientSet, err := client.CreateClient(componentbaseconfig.ClientConnectionConfiguration{Kubeconfig: os.Getenv("KUBECONFIG")}, "")
+	if err != nil {
+		t.Fatalf("Error during kubernetes client creation with %v", err)
+	}
+
+	deschedulerPolicyConfigMapObj, err := deschedulerPolicyConfigMap(&apiv1alpha2.DeschedulerPolicy{})
+	if err != nil {
+		t.Fatalf("Error building descheduler policy configmap: %v", err)
+	}
+
+	t.Logf("Creating %q policy CM ...", deschedulerPolicyConfigMapObj.Name)
+	if _, err := clientSet.CoreV1().ConfigMaps(deschedulerPolicyConfigMapObj.Namespace).Create(ctx, deschedulerPolicyConfigMapObj, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating %q CM: %v", deschedulerPolicyConfigMapObj.Name, err)
+	}
+	defer func() {
+		t.Logf("Deleting %q CM...", deschedulerPolicyConfigMapObj.Name)
+		if err := clientSet.CoreV1().ConfigMaps(deschedulerPolicyConfigMapObj.Namespace).Delete(ctx, deschedulerPolicyConfigMapObj.Name, metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("Unable to delete %q CM: %v", deschedulerPolicyConfigMapObj.Name, err)
+		}
+	}()
+
+	job := deschedulerRunOnceJob("descheduling-interval")
+	jobClient := clientSet.BatchV1().Jobs(job.Namespace)
+
+	t.Logf("Creating a run-once descheduler job %q", job.Name)
+	if _, err := jobClient.Create(ctx, job, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Error creating descheduler job %q: %v", job.Name, err)
+	}
+	defer func() {
+		printJobPodLogs(ctx, t, clientSet, job)
+		t.Logf("Deleting descheduler job %q...", job.Name)
+		deletePropagationPolicy := metav1.DeletePropagationForeground
+		if err := jobClient.Delete(ctx, job.Name, metav1.DeleteOptions{PropagationPolicy: &deletePropagationPolicy}); err != nil {
+			t.Fatalf("Unable to delete descheduler job %q: %v", job.Name, err)
+		}
+	}()
+
+	t.Logf("Waiting for descheduler job %q to complete", job.Name)
+	if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 3*time.Minute, true, func(ctx context.Context) (bool, error) {
+		current, err := jobClient.Get(ctx, job.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, condition := range current.Status.Conditions {
+			if condition.Status != v1.ConditionTrue {
+				continue
+			}
+			switch condition.Type {
+			case batchv1.JobComplete:
+				return true, nil
+			case batchv1.JobFailed:
+				return false, fmt.Errorf("job %q failed: %v: %v", job.Name, condition.Reason, condition.Message)
+			}
+		}
+		t.Logf("Job %q has not completed yet, waiting...", job.Name)
+		return false, nil
+	}); err != nil {
+		t.Errorf("Descheduler job did not run-once-and-exit within timeout: %v", err)
+	}
+}
+
+// deschedulerRunOnceJob builds a Job that runs the descheduler image once and
+// exits. The liveness probe is dropped since a run-once descheduler can exit
+// before the first probe fires.
+func deschedulerRunOnceJob(testName string) *batchv1.Job {
+	podSpec := deschedulerPodSpec("0")
+	podSpec.RestartPolicy = v1.RestartPolicyNever
+	podSpec.Containers[0].LivenessProbe = nil
+
+	labelsSet := map[string]string{"app": "descheduler", "test": testName}
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "descheduler-run-once-" + testName,
+			Namespace: "kube-system",
+			Labels:    labelsSet,
+		},
+		Spec: batchv1.JobSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labelsSet,
+				},
+				Spec: podSpec,
+			},
+		},
+	}
+}
+
+// printJobPodLogs prints the logs of every pod created for the given job.
+func printJobPodLogs(ctx context.Context, t *testing.T, clientSet clientset.Interface, job *batchv1.Job) {
+	podList, err := clientSet.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.FormatLabels(job.Labels)})
+	if err != nil {
+		t.Logf("Unable to list pods of job %q: %v", job.Name, err)
+		return
+	}
+	for _, pod := range podList.Items {
+		printPodLogs(ctx, t, clientSet, pod.Name)
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -46,10 +46,8 @@ import (
 	utilptr "k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
-	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	deschedulerapi "sigs.k8s.io/descheduler/pkg/api"
 	deschedulerapiv1alpha2 "sigs.k8s.io/descheduler/pkg/api/v1alpha2"
-	"sigs.k8s.io/descheduler/pkg/descheduler"
 	"sigs.k8s.io/descheduler/pkg/descheduler/client"
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	eutils "sigs.k8s.io/descheduler/pkg/descheduler/evictions/utils"
@@ -112,8 +110,88 @@ func deschedulerPolicyConfigMap(policy *deschedulerapiv1alpha2.DeschedulerPolicy
 	return cm, nil
 }
 
+// deschedulerPodSpec returns the pod spec used to run the descheduler image
+// inside the cluster, with the given `--descheduling-interval` value.
+func deschedulerPodSpec(deschedulingInterval string) v1.PodSpec {
+	podSpec := v1.PodSpec{
+		PriorityClassName:  "system-cluster-critical",
+		ServiceAccountName: "descheduler-sa",
+		SecurityContext: &v1.PodSecurityContext{
+			RunAsNonRoot: utilptr.To(true),
+			SeccompProfile: &v1.SeccompProfile{
+				Type: v1.SeccompProfileTypeRuntimeDefault,
+			},
+		},
+		Containers: []v1.Container{
+			{
+				Name:            "descheduler",
+				Image:           *deschedulerImage,
+				ImagePullPolicy: "IfNotPresent",
+				Command:         []string{"/bin/descheduler"},
+				Args:            []string{"--policy-config-file", "/policy-dir/policy.yaml", "--descheduling-interval", deschedulingInterval, "--v", "4"},
+				Ports:           []v1.ContainerPort{{ContainerPort: 10258, Protocol: "TCP"}},
+				LivenessProbe: &v1.Probe{
+					FailureThreshold: 3,
+					ProbeHandler: v1.ProbeHandler{
+						HTTPGet: &v1.HTTPGetAction{
+							Path:   "/healthz",
+							Port:   intstr.FromInt(10258),
+							Scheme: v1.URISchemeHTTPS,
+						},
+					},
+					InitialDelaySeconds: 3,
+					PeriodSeconds:       10,
+				},
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("500m"),
+						v1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+				SecurityContext: &v1.SecurityContext{
+					AllowPrivilegeEscalation: utilptr.To(false),
+					Capabilities: &v1.Capabilities{
+						Drop: []v1.Capability{
+							"ALL",
+						},
+					},
+					Privileged:             utilptr.To[bool](false),
+					ReadOnlyRootFilesystem: utilptr.To[bool](true),
+					RunAsNonRoot:           utilptr.To[bool](true),
+				},
+				VolumeMounts: []v1.VolumeMount{
+					{
+						MountPath: "/policy-dir",
+						Name:      "policy-volume",
+					},
+				},
+			},
+		},
+		Volumes: []v1.Volume{
+			{
+				Name: "policy-volume",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "descheduler-policy-configmap",
+						},
+					},
+				},
+			},
+		},
+	}
+	if *podRunAsUserId != 0 {
+		podSpec.SecurityContext.RunAsUser = podRunAsUserId
+	}
+	if *podRunAsGroupId != 0 {
+		podSpec.SecurityContext.RunAsGroup = podRunAsGroupId
+	}
+
+	return podSpec
+}
+
 func deschedulerDeployment(testName string) *appsv1.Deployment {
-	deploymentObject := &appsv1.Deployment{
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "descheduler",
 			Namespace: "kube-system",
@@ -128,84 +206,10 @@ func deschedulerDeployment(testName string) *appsv1.Deployment {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": "descheduler", "test": testName},
 				},
-				Spec: v1.PodSpec{
-					PriorityClassName:  "system-cluster-critical",
-					ServiceAccountName: "descheduler-sa",
-					SecurityContext: &v1.PodSecurityContext{
-						RunAsNonRoot: utilptr.To(true),
-						SeccompProfile: &v1.SeccompProfile{
-							Type: v1.SeccompProfileTypeRuntimeDefault,
-						},
-					},
-					Containers: []v1.Container{
-						{
-							Name:            "descheduler",
-							Image:           *deschedulerImage,
-							ImagePullPolicy: "IfNotPresent",
-							Command:         []string{"/bin/descheduler"},
-							Args:            []string{"--policy-config-file", "/policy-dir/policy.yaml", "--descheduling-interval", "100m", "--v", "4"},
-							Ports:           []v1.ContainerPort{{ContainerPort: 10258, Protocol: "TCP"}},
-							LivenessProbe: &v1.Probe{
-								FailureThreshold: 3,
-								ProbeHandler: v1.ProbeHandler{
-									HTTPGet: &v1.HTTPGetAction{
-										Path:   "/healthz",
-										Port:   intstr.FromInt(10258),
-										Scheme: v1.URISchemeHTTPS,
-									},
-								},
-								InitialDelaySeconds: 3,
-								PeriodSeconds:       10,
-							},
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("500m"),
-									v1.ResourceMemory: resource.MustParse("256Mi"),
-								},
-							},
-							SecurityContext: &v1.SecurityContext{
-								AllowPrivilegeEscalation: utilptr.To(false),
-								Capabilities: &v1.Capabilities{
-									Drop: []v1.Capability{
-										"ALL",
-									},
-								},
-								Privileged:             utilptr.To[bool](false),
-								ReadOnlyRootFilesystem: utilptr.To[bool](true),
-								RunAsNonRoot:           utilptr.To[bool](true),
-							},
-							VolumeMounts: []v1.VolumeMount{
-								{
-									MountPath: "/policy-dir",
-									Name:      "policy-volume",
-								},
-							},
-						},
-					},
-					Volumes: []v1.Volume{
-						{
-							Name: "policy-volume",
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: "descheduler-policy-configmap",
-									},
-								},
-							},
-						},
-					},
-				},
+				Spec: deschedulerPodSpec("100m"),
 			},
 		},
 	}
-	if *podRunAsUserId != 0 {
-		deploymentObject.Spec.Template.Spec.SecurityContext.RunAsUser = podRunAsUserId
-	}
-	if *podRunAsGroupId != 0 {
-		deploymentObject.Spec.Template.Spec.SecurityContext.RunAsGroup = podRunAsGroupId
-	}
-
-	return deploymentObject
 }
 
 func printPodLogs(ctx context.Context, t *testing.T, kubeClient clientset.Interface, podName string) {
@@ -1389,43 +1393,6 @@ func TestPodLifeTimeOldestEvicted(t *testing.T) {
 		if pod.GetName() == oldestPod.GetName() {
 			t.Errorf("The oldest Pod %s was not evicted", oldestPod.GetName())
 		}
-	}
-}
-
-func TestDeschedulingInterval(t *testing.T) {
-	ctx := context.Background()
-	clientSet, err := client.CreateClient(componentbaseconfig.ClientConnectionConfiguration{Kubeconfig: os.Getenv("KUBECONFIG")}, "")
-	if err != nil {
-		t.Errorf("Error during client creation with %v", err)
-	}
-
-	// By default, the DeschedulingInterval param should be set to 0, meaning Descheduler only runs once then exits
-	s, err := options.NewDeschedulerServer()
-	if err != nil {
-		t.Fatalf("Unable to initialize server: %v", err)
-	}
-	s.Client = clientSet
-	s.DefaultFeatureGates = initFeatureGates()
-
-	deschedulerPolicy := &deschedulerapi.DeschedulerPolicy{}
-
-	c := make(chan bool, 1)
-	go func() {
-		evictionPolicyGroupVersion, err := eutils.SupportEviction(s.Client)
-		if err != nil || len(evictionPolicyGroupVersion) == 0 {
-			t.Errorf("Error when checking support for eviction: %v", err)
-		}
-		if err := descheduler.RunDeschedulerStrategies(ctx, s, deschedulerPolicy, evictionPolicyGroupVersion); err != nil {
-			t.Errorf("Error running descheduler strategies: %+v", err)
-		}
-		c <- true
-	}()
-
-	select {
-	case <-c:
-		// successfully returned
-	case <-time.After(3 * time.Minute):
-		t.Errorf("descheduler.Run timed out even without descheduling-interval set")
 	}
 }
 


### PR DESCRIPTION
## Summary

Per #1478, the e2e suite is being moved off in-process descheduler runs and onto deployments of the descheduler image so the tests exercise the real shipped artifact. \`TestDeschedulingInterval\` was one of the two remaining cases (along with \`TestClientConnectionConfiguration\`).

## What this changes

\`TestDeschedulingInterval\` verifies the run-once-and-exit lifecycle when no \`--descheduling-interval\` is set. The previous version called \`descheduler.RunDeschedulerStrategies\` directly, which doesn't reflect the production code path. The new version:

- Builds a one-shot Pod (\`restartPolicy=Never\`, no \`--descheduling-interval\` flag, no liveness probe — irrelevant for a one-shot run) via a new \`newDeschedulerOneShotPod\` helper.
- Mounts an empty \`DeschedulerPolicy\` ConfigMap (we're testing the lifecycle, not any specific descheduling decision).
- Asserts the Pod reaches \`Succeeded\` phase within 3 minutes — which is what \`pkg/descheduler/descheduler.go:546\` (\`if rs.DeschedulingInterval.Seconds() == 0 { cancel() }\`) guarantees.

The helper derives the Pod from the existing \`deschedulerDeployment\` template so the container image, security context, volume mounts, and SA stay in lock-step with the long-running tests.

## Removed

The old in-process \`TestDeschedulingInterval\` in \`test/e2e/e2e_test.go\` and the now-unused \`options\` and \`pkg/descheduler\` imports it pulled in.

## Out of scope

\`TestClientConnectionConfiguration\` is intentionally not migrated here — the maintainer noted it's \"tricky\" because the descheduler doesn't currently expose the custom client configuration. Happy to take that as a follow-up if you'd like to scope it.

## Test plan

- [x] \`go build -tags e2e ./test/e2e/...\` clean
- [x] \`go vet -tags e2e ./test/e2e/...\` clean
- [ ] Full e2e run on a real cluster (will rely on CI)

Refs #1478