### PR TITLE
feat: add opt-in schedulerName and runtimeClassName to the Helm chart

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -69,6 +69,8 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `podDisruptionBudget.annotations`   | Annotations to add to the PodDisruptionBudget                                                                         | `{}`                                      |
 | `cmdOptions`                        | The options to pass to the _descheduler_ command                                                                      | _see values.yaml_                         |
 | `priorityClassName`                 | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                 |
+| `schedulerName`                     | The name of the scheduler used to schedule the descheduler cronjob/deployment pods                                    | `""`                                      |
+| `runtimeClassName`                  | The RuntimeClass applied to the descheduler cronjob/deployment pods                                                   | `""`                                      |
 | `rbac.create`                       | If `true`, create & use RBAC resources                                                                                | `true`                                    |
 | `resources`                         | Descheduler container CPU and memory requests/limits                                                                  | _see values.yaml_                         |
 | `serviceAccount.create`             | If `true`, create a service account for the cron job                                                                  | `true`                                    |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -87,6 +87,12 @@ spec:
           {{- if .Values.priorityClassName }}
           priorityClassName: {{ .Values.priorityClassName }}
           {{- end }}
+          {{- if .Values.schedulerName }}
+          schedulerName: {{ .Values.schedulerName }}
+          {{- end }}
+          {{- if .Values.runtimeClassName }}
+          runtimeClassName: {{ .Values.runtimeClassName }}
+          {{- end }}
           serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
           {{- if kindIs "bool" .Values.automountServiceAccountToken }}
           automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -41,6 +41,12 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
+      {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
       serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
       {{- if kindIs "bool" .Values.automountServiceAccountToken }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/charts/descheduler/tests/cronjob_test.yaml
+++ b/charts/descheduler/tests/cronjob_test.yaml
@@ -15,3 +15,29 @@ tests:
     asserts:
       - isKind:
           of: CronJob
+
+  - it: sets schedulerName when provided
+    set:
+      schedulerName: custom-scheduler
+    template: templates/cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.schedulerName
+          value: custom-scheduler
+
+  - it: sets runtimeClassName when provided
+    set:
+      runtimeClassName: gvisor
+    template: templates/cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.runtimeClassName
+          value: gvisor
+
+  - it: omits schedulerName and runtimeClassName by default
+    template: templates/cronjob.yaml
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.schedulerName
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.runtimeClassName

--- a/charts/descheduler/tests/deployment_test.yaml
+++ b/charts/descheduler/tests/deployment_test.yaml
@@ -47,3 +47,29 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --leader-elect-resource-namespace=typo
+
+  - it: sets schedulerName when provided
+    set:
+      schedulerName: custom-scheduler
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.schedulerName
+          value: custom-scheduler
+
+  - it: sets runtimeClassName when provided
+    set:
+      runtimeClassName: gvisor
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.runtimeClassName
+          value: gvisor
+
+  - it: omits schedulerName and runtimeClassName by default
+    template: templates/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.schedulerName
+      - notExists:
+          path: spec.template.spec.runtimeClassName

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -164,6 +164,14 @@ deschedulerPolicy:
 
 priorityClassName: system-cluster-critical
 
+# schedulerName is the name of the scheduler used to schedule the descheduler pods.
+# Leave empty to use the cluster default scheduler.
+schedulerName: ""
+
+# runtimeClassName is the RuntimeClass applied to the descheduler pods.
+# Leave empty to use the cluster default runtime.
+runtimeClassName: ""
+
 nodeSelector: {}
 #  foo: bar
 


### PR DESCRIPTION
## Description

Adds two optional pod-spec fields to the descheduler chart, mirroring the existing `priorityClassName` / `topologySpreadConstraints` knobs across both the Deployment and CronJob workloads:

- `schedulerName` — schedule the descheduler pods with a non-default scheduler
- `runtimeClassName` — run the descheduler pods under a specific RuntimeClass (e.g. gVisor / Kata)

Both default to an empty string, so the rendered output is unchanged for existing users (default render is byte-identical). This follows the same opt-in pattern as the recently merged PodDisruptionBudget support (#1885).

## Validation

- `helm unittest charts/descheduler --strict` — 22 passed (6 new cases across `deployment_test.yaml` and `cronjob_test.yaml`)
- `ct lint --config=.github/ci/ct.yaml` — passed
- `helm template` default render is byte-identical to `master` for both `kind=Deployment` and `kind=CronJob`
- With the fields set, both workloads render `schedulerName:` and `runtimeClassName:` at the pod spec level

## Checklist

- [x] Testing: helm-unittest cases for both fields (set + default-absent) on Deployment and CronJob
- [x] Backward Compatibility: default empty → render unchanged for existing users
- [x] Documentation & Changelog: README parameters table updated