### PR TITLE
Remove unnecessary pods delete permission from ClusterRole

### DIFF
--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -17,7 +17,7 @@ rules:
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "watch", "list", "delete"]
+  verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs: ["create"]

--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -15,7 +15,7 @@ rules:
   verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["get", "watch", "list", "delete"]
+  verbs: ["get", "watch", "list"]
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs: ["create"]


### PR DESCRIPTION
Fixes #1887

## What
The descheduler `ClusterRole` grants `pods: delete` in addition to `pods/eviction: create`. The direct `delete` verb is unnecessary and violates least privilege.

## Why it's safe
The descheduler evicts exclusively through the **eviction subresource** — `PolicyV1().Evictions(...).Evict(ctx, eviction)` (`pkg/descheduler/evictions/evictions.go`), which requires `pods/eviction: create`. There are **no direct `Pods().Delete()` calls** anywhere in the (non-test) codebase, so the `pods: delete` permission is unused.

## Change
Drop `delete` from the `pods` rule in both the kustomize base and the Helm chart:
- `kubernetes/base/rbac.yaml`
- `charts/descheduler/templates/clusterrole.yaml`

`pods/eviction: create` is left intact. `helm template` renders the ClusterRole with `verbs: ["get", "watch", "list"]` for `pods` and `create` for `pods/eviction`.