### PR TITLE
Add workload-scoped descheduler_pod_evictions_total metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,6 +1141,7 @@ To get best results from HA mode some additional configurations might require:
 | build_info                            | 	gauge       | 	constant 1                                                                       |
 | pods_evicted                          | CounterVec   | total number of pods evicted, is deprecated in version v0.34.0                    |
 | pods_evicted_total                    | CounterVec   | total number of pods evicted                                                      |
+| pod_evictions_total                   | CounterVec   | number of pod eviction attempts by owning workload (result: success, error, blocked, background) |
 | descheduler_loop_duration_seconds     | HistogramVec | time taken to complete a whole descheduling cycle (support _bucket, _sum, _count), is deprecated in version v0.34.0  |
 | loop_duration_seconds                 | HistogramVec | time taken to complete a whole descheduling cycle (support _bucket, _sum, _count) |
 | descheduler_strategy_duration_seconds | HistogramVec | time taken to complete each stragtegy of descheduling operation (support _bucket, _sum, _count), is deprecated in version v0.34.0  |

--- a/charts/descheduler/templates/clusterrole.yaml
+++ b/charts/descheduler/templates/clusterrole.yaml
@@ -39,6 +39,12 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "watch", "list"]
 {{- if and .Values.deschedulerPolicy }}
 {{- range .Values.deschedulerPolicy.metricsProviders }}
 {{- if and (hasKey . "source") (eq .source "KubernetesMetrics") }}

--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -38,6 +38,12 @@ rules:
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "watch", "list"]
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -46,6 +46,14 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result", "strategy", "profile", "namespace", "node"})
 
