### PR TITLE
fix: validate LowNodeUtilization metrics source

### DIFF
--- a/pkg/framework/plugins/nodeutilization/validation.go
+++ b/pkg/framework/plugins/nodeutilization/validation.go
@@ -63,8 +63,17 @@ func ValidateLowNodeUtilizationArgs(obj runtime.Object) error {
 		return err
 	}
 	if args.MetricsUtilization != nil {
-		if args.MetricsUtilization.Source == api.KubernetesMetrics && args.MetricsUtilization.MetricsServer {
-			return fmt.Errorf("it is not allowed to set both %q source and metricsServer", api.KubernetesMetrics)
+		if args.MetricsUtilization.Source == "" && !args.MetricsUtilization.MetricsServer {
+			return fmt.Errorf("metrics source is empty")
+		}
+		if args.MetricsUtilization.Source != "" && args.MetricsUtilization.Source != api.KubernetesMetrics && args.MetricsUtilization.Source != api.PrometheusMetrics {
+			return fmt.Errorf("unrecognized metrics source")
+		}
+		if args.MetricsUtilization.MetricsServer && args.MetricsUtilization.Source != "" {
+			return fmt.Errorf("it is not allowed to set both source and metricsServer")
+		}
+		if args.MetricsUtilization.MetricsServer && args.MetricsUtilization.Prometheus != nil {
+			return fmt.Errorf("prometheus configuration is not allowed when metricsServer is enabled")
 		}
 		if args.MetricsUtilization.Source == api.KubernetesMetrics && args.MetricsUtilization.Prometheus != nil {
 			return fmt.Errorf("prometheus configuration is not allowed to set when source is set to %q", api.KubernetesMetrics)

--- a/pkg/framework/plugins/nodeutilization/validation_test.go
+++ b/pkg/framework/plugins/nodeutilization/validation_test.go
@@ -201,7 +201,66 @@ func TestValidateLowNodeUtilizationPluginConfig(t *testing.T) {
 					Source:        api.KubernetesMetrics,
 				},
 			},
-			errInfo: fmt.Errorf("it is not allowed to set both \"KubernetesMetrics\" source and metricsServer"),
+			errInfo: fmt.Errorf("it is not allowed to set both source and metricsServer"),
+		},
+		{
+			name: "legacy metrics server without metrics source",
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  80,
+				},
+				MetricsUtilization: &MetricsUtilization{
+					MetricsServer: true,
+				},
+			},
+			errInfo: nil,
+		},
+		{
+			name: "metrics server with explicit metrics source",
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  80,
+				},
+				MetricsUtilization: &MetricsUtilization{
+					MetricsServer: true,
+					Source:        api.PrometheusMetrics,
+				},
+			},
+			errInfo: fmt.Errorf("it is not allowed to set both source and metricsServer"),
+		},
+		{
+			name: "metrics server with prometheus configuration",
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  80,
+				},
+				MetricsUtilization: &MetricsUtilization{
+					MetricsServer: true,
+					Prometheus:    &Prometheus{Query: "up"},
+				},
+			},
+			errInfo: fmt.Errorf("prometheus configuration is not allowed when metricsServer is enabled"),
 		},
 		{
 			name: "missing prometheus query",
@@ -241,6 +300,42 @@ func TestValidateLowNodeUtilizationPluginConfig(t *testing.T) {
 				},
 			},
 			errInfo: fmt.Errorf("prometheus configuration is not allowed to set when source is set to \"KubernetesMetrics\""),
+		},
+		{
+			name: "metrics utilization without metrics source",
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  80,
+				},
+				MetricsUtilization: &MetricsUtilization{},
+			},
+			errInfo: fmt.Errorf("metrics source is empty"),
+		},
+		{
+			name: "unknown metrics source",
+			args: &LowNodeUtilizationArgs{
+				Thresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    20,
+					v1.ResourceMemory: 20,
+					extendedResource:  20,
+				},
+				TargetThresholds: api.ResourceThresholds{
+					v1.ResourceCPU:    80,
+					v1.ResourceMemory: 80,
+					extendedResource:  80,
+				},
+				MetricsUtilization: &MetricsUtilization{
+					Source: api.MetricsSource("UnknownMetrics"),
+				},
+			},
+			errInfo: fmt.Errorf("unrecognized metrics source"),
 		},
 	}
 


### PR DESCRIPTION
## Description
Tiny config validation fix, nothing fancy.

`LowNodeUtilization` accepted `metricsUtilization: {}` or a typo'd `metricsUtilization.source`. That can come straight from policy YAML, since `source` is just a string; no cloud quota / API ceiling blocks it. Later the plugin trips at runtime with `metrics source is empty` or `unrecognized metrics source`.

This catches that during policy validation instead. Legacy `metricsServer: true` stays valid.

## Reproduce
Before the fix, the new table cases returned `nil`:

```sh
go test ./pkg/framework/plugins/nodeutilization -run TestValidateLowNodeUtilizationPluginConfig -count=1
```

Now they pass, and the wider package suite is clean:

```sh
go test ./pkg/...
```

Related search: #1658 and #1840 are in the same metrics config area, but this does not directly close them.

## Checklist
- [x] Code Readability
- [x] Naming Conventions
- [x] Code Duplication
- [x] Function/Method Size
- [x] Comments & Documentation
- [x] Error Handling
- [x] Testing
- [x] Performance
- [x] Dependencies
- [x] Logging & Monitoring
- [x] Backward Compatibility
- [x] Resource Management
- [x] PR Description
- [x] Documentation & Changelog
