### PR TITLE
fix(.github/workflows/manifests.yaml): pin actions to a sha

### DIFF
--- a/.github/workflows/manifests.yaml
+++ b/.github/workflows/manifests.yaml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # git ls-remote https://github.com/actions/checkout.git refs/tags/v6.0.2
       - name: Create kind cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # git ls-remote https://github.com/helm/kind-action.git refs/tags/v1.14.0
         with:
           node_image: kindest/node:${{ matrix.k8s-version }}
           kubectl_version: ${{ matrix.k8s-version }}
           config: test/kind-config.yaml
           version: ${{ matrix.kind-version }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # git ls-remote https://github.com/actions/setup-go.git refs/tags/v6.4.0
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
## Description
```
Error: The actions actions/checkout@v4, helm/kind-action@v1.12.0, and actions/setup-go@v5 are not allowed in kubernetes-sigs/descheduler because all actions must be pinned to a full-length commit SHA.
```

From https://github.com/kubernetes-sigs/descheduler/actions/runs/25433159944/job/74604617066?pr=1866 running over https://github.com/kubernetes-sigs/descheduler/pull/1866.

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?
