### PR TITLE
feat: add opt-in hostUsers to the Helm chart

### DIFF
--- a/charts/descheduler/README.md
+++ b/charts/descheduler/README.md
@@ -71,6 +71,7 @@ The following table lists the configurable parameters of the _descheduler_ chart
 | `priorityClassName`                 | The name of the priority class to add to pods                                                                         | `system-cluster-critical`                 |
 | `schedulerName`                     | The name of the scheduler used to schedule the descheduler cronjob/deployment pods                                    | `""`                                      |
 | `runtimeClassName`                  | The RuntimeClass applied to the descheduler cronjob/deployment pods                                                   | `""`                                      |
+| `hostUsers`                         | If set (`true`/`false`), sets `hostUsers` on the pod spec to control user-namespace sharing                           | `nil`                                     |
 | `rbac.create`                       | If `true`, create & use RBAC resources                                                                                | `true`                                    |
 | `resources`                         | Descheduler container CPU and memory requests/limits                                                                  | _see values.yaml_                         |
 | `serviceAccount.create`             | If `true`, create a service account for the cron job                                                                  | `true`                                    |

--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -93,6 +93,9 @@ spec:
           {{- if .Values.runtimeClassName }}
           runtimeClassName: {{ .Values.runtimeClassName }}
           {{- end }}
+          {{- if kindIs "bool" .Values.hostUsers }}
+          hostUsers: {{ .Values.hostUsers }}
+          {{- end }}
           serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
           {{- if kindIs "bool" .Values.automountServiceAccountToken }}
           automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/charts/descheduler/templates/deployment.yaml
+++ b/charts/descheduler/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName }}
       {{- end }}
+      {{- if kindIs "bool" .Values.hostUsers }}
+      hostUsers: {{ .Values.hostUsers }}
+      {{- end }}
       serviceAccountName: {{ template "descheduler.serviceAccountName" . }}
       {{- if kindIs "bool" .Values.automountServiceAccountToken }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/charts/descheduler/tests/cronjob_test.yaml
+++ b/charts/descheduler/tests/cronjob_test.yaml
@@ -41,3 +41,27 @@ tests:
           path: spec.jobTemplate.spec.template.spec.schedulerName
       - notExists:
           path: spec.jobTemplate.spec.template.spec.runtimeClassName
+
+  - it: sets hostUsers to false when configured
+    set:
+      hostUsers: false
+    template: templates/cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.hostUsers
+          value: false
+
+  - it: sets hostUsers to true when configured
+    set:
+      hostUsers: true
+    template: templates/cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.hostUsers
+          value: true
+
+  - it: omits hostUsers by default
+    template: templates/cronjob.yaml
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.hostUsers

--- a/charts/descheduler/tests/deployment_test.yaml
+++ b/charts/descheduler/tests/deployment_test.yaml
@@ -73,3 +73,27 @@ tests:
           path: spec.template.spec.schedulerName
       - notExists:
           path: spec.template.spec.runtimeClassName
+
+  - it: sets hostUsers to false when configured
+    set:
+      hostUsers: false
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: false
+
+  - it: sets hostUsers to true when configured
+    set:
+      hostUsers: true
+    template: templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.hostUsers
+          value: true
+
+  - it: omits hostUsers by default
+    template: templates/deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostUsers

--- a/charts/descheduler/values.yaml
+++ b/charts/descheduler/values.yaml
@@ -172,6 +172,11 @@ schedulerName: ""
 # Leave empty to use the cluster default runtime.
 runtimeClassName: ""
 
+# Set the Pod spec `hostUsers` field to control user-namespace sharing.
+# Default is not set (the cluster default applies). Set to `false` to opt into
+# user-namespace isolation, or `true` to share the host user namespace.
+# hostUsers: false
+
 nodeSelector: {}
 #  foo: bar
 


### PR DESCRIPTION
Adds an opt-in `hostUsers` field to the descheduler Helm chart so the Pod spec `hostUsers` (user-namespace sharing, Kubernetes 1.28+) can be configured. Mirrors the existing `automountServiceAccountToken` bool pattern (`{{- if kindIs "bool" .Values.hostUsers }}`), so an unset value leaves the render byte-identical and both `true` and `false` are honored. Applied to both the Deployment and CronJob workloads.

Validation (local):
- `helm unittest charts/descheduler --strict`: 22 passed (6 new cases: set-true / set-false / omit-default x Deployment + CronJob)
- `ct lint --config .github/ci/ct.yaml --charts charts/descheduler --validate-maintainers=false`: all charts linted successfully
- Default render byte-identical to master for both `kind=Deployment` and `kind=CronJob`
- `--set hostUsers=false` renders `hostUsers: false`; `--set hostUsers=true` renders `hostUsers: true` on both workloads