### PR TITLE
no-op: just for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="assets/logo/descheduler-stacked-color.png" width="40%" align="center" alt="descheduler">
 </p>
 
-# Descheduler for Kubernetes
+# Descheduler for Kubernetes 
 
 Scheduling in Kubernetes is the process of binding pending pods to nodes, and is performed by
 a component of Kubernetes called kube-scheduler. The scheduler's decisions, whether or where a


### PR DESCRIPTION
Just to test the deploy GA goes green after merging https://github.com/kubernetes-sigs/descheduler/pull/1866
/hold