### PR TITLE
fix(nodeutilization): avoid appending onto a shared-cache pod's Containers slice

### DIFF
--- a/pkg/framework/plugins/nodeutilization/nodeutilization.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization.go
@@ -758,7 +758,7 @@ func assessAvailableResourceInNodes(
 // has a resource request specified for any of the given resources names.
 func withResourceRequestForAny(names ...v1.ResourceName) podutil.FilterFunc {
 	return func(pod *v1.Pod) bool {
-		all := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+		all := slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers)
 		for _, name := range names {
 			for _, container := range all {
 				if _, ok := container.Resources.Requests[name]; ok {

--- a/pkg/framework/plugins/nodeutilization/nodeutilization_test.go
+++ b/pkg/framework/plugins/nodeutilization/nodeutilization_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/descheduler/pkg/api"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/nodeutilization/classifier"
 	"sigs.k8s.io/descheduler/pkg/framework/plugins/nodeutilization/normalizer"
+	"sigs.k8s.io/descheduler/test"
 )
 
 func BuildTestNodeInfo(name string, apply func(*NodeInfo)) *NodeInfo {
@@ -575,5 +576,30 @@ func TestNormalizeAndClassify(t *testing.T) {
 				t.Fatalf("unexpected result: %v, expecting: %v", res, tt.expected)
 			}
 		})
+	}
+}
+
+func TestWithResourceRequestForAnyDoesNotMutateCachedPod(t *testing.T) {
+	// Pods handed to this filter come from the shared informer cache and must
+	// be treated as read-only. Build a Containers slice with spare capacity
+	// (len 2, cap 3) so an append through it would write into backing memory
+	// owned by the cached object rather than allocating.
+	backing := make([]v1.Container, 3)
+	backing[0] = v1.Container{Name: "app"}
+	backing[1] = v1.Container{Name: "sidecar"}
+	backing[2] = v1.Container{Name: "sentinel"}
+
+	pod := test.BuildTestPod("p1", 100, 0, "node1", func(pod *v1.Pod) {
+		pod.Spec.Containers = backing[:2]
+		pod.Spec.InitContainers = []v1.Container{{Name: "init"}}
+	})
+
+	withResourceRequestForAny(v1.ResourceCPU)(pod)
+
+	if backing[2].Name != "sentinel" {
+		t.Errorf("filter wrote through the pod's Containers slice into shared backing memory: got %q, want %q", backing[2].Name, "sentinel")
+	}
+	if len(pod.Spec.Containers) != 2 || pod.Spec.Containers[0].Name != "app" || pod.Spec.Containers[1].Name != "sidecar" {
+		t.Errorf("filter modified the pod's Containers slice: %v", pod.Spec.Containers)
 	}
 }


### PR DESCRIPTION
**What this does**

`withResourceRequestForAny` builds a combined container list with:

```go
all := append(pod.Spec.Containers, pod.Spec.InitContainers...)
```

The pods here come from the shared informer cache. When `cap(pod.Spec.Containers) > len(pod.Spec.Containers)`, `append` writes the init containers into the spare capacity of the cached slice's backing array — i.e. it mutates a shared cache object from inside what is meant to be a read-only filter. In the common case the slice has `len == cap` and `append` allocates, so it's latent, but it's the kind of aliasing bug that's hard to reproduce and easy to trip later.

This switches to `slices.Concat`, which always returns a fresh slice and never aliases its inputs. `slices` is already imported in this file.

**Which issue(s) this PR fixes**

None filed — noticed while reading the nodeutilization pod filters.