### PR TITLE
Always emit CronJob suspend in Helm chart when value is a bool

### DIFF
--- a/charts/descheduler/templates/cronjob.yaml
+++ b/charts/descheduler/templates/cronjob.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- end }}
 spec:
   schedule: {{ .Values.schedule | quote }}
-  {{- if .Values.suspend }}
+  {{- if kindIs "bool" .Values.suspend }}
   suspend: {{ .Values.suspend }}
   {{- end }}
   concurrencyPolicy: "Forbid"

--- a/charts/descheduler/tests/cronjob_test.yaml
+++ b/charts/descheduler/tests/cronjob_test.yaml
@@ -41,3 +41,19 @@ tests:
           path: spec.jobTemplate.spec.template.spec.schedulerName
       - notExists:
           path: spec.jobTemplate.spec.template.spec.runtimeClassName
+
+  - it: renders suspend false by default so GitOps can reconcile
+    template: templates/cronjob.yaml
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: false
+
+  - it: renders suspend true when set
+    template: templates/cronjob.yaml
+    set:
+      suspend: true
+    asserts:
+      - equal:
+          path: spec.suspend
+          value: true


### PR DESCRIPTION
## Summary
- CronJob Helm template used `{{- if .Values.suspend }}`, which skips `suspend: false` (Go template zero-value), so the field never appeared in the rendered manifest
- After an external `kubectl patch` set `suspend: true`, Helm/GitOps had nothing to reconcile against and could not restore `suspend: false`
- Emit `suspend` whenever the value is a bool (`kindIs bool`), matching the existing pattern for `automountServiceAccountToken`, and cover default `false` / `true` in helm-unittest

## Test plan
- [ ] `helm unittest charts/descheduler` (new CronJob suspend cases)
- [ ] `helm template` with default values shows `suspend: false`
- [ ] `helm template --set suspend=true` shows `suspend: true`
- [ ] Chart lint / Helm CI workflow green