+	PodEvictionsTotal = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      DeschedulerSubsystem,
+			Name:           "pod_evictions_total",
+			Help:           "Number of pod-level descheduler eviction attempts and results, resolved to the owning workload. The 'result' label is one of success, error, blocked or background.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"namespace", "workload_kind", "workload_name", "node", "strategy", "profile", "result", "reason"})
+
 	buildInfo = metrics.NewGauge(
 		&metrics.GaugeOpts{
 			Subsystem:      DeschedulerSubsystem,
@@ -95,6 +103,7 @@ var (
 	metricsList = []metrics.Registerable{
 		PodsEvicted,
 		PodsEvictedTotal,
+		PodEvictionsTotal,
 		buildInfo,
 		DeschedulerLoopDuration,
 		DeschedulerStrategyDuration,

--- a/pkg/descheduler/descheduler.go
+++ b/pkg/descheduler/descheduler.go
@@ -28,9 +28,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
@@ -127,6 +130,21 @@ func newDescheduler(ctx context.Context, rs *options.DeschedulerServer, deschedu
 	// the descheduling cycle, where informer registration is ignored.
 	_ = sharedInformerFactory.Core().V1().PersistentVolumeClaims().Informer()
 
+	// ReplicaSets and Jobs are watched only to resolve a pod's owning workload
+	// for the pod_evictions_total metric, so their informers are registered only when metrics are enabled.
+	var workloadResolver evictions.WorkloadResolver
+	if !rs.DisableMetrics {
+		replicaSetInformer := sharedInformerFactory.Apps().V1().ReplicaSets()
+		if err := replicaSetInformer.Informer().SetTransform(trimWorkloadMetadata); err != nil {
+			return nil, fmt.Errorf("unable to set ReplicaSet informer transform: %v", err)
+		}
+		jobInformer := sharedInformerFactory.Batch().V1().Jobs()
+		if err := jobInformer.Informer().SetTransform(trimWorkloadMetadata); err != nil {
+			return nil, fmt.Errorf("unable to set Job informer transform: %v", err)
+		}
+		workloadResolver = newWorkloadResolver(replicaSetInformer.Lister(), jobInformer.Lister())
+	}
+
 	getPodsAssignedToNode, err := podutil.BuildGetPodsAssignedToNodeFunc(podInformer)
 	if err != nil {
 		return nil, fmt.Errorf("build get pods assigned to node function error: %v", err)
@@ -146,7 +164,8 @@ func newDescheduler(ctx context.Context, rs *options.DeschedulerServer, deschedu
 			WithEvictionFailureEventNotification(deschedulerPolicy.EvictionFailureEventNotification).
 			WithGracePeriodSeconds(deschedulerPolicy.GracePeriodSeconds).
 			WithDryRun(rs.DryRun).
-			WithMetricsEnabled(!rs.DisableMetrics),
+			WithMetricsEnabled(!rs.DisableMetrics).
+			WithWorkloadResolver(workloadResolver),
 	)
 	if err != nil {
 		return nil, err
@@ -418,8 +437,18 @@ func bootstrapDescheduler(
 
 	// If in dry run mode, replace the descheduler with one using fake client/factory
 	if rs.DryRun {
+		// ReplicaSets and Jobs are mirrored so that dry-run workload resolution matches live mode instead
+		// of degrading to unstable, high-cardinality intermediate-owner names.
+		// They are registered (and mirrored) only when metrics are enabled.
+		var extraResources []schema.GroupVersionResource
+		if !rs.DisableMetrics {
+			extraResources = append(extraResources,
+				appsv1.SchemeGroupVersion.WithResource("replicasets"),
+				batchv1.SchemeGroupVersion.WithResource("jobs"),
+			)
+		}
 		// Create sandbox with resources to mirror from real client
-		kubeClientSandbox, err := newDefaultKubeClientSandbox(rs.Client, sharedInformerFactory)
+		kubeClientSandbox, err := newDefaultKubeClientSandbox(rs.Client, sharedInformerFactory, extraResources...)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create kube client sandbox: %v", err)
 		}
@@ -579,4 +608,16 @@ func trimManagedFields(obj interface{}) (interface{}, error) {
 		accessor.SetManagedFields(nil)
 	}
 	return obj, nil
+}
+
+func trimWorkloadMetadata(obj interface{}) (interface{}, error) {
+	switch t := obj.(type) {
+	case *appsv1.ReplicaSet:
+		t.Spec = appsv1.ReplicaSetSpec{}
+		t.Status = appsv1.ReplicaSetStatus{}
+	case *batchv1.Job:
+		t.Spec = batchv1.JobSpec{}
+		t.Status = batchv1.JobStatus{}
+	}
+	return trimManagedFields(obj)
 }

--- a/pkg/descheduler/evictions/evictions.go
+++ b/pkg/descheduler/evictions/evictions.go
@@ -58,6 +58,7 @@ var (
 type evictionRequestItem struct {
 	podName, podNamespace, podNodeName string
 	strategyName, profileName          string
+	workloadKind, workloadName         string
 	evictionAssumed                    bool
 	assumedTimestamp                   metav1.Time
 }
@@ -154,7 +155,7 @@ func (erc *evictionRequestsCache) addPod(pod *v1.Pod) {
 	erc.requestsTotal++
 }
 
-func (erc *evictionRequestsCache) assumePod(pod *v1.Pod, profileName, strategyName string) {
+func (erc *evictionRequestsCache) assumePod(pod *v1.Pod, profileName, strategyName, workloadKind, workloadName string) {
 	erc.mu.Lock()
 	defer erc.mu.Unlock()
 	uid := getPodKey(pod)
@@ -172,6 +173,8 @@ func (erc *evictionRequestsCache) assumePod(pod *v1.Pod, profileName, strategyNa
 			podNodeName:      item.podNodeName,
 			strategyName:     strategyName,
 			profileName:      profileName,
+			workloadKind:     workloadKind,
+			workloadName:     workloadName,
 			evictionAssumed:  true,
 			assumedTimestamp: metav1.NewTime(time.Now()),
 		}
@@ -183,6 +186,8 @@ func (erc *evictionRequestsCache) assumePod(pod *v1.Pod, profileName, strategyNa
 		podNodeName:      pod.Spec.NodeName,
 		strategyName:     strategyName,
 		profileName:      profileName,
+		workloadKind:     workloadKind,
+		workloadName:     workloadName,
 		evictionAssumed:  true,
 		assumedTimestamp: metav1.NewTime(time.Now()),
 	}
@@ -259,6 +264,7 @@ type PodEvictor struct {
 	eventRecorder                    events.EventRecorder
 	erCache                          *evictionRequestsCache
 	featureGates                     featuregate.FeatureGate
+	workloadResolver                 WorkloadResolver
 
 	// registeredHandlers contains the registrations of all handlers. It's used to check if all handlers have finished syncing before the scheduling cycles start.
 	registeredHandlers []cache.ResourceEventHandlerRegistration
@@ -276,6 +282,11 @@ func NewPodEvictor(
 		options = NewOptions()
 	}
 
+	workloadResolver := options.workloadResolver
+	if workloadResolver == nil {
+		workloadResolver = defaultWorkloadResolver
+	}
+
 	podEvictor := &PodEvictor{
 		client:                           client,
 		eventRecorder:                    eventRecorder,
@@ -290,15 +301,13 @@ func NewPodEvictor(
 		nodePodCount:                     make(nodePodEvictedCount),
 		namespacePodCount:                make(namespacePodEvictCount),
 		featureGates:                     featureGates,
+		workloadResolver:                 workloadResolver,
 	}
 
 	if featureGates.Enabled(features.EvictionsInBackground) {
 		erCache := newEvictionRequestsCache(assumedEvictionRequestTimeoutSeconds)
-		if podEvictor.metricsEnabled {
-			erCache.onAssumedTimeout = func(item evictionRequestItem) {
-				metrics.PodsEvicted.With(map[string]string{"result": "error", "strategy": item.strategyName, "namespace": item.podNamespace, "node": item.podNodeName, "profile": item.profileName}).Inc()
-				metrics.PodsEvictedTotal.With(map[string]string{"result": "error", "strategy": item.strategyName, "namespace": item.podNamespace, "node": item.podNodeName, "profile": item.profileName}).Inc()
-			}
+		erCache.onAssumedTimeout = func(item evictionRequestItem) {
+			podEvictor.observeAssumedEviction(item, "error", "error", "background_eviction_timeout")
 		}
 
 		handlerRegistration, err := podInformer.AddEventHandler(
@@ -342,13 +351,12 @@ func NewPodEvictor(
 					if newPod.Status.Phase == v1.PodSucceeded || newPod.Status.Phase == v1.PodFailed {
 						if item, exists := erCache.getPod(newPod); exists {
 							klog.V(3).InfoS("Pod with eviction in background completed. Removing pod from the cache.", "pod", klog.KObj(newPod))
-							if item.evictionAssumed && podEvictor.metricsEnabled {
-								result := "success"
+							if item.evictionAssumed {
 								if newPod.Status.Phase == v1.PodFailed {
-									result = "error"
+									podEvictor.observeAssumedEviction(item, "error", "error", "background_eviction_failed")
+								} else {
+									podEvictor.observeAssumedEviction(item, "success", "success", "")
 								}
-								metrics.PodsEvicted.With(map[string]string{"result": result, "strategy": item.strategyName, "namespace": item.podNamespace, "node": item.podNodeName, "profile": item.profileName}).Inc()
-								metrics.PodsEvictedTotal.With(map[string]string{"result": result, "strategy": item.strategyName, "namespace": item.podNamespace, "node": item.podNodeName, "profile": item.profileName}).Inc()
 							}
 							erCache.deletePod(newPod)
 						}
@@ -396,9 +404,8 @@ func NewPodEvictor(
 					}
 					if item, exists := erCache.getPod(pod); exists {
 						klog.V(3).InfoS("Pod with eviction in background deleted/evicted. Removing pod from the cache.", "pod", klog.KObj(pod))
-						if item.evictionAssumed && podEvictor.metricsEnabled {
-							metrics.PodsEvicted.With(map[string]string{"result": "success", "strategy": item.strategyName, "namespace": item.podNamespace, "node": item.podNodeName, "profile": item.profileName}).Inc()
-							metrics.PodsEvictedTotal.With(map[string]string{"result": "success", "strategy": item.strategyName, "namespace": item.podNamespace, "node": item.podNodeName, "profile": item.profileName}).Inc()
+						if item.evictionAssumed {
+							podEvictor.observeAssumedEviction(item, "success", "success", "")
 						}
 					}
 					erCache.deletePod(pod)
@@ -504,6 +511,59 @@ type EvictOptions struct {
 	StrategyName string
 }
 
+// observeEviction records the outcome of one eviction attempt on all eviction
+// metrics. legacyResult preserves the historical result values of
+// pods_evicted and pods_evicted_total (which include raw error texts), while
+// result/reason carry the bounded values of pod_evictions_total.
+func (pe *PodEvictor) observeEviction(pod *v1.Pod, opts EvictOptions, legacyResult, result, reason string) {
+	if !pe.metricsEnabled {
+		return
+	}
+	workloadKind, workloadName := pe.workloadResolver(pod)
+	emitEvictionMetrics(pod.Namespace, pod.Spec.NodeName, opts.StrategyName, opts.ProfileName, workloadKind, workloadName, legacyResult, result, reason)
+}
+
+// observeAssumedEviction is the observeEviction counterpart for evictions in
+// background, where only the cached eviction request is available. It reuses
+// the workload resolved when the eviction was assumed, so all samples of one
+// background eviction report the same workload.
+func (pe *PodEvictor) observeAssumedEviction(item evictionRequestItem, legacyResult, result, reason string) {
+	if !pe.metricsEnabled {
+		return
+	}
+	emitEvictionMetrics(item.podNamespace, item.podNodeName, item.strategyName, item.profileName, item.workloadKind, item.workloadName, legacyResult, result, reason)
+}
+
+func emitEvictionMetrics(namespace, node, strategy, profile, workloadKind, workloadName, legacyResult, result, reason string) {
+	legacyLabels := map[string]string{"result": legacyResult, "strategy": strategy, "namespace": namespace, "node": node, "profile": profile}
+	metrics.PodsEvicted.With(legacyLabels).Inc()
+	metrics.PodsEvictedTotal.With(legacyLabels).Inc()
+	workloadKind, workloadName = workloadLabelValues(workloadKind, workloadName)
+	metrics.PodEvictionsTotal.With(map[string]string{
+		"namespace":     namespace,
+		"workload_kind": workloadKind,
+		"workload_name": workloadName,
+		"node":          node,
+		"strategy":      strategy,
+		"profile":       profile,
+		"result":        result,
+		"reason":        reason,
+	}).Inc()
+}
+
+// evictionErrorReason maps an eviction error to a bounded reason label value
+// so that the pod_evictions_total metric never carries arbitrary error text.
+func evictionErrorReason(err error) string {
+	switch {
+	case apierrors.IsTooManyRequests(err):
+		return "too_many_requests"
+	case apierrors.IsNotFound(err):
+		return "not_found"
+	default:
+		return "api_error"
+	}
+}
+
 // EvictPod evicts a pod while exercising eviction limits.
 // Returns true when the pod is evicted on the server side.
 func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptions) error {
@@ -531,10 +591,7 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 
 	if pe.maxPodsToEvictTotal != nil && pe.totalPodCount+pe.evictionRequestsTotal()+1 > *pe.maxPodsToEvictTotal {
 		err := NewEvictionTotalLimitError()
-		if pe.metricsEnabled {
-			metrics.PodsEvicted.With(map[string]string{"result": err.Error(), "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-			metrics.PodsEvictedTotal.With(map[string]string{"result": err.Error(), "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-		}
+		pe.observeEviction(pod, opts, err.Error(), "blocked", "total_limit_reached")
 		span.AddEvent("Eviction Failed", trace.WithAttributes(attribute.String("node", pod.Spec.NodeName), attribute.String("err", err.Error())))
 		klog.ErrorS(err, "Error evicting pod", "limit", *pe.maxPodsToEvictTotal)
 		if pe.evictionFailureEventNotification {
@@ -546,10 +603,7 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 	if pod.Spec.NodeName != "" {
 		if pe.maxPodsToEvictPerNode != nil && pe.nodePodCount[pod.Spec.NodeName]+pe.evictionRequestsPerNode(pod.Spec.NodeName)+1 > *pe.maxPodsToEvictPerNode {
 			err := NewEvictionNodeLimitError(pod.Spec.NodeName)
-			if pe.metricsEnabled {
-				metrics.PodsEvicted.With(map[string]string{"result": err.Error(), "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-				metrics.PodsEvictedTotal.With(map[string]string{"result": err.Error(), "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-			}
+			pe.observeEviction(pod, opts, err.Error(), "blocked", "node_limit_reached")
 			span.AddEvent("Eviction Failed", trace.WithAttributes(attribute.String("node", pod.Spec.NodeName), attribute.String("err", err.Error())))
 			klog.ErrorS(err, "Error evicting pod", "limit", *pe.maxPodsToEvictPerNode, "node", pod.Spec.NodeName)
 			if pe.evictionFailureEventNotification {
@@ -561,10 +615,7 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 
 	if pe.maxPodsToEvictPerNamespace != nil && pe.namespacePodCount[pod.Namespace]+pe.evictionRequestsPerNamespace(pod.Namespace)+1 > *pe.maxPodsToEvictPerNamespace {
 		err := NewEvictionNamespaceLimitError(pod.Namespace)
-		if pe.metricsEnabled {
-			metrics.PodsEvicted.With(map[string]string{"result": err.Error(), "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-			metrics.PodsEvictedTotal.With(map[string]string{"result": err.Error(), "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-		}
+		pe.observeEviction(pod, opts, err.Error(), "blocked", "namespace_limit_reached")
 		span.AddEvent("Eviction Failed", trace.WithAttributes(attribute.String("node", pod.Spec.NodeName), attribute.String("err", err.Error())))
 		klog.ErrorS(err, "Error evicting pod", "limit", *pe.maxPodsToEvictPerNamespace, "namespace", pod.Namespace, "pod", klog.KObj(pod))
 		if pe.evictionFailureEventNotification {
@@ -578,10 +629,7 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 		// err is used only for logging purposes
 		span.AddEvent("Eviction Failed", trace.WithAttributes(attribute.String("node", pod.Spec.NodeName), attribute.String("err", err.Error())))
 		klog.ErrorS(err, "Error evicting pod", "pod", klog.KObj(pod), "reason", opts.Reason)
-		if pe.metricsEnabled {
-			metrics.PodsEvicted.With(map[string]string{"result": "error", "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-			metrics.PodsEvictedTotal.With(map[string]string{"result": "error", "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-		}
+		pe.observeEviction(pod, opts, "error", "error", evictionErrorReason(err))
 		if pe.evictionFailureEventNotification {
 			pe.eventRecorder.Eventf(pod, nil, v1.EventTypeWarning, "EvictionFailed", "Descheduled", "pod eviction from %v node by sigs.k8s.io/descheduler failed: %v", pod.Spec.NodeName, err.Error())
 		}
@@ -598,10 +646,7 @@ func (pe *PodEvictor) EvictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 	pe.namespacePodCount[pod.Namespace]++
 	pe.totalPodCount++
 
-	if pe.metricsEnabled {
-		metrics.PodsEvicted.With(map[string]string{"result": "success", "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-		metrics.PodsEvictedTotal.With(map[string]string{"result": "success", "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-	}
+	pe.observeEviction(pod, opts, "success", "success", "")
 
 	if pe.dryRun {
 		klog.V(1).InfoS("Evicted pod in dry run mode", "pod", klog.KObj(pod), "reason", opts.Reason, "strategy", opts.StrategyName, "node", pod.Spec.NodeName, "profile", opts.ProfileName)
@@ -659,21 +704,22 @@ func (pe *PodEvictor) evictPod(ctx context.Context, pod *v1.Pod, opts EvictOptio
 					return true, nil
 				}
 				klog.V(3).InfoS("Eviction in background assumed", "pod", klog.KObj(pod))
-				pe.erCache.assumePod(pod, opts.ProfileName, opts.StrategyName)
+				var workloadKind, workloadName string
 				if pe.metricsEnabled {
-					metrics.PodsEvicted.With(map[string]string{"result": "background", "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
-					metrics.PodsEvictedTotal.With(map[string]string{"result": "background", "strategy": opts.StrategyName, "namespace": pod.Namespace, "node": pod.Spec.NodeName, "profile": opts.ProfileName}).Inc()
+					workloadKind, workloadName = pe.workloadResolver(pod)
+					emitEvictionMetrics(pod.Namespace, pod.Spec.NodeName, opts.StrategyName, opts.ProfileName, workloadKind, workloadName, "background", "background", "")
 				}
+				pe.erCache.assumePod(pod, opts.ProfileName, opts.StrategyName, workloadKind, workloadName)
 				return true, nil
 			}
 		}
 	}
 
 	if apierrors.IsTooManyRequests(err) {
-		return false, fmt.Errorf("error when evicting pod (ignoring) %q: %v", pod.Name, err)
+		return false, fmt.Errorf("error when evicting pod (ignoring) %q: %w", pod.Name, err)
 	}
 	if apierrors.IsNotFound(err) {
-		return false, fmt.Errorf("pod not found when evicting %q: %v", pod.Name, err)
+		return false, fmt.Errorf("pod not found when evicting %q: %w", pod.Name, err)
 	}
 	return false, err
 }

--- a/pkg/descheduler/evictions/options.go
+++ b/pkg/descheduler/evictions/options.go
@@ -13,6 +13,7 @@ type Options struct {
 	evictionFailureEventNotification bool
 	metricsEnabled                   bool
 	gracePeriodSeconds               *int64
+	workloadResolver                 WorkloadResolver
 }
 
 // NewOptions returns an Options with default values.
@@ -61,5 +62,10 @@ func (o *Options) WithEvictionFailureEventNotification(evictionFailureEventNotif
 	if evictionFailureEventNotification != nil {
 		o.evictionFailureEventNotification = *evictionFailureEventNotification
 	}
+	return o
+}
+
+func (o *Options) WithWorkloadResolver(workloadResolver WorkloadResolver) *Options {
+	o.workloadResolver = workloadResolver
 	return o
 }

--- a/pkg/descheduler/evictions/workload.go
+++ b/pkg/descheduler/evictions/workload.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evictions
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WorkloadResolver maps a pod to the (kind, name) of the workload owning it,
+// reported as the workload_kind/workload_name labels of the
+// descheduler_pod_evictions_total metric. Implementations must return stable,
+// bounded values (no per-pod or per-rollout generated names) and are expected
+// to be safe for concurrent use. Returning two empty strings means "no owning
+// workload"; the metric then reports a constant placeholder.
+type WorkloadResolver func(pod *v1.Pod) (kind, name string)
+
+// workloadNone is the workload kind/name reported for pods without a
+// resolvable owning workload (bare pods). A constant placeholder is used
+// instead of the pod name to keep the metric label cardinality bounded.
+const workloadNone = "<none>"
+
+// defaultWorkloadResolver reports the pod's direct controller. It is used when
+// no resolver is injected via WithWorkloadResolver. The descheduler injects a
+// resolver that additionally follows the ReplicaSet->Deployment and
+// Job->CronJob hops to keep generated intermediate-owner names out of the
+// metric.
+func defaultWorkloadResolver(pod *v1.Pod) (string, string) {
+	ref := metav1.GetControllerOf(pod)
+	if ref == nil {
+		return "", ""
+	}
+	return ref.Kind, ref.Name
+}
+
+// workloadLabelValues converts a resolver result to metric label values,
+// substituting the workloadNone placeholder for absent values.
+func workloadLabelValues(kind, name string) (string, string) {
+	if kind == "" {
+		kind = workloadNone
+	}
+	if name == "" {
+		name = workloadNone
+	}
+	return kind, name
+}

--- a/pkg/descheduler/evictions/workload_test.go
+++ b/pkg/descheduler/evictions/workload_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package evictions
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultWorkloadResolver(t *testing.T) {
+	isController := true
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		expectedKind string
+		expectedName string
+	}{
+		{
+			name: "controller owner is reported directly",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "db-0",
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "apps/v1", Kind: "StatefulSet", Name: "db", Controller: &isController},
+					},
+				},
+			},
+			expectedKind: "StatefulSet",
+			expectedName: "db",
+		},
+		{
+			name: "bare pod resolves to empty workload",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "lonely-pod"},
+			},
+			expectedKind: "",
+			expectedName: "",
+		},
+		{
+			name: "non-controller owner is ignored",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "owned-pod",
+					OwnerReferences: []metav1.OwnerReference{
+						{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "web-abc123"},
+					},
+				},
+			},
+			expectedKind: "",
+			expectedName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, name := defaultWorkloadResolver(tt.pod)
+			if kind != tt.expectedKind || name != tt.expectedName {
+				t.Errorf("defaultWorkloadResolver() = (%q, %q), want (%q, %q)", kind, name, tt.expectedKind, tt.expectedName)
+			}
+		})
+	}
+}
+
+func TestWorkloadLabelValues(t *testing.T) {
+	tests := []struct {
+		name         string
+		kind, rsName string
+		expectedKind string
+		expectedName string
+	}{
+		{
+			name:         "resolved workload is passed through",
+			kind:         "Deployment",
+			rsName:       "web",
+			expectedKind: "Deployment",
+			expectedName: "web",
+		},
+		{
+			name:         "absent workload maps to the placeholder",
+			kind:         "",
+			rsName:       "",
+			expectedKind: workloadNone,
+			expectedName: workloadNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, name := workloadLabelValues(tt.kind, tt.rsName)
+			if kind != tt.expectedKind || name != tt.expectedName {
+				t.Errorf("workloadLabelValues() = (%q, %q), want (%q, %q)", kind, name, tt.expectedKind, tt.expectedName)
+			}
+		})
+	}
+}

--- a/pkg/descheduler/kubeclientsandbox.go
+++ b/pkg/descheduler/kubeclientsandbox.go
@@ -95,15 +95,17 @@ type kubeClientSandbox struct {
 	podEvictionReactionFnc func(*fakeclientset.Clientset, *evictedPodsCache) func(action core.Action) (bool, runtime.Object, error)
 }
 
-func newDefaultKubeClientSandbox(client clientset.Interface, sharedInformerFactory informers.SharedInformerFactory) (*kubeClientSandbox, error) {
-	return newKubeClientSandbox(client, sharedInformerFactory,
+func newDefaultKubeClientSandbox(client clientset.Interface, sharedInformerFactory informers.SharedInformerFactory, extraResources ...schema.GroupVersionResource) (*kubeClientSandbox, error) {
+	resources := []schema.GroupVersionResource{
 		v1.SchemeGroupVersion.WithResource("pods"),
 		v1.SchemeGroupVersion.WithResource("nodes"),
 		v1.SchemeGroupVersion.WithResource("namespaces"),
 		schedulingv1.SchemeGroupVersion.WithResource("priorityclasses"),
 		policyv1.SchemeGroupVersion.WithResource("poddisruptionbudgets"),
 		v1.SchemeGroupVersion.WithResource("persistentvolumeclaims"),
-	)
+	}
+	resources = append(resources, extraResources...)
+	return newKubeClientSandbox(client, sharedInformerFactory, resources...)
 }
 
 func newKubeClientSandbox(client clientset.Interface, sharedInformerFactory informers.SharedInformerFactory, resources ...schema.GroupVersionResource) (*kubeClientSandbox, error) {

--- a/pkg/descheduler/workloadresolver.go
+++ b/pkg/descheduler/workloadresolver.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package descheduler
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	batchv1listers "k8s.io/client-go/listers/batch/v1"
+
+	"sigs.k8s.io/descheduler/pkg/descheduler/evictions"
+)
+
+// newWorkloadResolver returns the resolver used for the workload_kind and
+// workload_name labels of the pod_evictions_total metric.
+//
+// The pod's controller ownerRef is used directly for workloads that own pods
+// themselves (StatefulSet, DaemonSet, standalone Job, custom controllers).
+// Two intermediate owners with generated per-rollout/per-run names are
+// resolved one hop further to keep the label values stable and bounded:
+// apps ReplicaSet -> Deployment and batch Job -> CronJob. If the intermediate
+// object cannot be resolved (cache miss) or has no controller of its own
+// (orphan), the intermediate itself is reported.
+func newWorkloadResolver(replicaSetLister appsv1listers.ReplicaSetLister, jobLister batchv1listers.JobLister) evictions.WorkloadResolver {
+	return func(pod *v1.Pod) (string, string) {
+		ref := metav1.GetControllerOf(pod)
+		if ref == nil {
+			return "", ""
+		}
+		switch {
+		case ref.Kind == "ReplicaSet" && ownerRefGroup(ref) == appsv1.GroupName:
+			if rs, err := replicaSetLister.ReplicaSets(pod.Namespace).Get(ref.Name); err == nil {
+				if owner := metav1.GetControllerOf(rs); owner != nil {
+					return owner.Kind, owner.Name
+				}
+			}
+		case ref.Kind == "Job" && ownerRefGroup(ref) == batchv1.GroupName:
+			if job, err := jobLister.Jobs(pod.Namespace).Get(ref.Name); err == nil {
+				if owner := metav1.GetControllerOf(job); owner != nil {
+					return owner.Kind, owner.Name
+				}
+			}
+		}
+		return ref.Kind, ref.Name
+	}
+}
+
+func ownerRefGroup(ref *metav1.OwnerReference) string {
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return ""
+	}
+	return gv.Group
+}

--- a/pkg/descheduler/workloadresolver_test.go
+++ b/pkg/descheduler/workloadresolver_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package descheduler
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	batchv1listers "k8s.io/client-go/listers/batch/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func controllerRef(apiVersion, kind, name string) metav1.OwnerReference {
+	isController := true
+	return metav1.OwnerReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Name:       name,
+		Controller: &isController,
+	}
+}
+
+func podWithOwners(ns, name string, owners ...metav1.OwnerReference) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       ns,
+			Name:            name,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+func replicaSetWithOwners(ns, name string, owners ...metav1.OwnerReference) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       ns,
+			Name:            name,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+func jobWithOwners(ns, name string, owners ...metav1.OwnerReference) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       ns,
+			Name:            name,
+			OwnerReferences: owners,
+		},
+	}
+}
+
+func newReplicaSetLister(rss ...*appsv1.ReplicaSet) appsv1listers.ReplicaSetLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, rs := range rss {
+		_ = indexer.Add(rs)
+	}
+	return appsv1listers.NewReplicaSetLister(indexer)
+}
+
+func newJobLister(jobs ...*batchv1.Job) batchv1listers.JobLister {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	for _, job := range jobs {
+		_ = indexer.Add(job)
+	}
+	return batchv1listers.NewJobLister(indexer)
+}
+
+func TestWorkloadResolver(t *testing.T) {
+	tests := []struct {
+		name         string
+		pod          *v1.Pod
+		replicaSets  []*appsv1.ReplicaSet
+		jobs         []*batchv1.Job
+		expectedKind string
+		expectedName string
+	}{
+		{
+			name:         "deployment resolved through replicaset",
+			pod:          podWithOwners("default", "web-abc123-xyz", controllerRef("apps/v1", "ReplicaSet", "web-abc123")),
+			replicaSets:  []*appsv1.ReplicaSet{replicaSetWithOwners("default", "web-abc123", controllerRef("apps/v1", "Deployment", "web"))},
+			expectedKind: "Deployment",
+			expectedName: "web",
+		},
+		{
+			name:         "cronjob resolved through job",
+			pod:          podWithOwners("default", "mycron-28934712-xyz", controllerRef("batch/v1", "Job", "mycron-28934712")),
+			jobs:         []*batchv1.Job{jobWithOwners("default", "mycron-28934712", controllerRef("batch/v1", "CronJob", "mycron"))},
+			expectedKind: "CronJob",
+			expectedName: "mycron",
+		},
+		{
+			name:         "statefulset owns pod directly",
+			pod:          podWithOwners("default", "db-0", controllerRef("apps/v1", "StatefulSet", "db")),
+			expectedKind: "StatefulSet",
+			expectedName: "db",
+		},
+		{
+			name:         "daemonset owns pod directly",
+			pod:          podWithOwners("kube-system", "node-exporter-9f2", controllerRef("apps/v1", "DaemonSet", "node-exporter")),
+			expectedKind: "DaemonSet",
+			expectedName: "node-exporter",
+		},
+		{
+			name:         "bare pod with no controller",
+			pod:          podWithOwners("default", "lonely-pod"),
+			expectedKind: "",
+			expectedName: "",
+		},
+		{
+			name:         "replicaset missing from cache falls back to replicaset",
+			pod:          podWithOwners("default", "web-abc123-xyz", controllerRef("apps/v1", "ReplicaSet", "web-abc123")),
+			replicaSets:  nil,
+			expectedKind: "ReplicaSet",
+			expectedName: "web-abc123",
+		},
+		{
+			name:         "orphan replicaset without controller falls back to replicaset",
+			pod:          podWithOwners("default", "web-abc123-xyz", controllerRef("apps/v1", "ReplicaSet", "web-abc123")),
+			replicaSets:  []*appsv1.ReplicaSet{replicaSetWithOwners("default", "web-abc123")},
+			expectedKind: "ReplicaSet",
+			expectedName: "web-abc123",
+		},
+		{
+			name:         "standalone job without controller falls back to job",
+			pod:          podWithOwners("default", "migrate-xyz", controllerRef("batch/v1", "Job", "migrate")),
+			jobs:         []*batchv1.Job{jobWithOwners("default", "migrate")},
+			expectedKind: "Job",
+			expectedName: "migrate",
+		},
+		{
+			name:         "custom-group ReplicaSet kind is not resolved through the apps lister",
+			pod:          podWithOwners("default", "custom-pod", controllerRef("example.io/v1", "ReplicaSet", "web-abc123")),
+			replicaSets:  []*appsv1.ReplicaSet{replicaSetWithOwners("default", "web-abc123", controllerRef("apps/v1", "Deployment", "web"))},
+			expectedKind: "ReplicaSet",
+			expectedName: "web-abc123",
+		},
+		{
+			name:         "custom-group Job kind is not resolved through the batch lister",
+			pod:          podWithOwners("default", "custom-pod", controllerRef("example.io/v1", "Job", "mycron-28934712")),
+			jobs:         []*batchv1.Job{jobWithOwners("default", "mycron-28934712", controllerRef("batch/v1", "CronJob", "mycron"))},
+			expectedKind: "Job",
+			expectedName: "mycron-28934712",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolve := newWorkloadResolver(newReplicaSetLister(tt.replicaSets...), newJobLister(tt.jobs...))
+			kind, name := resolve(tt.pod)
+			if kind != tt.expectedKind || name != tt.expectedName {
+				t.Errorf("workload resolver returned (%q, %q), want (%q, %q)", kind, name, tt.expectedKind, tt.expectedName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Danila Bobkov <danila.bobkov@flant.com>

## Description

This PR adds a new metric `descheduler_pod_evictions_total` that attributes every pod eviction attempt to the **workload owning the pod**, so operators can answer "which Deployments/StatefulSets/CronJobs is the descheduler disrupting, and why" straight from Prometheus.

The existing `pods_evicted_total` aggregates by namespace/node/strategy/profile, which makes it impossible to attribute evictions to a workload; its `result` label also carries raw error strings for the limit-blocked cases. The new metric keeps a bounded, stable label set instead:

### Why a new metric instead of adding labels to `pods_evicted_total`

Adding labels to the existing metric would re-create every time series on upgrade (breaking `increase()` windows, recording rules and exact label matchers in existing alerts/dashboards), and would force the added cardinality on every user with no way to opt out. A separate metric can be dropped with a single `metric_relabel_configs` rule by anyone who does not need the workload dimension. This also follows the project's established migration pattern (`pods_evicted` → `pods_evicted_total`, `descheduler_loop_duration_seconds` → `loop_duration_seconds`): since the new metric is an informational superset of `pods_evicted_total` (the raw error texts map losslessly to `result="blocked"` + bounded `reason`), `pods_evicted_total` could be deprecated in its favor in a future release if maintainers find that direction reasonable.

### Workload resolution

The pod's controller ownerRef is used directly (StatefulSet, DaemonSet, custom controllers). Two intermediate owners with generated per-rollout/per-run names are resolved one hop further to keep label values stable and bounded:

- `apps` ReplicaSet → Deployment (a ReplicaSet name changes on every rollout),
- `batch` Job → CronJob (a CronJob mints a new Job name every scheduled run).

Both hops check the ownerRef API group, so a custom resource that happens to be named `ReplicaSet`/`Job` is never resolved through the wrong lister. On a cache miss or an orphan intermediate, the intermediate itself is reported. Bare pods report a constant `<none>` placeholder instead of the pod name, keeping cardinality bounded.


## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?