### PR TITLE
fix(removefailedpods): allow opt-in eviction of failed system-critical pods

### DIFF
--- a/pkg/framework/plugins/removefailedpods/failedpods.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
 	podutil "sigs.k8s.io/descheduler/pkg/descheduler/pod"
 	frameworktypes "sigs.k8s.io/descheduler/pkg/framework/types"
+	"sigs.k8s.io/descheduler/pkg/utils"
 )
 
 const PluginName = "RemoveFailedPods"
@@ -60,13 +61,21 @@ func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle)
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
 	defaultFilter := handle.Evictor().Filter
-	if failedPodsArgs.IncludingSystemCriticalPods {
-		// The operator has explicitly opted in to evicting failed pods that are
-		// otherwise protected by the framework default-evictor (system-critical
-		// priority, daemon set, etc.). Bypass the default-evictor filter at
-		// candidate-listing time; the PodFailed phase check (below),
-		// validateCanEvict, and PreEvictionFilter still gate eviction.
-		defaultFilter = func(pod *v1.Pod) bool { return true }
+	if failedPodsArgs.EvictFailedSystemCriticalPods {
+		// The operator has explicitly opted in to evicting failed pods that
+		// would otherwise be protected by the framework default-evictor's
+		// SystemCriticalPods check. Wrap the default-evictor filter so that
+		// pods which are both PodFailed and system-critical are admitted at
+		// candidate-listing time; all other DefaultEvictor protections
+		// (DaemonSet, StaticPod, LocalStorage, ...) still apply, as do
+		// PreEvictionFilter, the PodFailed phase check (below), and
+		// validateCanEvict.
+		defaultFilter = func(pod *v1.Pod) bool {
+			if pod.Status.Phase == v1.PodFailed && utils.IsCriticalPriorityPod(pod) {
+				return true
+			}
+			return handle.Evictor().Filter(pod)
+		}
 	}
 
 	podFilter, err := podutil.NewOptions().

--- a/pkg/framework/plugins/removefailedpods/failedpods.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods.go
@@ -59,8 +59,18 @@ func New(ctx context.Context, args runtime.Object, handle frameworktypes.Handle)
 	}
 
 	// We can combine Filter and PreEvictionFilter since for this strategy it does not matter where we run PreEvictionFilter
+	defaultFilter := handle.Evictor().Filter
+	if failedPodsArgs.IncludingSystemCriticalPods {
+		// The operator has explicitly opted in to evicting failed pods that are
+		// otherwise protected by the framework default-evictor (system-critical
+		// priority, daemon set, etc.). Bypass the default-evictor filter at
+		// candidate-listing time; the PodFailed phase check (below),
+		// validateCanEvict, and PreEvictionFilter still gate eviction.
+		defaultFilter = func(pod *v1.Pod) bool { return true }
+	}
+
 	podFilter, err := podutil.NewOptions().
-		WithFilter(podutil.WrapFilterFuncs(handle.Evictor().Filter, handle.Evictor().PreEvictionFilter)).
+		WithFilter(podutil.WrapFilterFuncs(defaultFilter, handle.Evictor().PreEvictionFilter)).
 		WithNamespaces(includedNamespaces).
 		WithoutNamespaces(excludedNamespaces).
 		WithLabelSelector(failedPodsArgs.LabelSelector).

