### PR TITLE
fix(nodeutilization): evict pods that tolerate destination taints via a broad toleration

### DIFF
--- a/pkg/utils/pod.go
+++ b/pkg/utils/pod.go
@@ -148,28 +148,24 @@ func PodRequestsAndLimits(pod *v1.Pod) (v1.ResourceList, v1.ResourceList) {
 // PodToleratesTaints returns true if a pod tolerates one node's taints
 func PodToleratesTaints(ctx context.Context, pod *v1.Pod, taintsOfNodes map[string][]v1.Taint) bool {
 	for nodeName, taintsForNode := range taintsOfNodes {
-		if len(pod.Spec.Tolerations) >= len(taintsForNode) {
+		// A single toleration can tolerate any number of taints (for example an
+		// Exists toleration with an empty key tolerates every taint), so we must
+		// always evaluate the tolerations against the taints rather than gating
+		// on the toleration/taint counts.
+		if TolerationsTolerateTaintsWithFilter(ctx, pod.Spec.Tolerations, taintsForNode, nil) {
+			return true
+		}
 
-			if TolerationsTolerateTaintsWithFilter(ctx, pod.Spec.Tolerations, taintsForNode, nil) {
-				return true
-			}
-
-			if klog.V(5).Enabled() {
-				for i := range taintsForNode {
-					if !TolerationsTolerateTaint(ctx, pod.Spec.Tolerations, &taintsForNode[i]) {
-						klog.V(5).InfoS("Pod doesn't tolerate node taint",
-							"pod", klog.KObj(pod),
-							"nodeName", nodeName,
-							"taint", fmt.Sprintf("%s:%s=%s", taintsForNode[i].Key, taintsForNode[i].Value, taintsForNode[i].Effect),
-						)
-					}
+		if klog.V(5).Enabled() {
+			for i := range taintsForNode {
+				if !TolerationsTolerateTaint(ctx, pod.Spec.Tolerations, &taintsForNode[i]) {
+					klog.V(5).InfoS("Pod doesn't tolerate node taint",
+						"pod", klog.KObj(pod),
+						"nodeName", nodeName,
+						"taint", fmt.Sprintf("%s:%s=%s", taintsForNode[i].Key, taintsForNode[i].Value, taintsForNode[i].Effect),
+					)
 				}
 			}
-		} else {
-			klog.V(5).InfoS("Pod doesn't tolerate nodes taint, count mismatch",
-				"pod", klog.KObj(pod),
-				"nodeName", nodeName,
-			)
 		}
 	}
 	return false

--- a/pkg/utils/pod_test.go
+++ b/pkg/utils/pod_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestPodToleratesTaints(t *testing.T) {
+	noScheduleTaint := func(key, value string) v1.Taint {
+		return v1.Taint{Key: key, Value: value, Effect: v1.TaintEffectNoSchedule}
+	}
+	existsToleration := func(key string) v1.Toleration {
+		return v1.Toleration{Key: key, Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule}
+	}
+
+	tests := []struct {
+		name          string
+		tolerations   []v1.Toleration
+		taintsOfNodes map[string][]v1.Taint
+		want          bool
+	}{
+		{
+			// Regression test: a single wildcard Exists toleration tolerates
+			// every taint, so it must tolerate a node carrying more taints than
+			// the pod has tolerations.
+			name:        "single wildcard Exists toleration tolerates a node with multiple taints",
+			tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},
+			taintsOfNodes: map[string][]v1.Taint{
+				"node1": {noScheduleTaint("gpu", "true"), noScheduleTaint("dedicated", "team-a")},
+			},
+			want: true,
+		},
+		{
+			name:        "no tolerations does not tolerate a tainted node",
+			tolerations: nil,
+			taintsOfNodes: map[string][]v1.Taint{
+				"node1": {noScheduleTaint("gpu", "true")},
+			},
+			want: false,
+		},
+		{
+			name:        "explicit tolerations cover every taint",
+			tolerations: []v1.Toleration{existsToleration("gpu"), existsToleration("dedicated")},
+			taintsOfNodes: map[string][]v1.Taint{
+				"node1": {noScheduleTaint("gpu", "true"), noScheduleTaint("dedicated", "team-a")},
+			},
+			want: true,
+		},
+		{
+			name:        "a single untolerated taint fails the node",
+			tolerations: []v1.Toleration{existsToleration("gpu")},
+			taintsOfNodes: map[string][]v1.Taint{
+				"node1": {noScheduleTaint("gpu", "true"), noScheduleTaint("dedicated", "team-a")},
+			},
+			want: false,
+		},
+		{
+			name:        "a node without taints is always tolerated",
+			tolerations: nil,
+			taintsOfNodes: map[string][]v1.Taint{
+				"node1": {},
+			},
+			want: true,
+		},
+		{
+			name:        "tolerated if any node in the set is tolerated",
+			tolerations: []v1.Toleration{existsToleration("gpu")},
+			taintsOfNodes: map[string][]v1.Taint{
+				"node1": {noScheduleTaint("gpu", "true"), noScheduleTaint("dedicated", "team-a")},
+				"node2": {noScheduleTaint("gpu", "true")},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &v1.Pod{Spec: v1.PodSpec{Tolerations: tt.tolerations}}
+			if got := PodToleratesTaints(context.Background(), pod, tt.taintsOfNodes); got != tt.want {
+				t.Errorf("PodToleratesTaints() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this does**

`PodToleratesTaints` decides, for a set of candidate destination nodes, whether a pod tolerates at least one of them. It does this by comparing the pod's tolerations to each node's taints — but only when:

```go
if len(pod.Spec.Tolerations) >= len(taintsForNode) {
```

That precondition isn't correct. A single toleration can tolerate any number of taints — an `Exists` toleration with an empty key tolerates *every* taint. So a pod with fewer tolerations than a node has taints is skipped by the guard and reported as not tolerating the node, even when it actually tolerates all of its taints.

The only caller is the Low/HighNodeUtilization eviction loop (`evictPods` in `pkg/framework/plugins/nodeutilization/nodeutilization.go`), which uses this to decide whether a pod can be moved to a destination node. The effect is that pods with a broad toleration are silently skipped whenever the destination nodes carry more taints than the pod has tolerations — so the plugins quietly stop rebalancing them.

**Repro**

- Destination (under-utilized) nodes tainted with two `NoSchedule` taints, e.g. `nvidia.com/gpu=:NoSchedule` and `dedicated=team-a:NoSchedule`.
- A pod on an over-utilized node with `tolerations: [{operator: Exists}]` (tolerates everything).

The guard evaluates `1 >= 2` → false → the real toleration check is skipped → the pod is treated as fitting nowhere and is never evicted, even though it fully tolerates the destination nodes.

**The fix**

Drop the count precondition and always evaluate the tolerations against the taints (which is what `TolerationsTolerateTaintsWithFilter` already does correctly, and matches how the scheduler reasons about tolerations). The verbose per-taint diagnostic logging is kept.

Added `TestPodToleratesTaints`, including the regression case above. It fails on `master` (`= false, want true`) and passes with this change.

**Which issue(s) this PR fixes**

None filed — found while reading the nodeutilization eviction path. Happy to open a tracking issue if maintainers prefer.