### PR TITLE
docs(removefailedpods): add example for evicting failed system-critical pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,37 @@ profiles:
           - "RemoveFailedPods"
 ```
 
+**Example: evicting failed system-critical pods**
+
+By default, the `DefaultEvictor`'s `SystemCriticalPods` protection prevents `RemoveFailedPods` from evicting `Failed`-phase pods that carry a system-critical priority class (e.g. a stuck `cert-manager` pod, see [#1775](https://github.com/kubernetes-sigs/descheduler/issues/1775)). To clean these up without exposing *living* system-critical pods to eviction, run `RemoveFailedPods` in a dedicated profile that disables only the `SystemCriticalPods` protection. Because the relaxed protection is scoped to its own profile, system-critical pods remain fully protected in every other profile:
+
+```yaml
+apiVersion: "descheduler/v1alpha2"
+kind: "DeschedulerPolicy"
+profiles:
+  # Dedicated profile: only RemoveFailedPods runs with the SystemCriticalPods protection disabled.
+  - name: RemoveFailedPodsCritical
+    pluginConfig:
+    - name: "DefaultEvictor"
+      args:
+        podProtections:
+          defaultDisabled:
+          - "SystemCriticalPods"
+    - name: "RemoveFailedPods"
+      args:
+        reasons:
+        - "Error"
+        excludeOwnerKinds:
+        - "Job"
+        minPodLifetimeSeconds: 120
+    plugins:
+      deschedule:
+        enabled:
+          - "RemoveFailedPods"
+```
+
+Note that `reasons` values match the failure reason reported in the pod's status — for example, a container that exits non-zero reports `reason: Error` under `status.containerStatuses[].state.terminated`. `PodFailed` is a pod *phase*, not a reason, so listing it as a `reasons` value will never match any pod.
+
 ## Filter Pods
 
 ### Namespace filtering


### PR DESCRIPTION
## Description

Documents the config-only pattern for evicting `Failed`-phase **system-critical** pods with `RemoveFailedPods`, as suggested by @ingvagabund in #1775 / #1865 and validated end-to-end by @alex-berger (https://github.com/kubernetes-sigs/descheduler/pull/1865#issuecomment-4613065776). ingvagabund invited this README example in https://github.com/kubernetes-sigs/descheduler/pull/1865#issuecomment-4386947859.

Adds a second example to the `RemoveFailedPods` README section showing:

- a **dedicated profile** that disables only the `SystemCriticalPods` protection, so *living* system-critical pods stay protected in every other profile;
- a note that `reasons` matches the failure reason reported in the pod's status (e.g. `Error` for a non-zero container exit), **not** the pod phase — `PodFailed` is a phase and never matches. This is the exact pitfall hit during validation in #1865, so documenting it next to the example should save future operators the same round-trip.

Docs-only change; no code touched.

Related: #1775, #1865

🤖 Generated with [Claude Code](https://claude.com/claude-code)