--- a/pkg/framework/plugins/removefailedpods/failedpods_test.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods_test.go
@@ -354,9 +354,9 @@ func TestRemoveFailedPods(t *testing.T) {
 			},
 		},
 		{
-			description: "includingSystemCriticalPods=true, system-critical priority failed pod is evicted",
+			description: "evictFailedSystemCriticalPods=true, system-critical priority failed pod is evicted",
 			args: RemoveFailedPodsArgs{
-				IncludingSystemCriticalPods: true,
+				EvictFailedSystemCriticalPods: true,
 			},
 			nodes:                   []*v1.Node{test.BuildTestNode("node1", 2000, 3000, 10, nil)},
 			expectedEvictedPodCount: 1,
@@ -387,14 +387,14 @@ func TestRemoveFailedPods(t *testing.T) {
 			}
 
 			plugin, err := New(ctx, &RemoveFailedPodsArgs{
-				Reasons:                     tc.args.Reasons,
-				ExitCodes:                   tc.args.ExitCodes,
-				MinPodLifetimeSeconds:       tc.args.MinPodLifetimeSeconds,
-				IncludingInitContainers:     tc.args.IncludingInitContainers,
-				IncludingSystemCriticalPods: tc.args.IncludingSystemCriticalPods,
-				ExcludeOwnerKinds:           tc.args.ExcludeOwnerKinds,
-				LabelSelector:               tc.args.LabelSelector,
-				Namespaces:                  tc.args.Namespaces,
+				Reasons:                       tc.args.Reasons,
+				ExitCodes:                     tc.args.ExitCodes,
+				MinPodLifetimeSeconds:         tc.args.MinPodLifetimeSeconds,
+				IncludingInitContainers:       tc.args.IncludingInitContainers,
+				EvictFailedSystemCriticalPods: tc.args.EvictFailedSystemCriticalPods,
+				ExcludeOwnerKinds:             tc.args.ExcludeOwnerKinds,
+				LabelSelector:                 tc.args.LabelSelector,
+				Namespaces:                    tc.args.Namespaces,
 			},
 				handle,
 			)

--- a/pkg/framework/plugins/removefailedpods/failedpods_test.go
+++ b/pkg/framework/plugins/removefailedpods/failedpods_test.go
@@ -342,6 +342,30 @@ func TestRemoveFailedPods(t *testing.T) {
 				buildTestPod("p2", "node1", newPodStatus("Shutdown", v1.PodFailed, nil, nil), nil),
 			},
 		},
