### PR TITLE
ci: pin GitHub Actions to immutable SHAs

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -20,25 +20,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: v3.15.1
 
-      - uses: actions/setup-python@v5.1.1
+      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: 3.12
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: 'go.mod'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
         with:
           version: v3.11.0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           fetch-depth: 0
 
@@ -23,12 +23,12 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
         with:
           version: v3.15.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "descheduler-helm-chart-{{ .Version }}"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -19,7 +19,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -38,6 +38,6 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7c1e4cf0b20d7c1872b26569c00ba908797a59bf # v4
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
This PR pins all GitHub Actions in workflows to immutable commit SHAs to satisfy action pinning policy checks.

### Why
Recent CI checks fail due to unpinned action references (tag-based `@v*`), which are mutable. Pinning by SHA improves supply-chain integrity and satisfies policy enforcement.

### What changed
Updated the following workflows to pin all `uses:` entries to commit SHAs:
- `.github/workflows/release.yaml`
- `.github/workflows/helm.yaml`
- `.github/workflows/security.yaml`

Actions pinned include:
- `actions/checkout`
- `azure/setup-helm`
- `helm/chart-releaser-action`
- `actions/setup-python`
- `actions/setup-go`
- `helm/chart-testing-action`
- `github/codeql-action/upload-sarif`

Each pin includes an inline comment indicating the originating tag for readability.

### Notes
- Functionality is unchanged; this is a security/compliance hardening change only.
- Existing already-pinned workflows (e.g., `manifests.yaml`) were left untouched.
