### PR TITLE
feat(deployment): adds revisionHistoryLimit as a configurable parameter

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `ttlSecondsAfterFinished`           | If set, configure `ttlSecondsAfterFinished` for the _descheduler_ job                                                 | `nil`                                     |
 | `deschedulingInterval`              | If using kind:Deployment, sets time between consecutive descheduler executions.                                       | `5m`                                      |
 | `replicas`                          | The replica count for Deployment                                                                                      | `1`                                       |
+| `revisionHistoryLimit               | The revision history limit for Deployment                                                                             | `10`                                      |
 | `leaderElection`                    | The options for high availability when running replicated components                                                  | _see values.yaml_                         |
 | `cmdOptions`                        | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                         |
 | `priorityClassName`                 | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                 |

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
   {{- else }}
   replicas: 1
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "descheduler.selectorLabels" . | nindent 6 }}

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -68,6 +68,8 @@ deschedulingInterval: 5m
 # only if that node is in the same zone as at least one already-running descheduler
 replicas: 1
 
+revisionHistoryLimit: 10
+
 # Specifies whether Leader Election resources should be created
 # Required when running as a Deployment
 # NOTE: Leader election can't be activated if DryRun enabled


### PR DESCRIPTION
# Summary

Adds `revisionHistoryLimit` as a configurable chart value for the Deployment resource

# Motivation

Some environments may prefer retaining fewer ReplicaSets to avoid unnecessary clutter, while others might require more. Exposing `revisionHistoryLimit` as a chart value provides additional flexibility without changing the current default behaviour.
This is a common parameter exposed by many charts and as such, users may expect it to be configurable (myself included).
Given the infinitesimality and low risk of the change, I've taken the liberty of not opening an issue beforehand. Do let me know whether you'd like me to open one regardless.

## Backwards compatibility

-   No breaking changes
-   Default value remains `10`, matching the Kubernetes default