### PR TITLE
Register the PodDisruptionBudget informer so PodsWithoutPDB protection works

### DIFF
--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -126,6 +126,11 @@ func newDescheduler(ctx context.Context, rs *options.DeschedulerServer, deschedu
 	// Temporarily register the PVC because it is used by the DefaultEvictor plugin during
 	// the descheduling cycle, where informer registration is ignored.
 	_ = sharedInformerFactory.Core().V1().PersistentVolumeClaims().Informer()
+	// Temporarily register the PDB for the same reason: the DefaultEvictor PodsWithoutPDB
+	// protection reads the PDB lister during the descheduling cycle, which runs after the
+	// factory has started, so the informer must be registered up front or the lister is
+	// empty and every pod is treated as not covered by a PDB.
+	_ = sharedInformerFactory.Policy().V1().PodDisruptionBudgets().Informer()
 
 	getPodsAssignedToNode, err := podutil.BuildGetPodsAssignedToNodeFunc(podInformer)
 	if err != nil {

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -389,6 +389,85 @@ func TestDuplicate(t *testing.T) {
 	}
 }
 
+// TestPodsWithoutPDBProtectionRespectsPDBs is a regression test for #1882.
+//
+// The DefaultEvictor PodsWithoutPDB protection reads the PDB lister during the
+// descheduling cycle, which runs after the shared informer factory has started.
+// If the PDB informer is not registered up front, the lister is empty, every pod
+// looks "without PDB", the protection blocks all evictions, and nothing is evicted.
+//
+// Here the duplicate pods ARE covered by a PDB, so with PodsWithoutPDB enabled they
+// must still be evictable by RemoveDuplicates. This fails without the informer
+// registration (the pods are wrongly treated as uncovered and protected). It must run
+// through the real newDescheduler/RunDeschedulerStrategies path: the defaultevictor
+// unit harness pre-registers the PDB lister and would mask the bug.
+func TestPodsWithoutPDBProtectionRespectsPDBs(t *testing.T) {
+	initPluginRegistry()
+
+	ctx := context.Background()
+	node1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)
+	node2 := test.BuildTestNode("n2", 2000, 3000, 10, nil)
+
+	ownerRef := test.GetReplicaSetOwnerRefList()
+	buildPod := func(name string) *v1.Pod {
+		p := test.BuildTestPod(name, 100, 0, node1.Name, nil)
+		p.Namespace = "default"
+		p.Labels = map[string]string{"app": "foo"}
+		p.ObjectMeta.OwnerReferences = ownerRef
+		return p
+	}
+	p1, p2, p3 := buildPod("p1"), buildPod("p2"), buildPod("p3")
+	pdb := test.BuildTestPDB("foo-pdb", "foo")
+
+	client := fakeclientset.NewSimpleClientset(node1, node2, p1, p2, p3, pdb)
+	eventClient := fakeclientset.NewSimpleClientset(node1, node2, p1, p2, p3, pdb)
+
+	rs, err := options.NewDeschedulerServer()
+	if err != nil {
+		t.Fatalf("Unable to initialize server: %v", err)
+	}
+	rs.Client = client
+	rs.EventClient = eventClient
+	rs.DefaultFeatureGates = initFeatureGates()
+
+	var evictedPods []string
+	client.PrependReactor("create", "pods", podEvictionReactionTestingFnc(&evictedPods, nil, nil))
+
+	policy := &api.DeschedulerPolicy{
+		Profiles: []api.DeschedulerProfile{
+			{
+				Name: "Profile",
+				PluginConfigs: []api.PluginConfig{
+					{
+						Name: "RemoveDuplicates",
+						Args: &removeduplicates.RemoveDuplicatesArgs{},
+					},
+					{
+						Name: "DefaultEvictor",
+						Args: &defaultevictor.DefaultEvictorArgs{
+							PodProtections: defaultevictor.PodProtections{
+								ExtraEnabled: []defaultevictor.PodProtection{defaultevictor.PodsWithoutPDB},
+							},
+						},
+					},
+				},
+				Plugins: api.Plugins{
+					Filter:  api.PluginSet{Enabled: []string{"DefaultEvictor"}},
+					Balance: api.PluginSet{Enabled: []string{"RemoveDuplicates"}},
+				},
+			},
+		},
+	}
+
+	if err := RunDeschedulerStrategies(ctx, rs, policy, "v1"); err != nil {
+		t.Fatalf("Unable to run descheduler strategies: %v", err)
+	}
+
+	if len(evictedPods) == 0 {
+		t.Fatalf("expected a duplicate pod covered by a PDB to be evicted, but PodsWithoutPDB protection blocked all evictions (PDB informer not synced?)")
+	}
+}
+
 func TestRootCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	n1 := test.BuildTestNode("n1", 2000, 3000, 10, nil)

--- a/pkg/descheduler/descheduler_test.go
+++ b/pkg/descheduler/descheduler_test.go
@@ -463,8 +463,12 @@ func TestPodsWithoutPDBProtectionRespectsPDBs(t *testing.T) {
 		t.Fatalf("Unable to run descheduler strategies: %v", err)
 	}
 
-	if len(evictedPods) == 0 {
-		t.Fatalf("expected a duplicate pod covered by a PDB to be evicted, but PodsWithoutPDB protection blocked all evictions (PDB informer not synced?)")
+	// Three duplicate pods on node1 with two feasible nodes means RemoveDuplicates
+	// should evict exactly one. Asserting != 1 catches both the original regression
+	// (PodsWithoutPDB blocking all evictions when the PDB informer is not synced)
+	// and any future over-eviction on this path.
+	if len(evictedPods) != 1 {
+		t.Fatalf("expected exactly one duplicate pod covered by a PDB to be evicted, got %d", len(evictedPods))
 	}
 }
 


### PR DESCRIPTION
Fixes #1882

## Problem

The `DefaultEvictor` `PodsWithoutPDB` protection reads the PodDisruptionBudget lister (`handle.SharedInformerFactory().Policy().V1().PodDisruptionBudgets().Lister()`) during the descheduling cycle. That cycle runs **after** `sharedInformerFactory.Start()` / `WaitForCacheSync()`, and the factory only starts informers that were registered before `Start()`.

The PDB informer was never registered in production code, so the lister returns an empty list and `IsPodCoveredByPDB` reports `false` for **every** pod. With `PodsWithoutPDB` enabled, that means every pod looks "without a PDB" and is protected — silently blocking **all** evictions (the reported symptom: `evictedPods=0`, no errors).

## Fix

Register the PDB informer up front in `newDescheduler`, exactly mirroring the existing workaround already in place for the `PersistentVolumeClaims` informer used by the same plugin (a few lines above).

## Test

Added `TestPodsWithoutPDBProtectionRespectsPDBs`, which runs through the **real** `newDescheduler` / `RunDeschedulerStrategies` startup path with `PodsWithoutPDB` enabled and duplicate pods covered by a PDB, asserting they are still evicted.

This must go through the real startup path — the `defaultevictor` unit harness pre-registers the PDB lister, which masks the bug. Verified:

- **without the fix:** `FAIL … PodsWithoutPDB protection blocked all evictions`
- **with the fix:** `ok`

`go build` / `go vet` / the new test all pass.