+		{
+			description:             "system-critical priority failed pod is protected by default",
+			args:                    createRemoveFailedPodsArgs(false, nil, nil, nil, nil),
+			nodes:                   []*v1.Node{test.BuildTestNode("node1", 2000, 3000, 10, nil)},
+			expectedEvictedPodCount: 0,
+			pods: []*v1.Pod{
+				buildCriticalPriorityPod("p1", "node1", newPodStatus("", "", nil, &v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{Reason: "NodeAffinity"},
+				})),
+			},
+		},
+		{
+			description: "includingSystemCriticalPods=true, system-critical priority failed pod is evicted",
+			args: RemoveFailedPodsArgs{
+				IncludingSystemCriticalPods: true,
+			},
+			nodes:                   []*v1.Node{test.BuildTestNode("node1", 2000, 3000, 10, nil)},
+			expectedEvictedPodCount: 1,
+			pods: []*v1.Pod{
+				buildCriticalPriorityPod("p1", "node1", newPodStatus("", "", nil, &v1.ContainerState{
+					Terminated: &v1.ContainerStateTerminated{Reason: "NodeAffinity"},
+				})),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
@@ -363,13 +387,14 @@ func TestRemoveFailedPods(t *testing.T) {
 			}
 
 			plugin, err := New(ctx, &RemoveFailedPodsArgs{
-				Reasons:                 tc.args.Reasons,
-				ExitCodes:               tc.args.ExitCodes,
-				MinPodLifetimeSeconds:   tc.args.MinPodLifetimeSeconds,
-				IncludingInitContainers: tc.args.IncludingInitContainers,
-				ExcludeOwnerKinds:       tc.args.ExcludeOwnerKinds,
-				LabelSelector:           tc.args.LabelSelector,
-				Namespaces:              tc.args.Namespaces,
+				Reasons:                     tc.args.Reasons,
+				ExitCodes:                   tc.args.ExitCodes,
+				MinPodLifetimeSeconds:       tc.args.MinPodLifetimeSeconds,
+				IncludingInitContainers:     tc.args.IncludingInitContainers,
+				IncludingSystemCriticalPods: tc.args.IncludingSystemCriticalPods,
+				ExcludeOwnerKinds:           tc.args.ExcludeOwnerKinds,
+				LabelSelector:               tc.args.LabelSelector,
+				Namespaces:                  tc.args.Namespaces,
 			},
 				handle,
 			)
@@ -412,5 +437,14 @@ func buildTestPod(podName, nodeName string, podStatus v1.PodStatus, deletionTime
 	pod.ObjectMeta.OwnerReferences = test.GetReplicaSetOwnerRefList()
 	pod.ObjectMeta.SetCreationTimestamp(metav1.Now())
 	pod.DeletionTimestamp = deletionTimestamp
+	return pod
+}
+
+// buildCriticalPriorityPod builds a failed pod whose priority matches the
+// system-critical threshold checked by utils.IsCriticalPriorityPod.
+func buildCriticalPriorityPod(podName, nodeName string, podStatus v1.PodStatus) *v1.Pod {
+	pod := buildTestPod(podName, nodeName, podStatus, nil)
+	priority := int32(2000000000)
+	pod.Spec.Priority = &priority
 	return pod
 }

--- a/pkg/framework/plugins/removefailedpods/types.go
+++ b/pkg/framework/plugins/removefailedpods/types.go
@@ -25,12 +25,12 @@ import (
 type RemoveFailedPodsArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces                  *api.Namespaces       `json:"namespaces,omitempty"`
-	LabelSelector               *metav1.LabelSelector `json:"labelSelector,omitempty"`
-	ExcludeOwnerKinds           []string              `json:"excludeOwnerKinds,omitempty"`
-	MinPodLifetimeSeconds       *uint                 `json:"minPodLifetimeSeconds,omitempty"`
-	Reasons                     []string              `json:"reasons,omitempty"`
-	ExitCodes                   []int32               `json:"exitCodes,omitempty"`
-	IncludingInitContainers     bool                  `json:"includingInitContainers,omitempty"`
-	IncludingSystemCriticalPods bool                  `json:"includingSystemCriticalPods,omitempty"`
+	Namespaces                    *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector                 *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	ExcludeOwnerKinds             []string              `json:"excludeOwnerKinds,omitempty"`
+	MinPodLifetimeSeconds         *uint                 `json:"minPodLifetimeSeconds,omitempty"`
+	Reasons                       []string              `json:"reasons,omitempty"`
+	ExitCodes                     []int32               `json:"exitCodes,omitempty"`
+	IncludingInitContainers       bool                  `json:"includingInitContainers,omitempty"`
+	EvictFailedSystemCriticalPods bool                  `json:"evictFailedSystemCriticalPods,omitempty"`
 }

--- a/pkg/framework/plugins/removefailedpods/types.go
+++ b/pkg/framework/plugins/removefailedpods/types.go
@@ -25,11 +25,12 @@ import (
 type RemoveFailedPodsArgs struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Namespaces              *api.Namespaces       `json:"namespaces,omitempty"`
-	LabelSelector           *metav1.LabelSelector `json:"labelSelector,omitempty"`
-	ExcludeOwnerKinds       []string              `json:"excludeOwnerKinds,omitempty"`
-	MinPodLifetimeSeconds   *uint                 `json:"minPodLifetimeSeconds,omitempty"`
-	Reasons                 []string              `json:"reasons,omitempty"`
-	ExitCodes               []int32               `json:"exitCodes,omitempty"`
-	IncludingInitContainers bool                  `json:"includingInitContainers,omitempty"`
+	Namespaces                  *api.Namespaces       `json:"namespaces,omitempty"`
+	LabelSelector               *metav1.LabelSelector `json:"labelSelector,omitempty"`
+	ExcludeOwnerKinds           []string              `json:"excludeOwnerKinds,omitempty"`
+	MinPodLifetimeSeconds       *uint                 `json:"minPodLifetimeSeconds,omitempty"`
+	Reasons                     []string              `json:"reasons,omitempty"`
+	ExitCodes                   []int32               `json:"exitCodes,omitempty"`
+	IncludingInitContainers     bool                  `json:"includingInitContainers,omitempty"`
+	IncludingSystemCriticalPods bool                  `json:"includingSystemCriticalPods,omitempty"`
 }


### PR DESCRIPTION
## Description

Fixes #1775.

The `RemoveFailedPods` plugin chains `handle.Evictor().Filter` into its candidate-listing filter, which protects all system-critical-priority pods regardless of `pod.Status.Phase`. As reported in #1775, this prevents cleanup of `Failed`-phase system-critical pods (e.g. a stuck `cert-manager` pod). Disabling `SystemCriticalPods` protection at the `DefaultEvictor` level is not an acceptable workaround because it would also expose **living** system-critical pods to eviction.

This PR adds an opt-in `IncludingSystemCriticalPods bool` field to `RemoveFailedPodsArgs`. When the operator explicitly sets it, the plugin replaces `handle.Evictor().Filter` with an unconditional permit at candidate-listing time. The eviction is still gated by:

- the existing `PodFailed` phase check
- `validateCanEvict` (`Reasons`, `ExitCodes`, `MinPodLifetimeSeconds`, `ExcludeOwnerKinds`, namespaces, labels)
- `handle.Evictor().PreEvictionFilter`

**Default behaviour is unchanged** — both living and failed system-critical pods stay protected unless the operator opts in.

This addresses @googs1025's "by design" comment on the issue: the framework-level protection stays the framework default; the new flag is a per-plugin, per-operator escape valve scoped specifically to the cleanup-stuck-failed-pods use case, without the broader blast radius of disabling `SystemCriticalPods` in `DefaultEvictor`.

Posted the design proposal on the issue thread first (https://github.com/kubernetes-sigs/descheduler/issues/1775#issuecomment-4363120984) — happy to make the toggle finer-grained (e.g. a per-protection struct) if reviewers prefer.

### Trade-off

The flag also bypasses the framework's other default protections (DaemonSet, StaticPod, LocalStorage, FailedBarePods) **for failed pods** when set. The argument: failed pods are by definition not running, so DaemonSet/StaticPod semantics don't apply the same way, and the operator has explicitly opted in. If reviewers prefer to keep those protections enforced even when this flag is set, the implementation can be tightened to bypass only the system-critical check.

### Test plan

`go test ./pkg/framework/plugins/removefailedpods/... -v` — all existing 25 cases pass plus 2 new cases:

- `system-critical priority failed pod is protected by default` (asserts default behaviour is unchanged)
- `includingSystemCriticalPods=true, system-critical priority failed pod is evicted` (asserts the opt-in works)

`go vet ./pkg/framework/plugins/removefailedpods/...` clean. `go build ./...` clean.

## Checklist
- [x] Code Readability: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] Naming Conventions: Are variable, function, and structs descriptive and consistent?
- [x] Code Duplication: Is there any repeated code that should be refactored?
- [x] Function/Method Size: Are functions/methods short and focused on a single task?
- [x] Comments & Documentation: Are comments clear, useful, and not excessive?
- [x] Error Handling: Are errors handled appropriately?
- [x] Testing: Are there sufficient unit/integration tests?
- [x] Performance: Are there any obvious performance issues or unnecessary computations?
- [x] Dependencies: Are new dependencies justified?
- [x] Logging & Monitoring: Is logging used appropriately?
- [x] Backward Compatibility: Does this change break any existing functionality or APIs?
- [x] Resource Management: Are resources managed and released properly?
- [x] PR Description: Is the PR description clear, providing enough context?
- [ ] Documentation & Changelog: Are README and docs updated if necessary? (No CHANGELOG.md in repo; docs unchanged.)