### PR TITLE
Fix LoggingAlphaOptions wiring

### DIFF
--- a/cmd/descheduler/app/server.go
+++ b/cmd/descheduler/app/server.go
@@ -28,13 +28,13 @@ import (
 
 	"sigs.k8s.io/descheduler/cmd/descheduler/app/options"
 	"sigs.k8s.io/descheduler/pkg/descheduler"
+	"sigs.k8s.io/descheduler/pkg/features"
 	"sigs.k8s.io/descheduler/pkg/tracing"
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
-	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	_ "k8s.io/component-base/logs/json/register"
@@ -49,7 +49,6 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 		klog.ErrorS(err, "unable to initialize server")
 	}
 
-	featureGate := featuregate.NewFeatureGate()
 	logConfig := logsapi.NewLoggingConfiguration()
 
 	cmd := &cobra.Command{
@@ -58,7 +57,10 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 		Long:  "The descheduler evicts pods which may be bound to less desired nodes",
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			logs.InitLogs()
-			if logsapi.ValidateAndApply(logConfig, featureGate); err != nil {
+			if err := features.DefaultMutableFeatureGate.SetFromMap(s.FeatureGates); err != nil {
+				return err
+			}
+			if err := logsapi.ValidateAndApply(logConfig, features.DefaultMutableFeatureGate); err != nil {
 				return err
 			}
 			descheduler.SetupPlugins()
@@ -80,9 +82,9 @@ func NewDeschedulerCommand(out io.Writer) *cobra.Command {
 	}
 	cmd.SetOut(out)
 	flags := cmd.Flags()
+	runtime.Must(logsapi.AddFeatureGates(features.DefaultMutableFeatureGate))
 	s.AddFlags(flags)
 
-	runtime.Must(logsapi.AddFeatureGates(featureGate))
 	logsapi.AddFlags(logConfig, flags)
 
 	return cmd

--- a/cmd/descheduler/app/server_test.go
+++ b/cmd/descheduler/app/server_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestNewDeschedulerCommand_LoggingAlphaOptions(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "LoggingAlphaOptions=false rejects --log-json-split-stream",
+			args: []string{
+				"--logging-format=json",
+				"--log-json-split-stream",
+				"--feature-gates=LoggingAlphaOptions=false",
+			},
+			wantErr: "LoggingAlphaOptions is disabled",
+		},
+		{
+			name: "LoggingAlphaOptions=true accepts --log-json-split-stream",
+			args: []string{
+				"--logging-format=json",
+				"--log-json-split-stream",
+				"--feature-gates=LoggingAlphaOptions=true",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := NewDeschedulerCommand(io.Discard)
+			if err := cmd.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags(%v): %v", tc.args, err)
+			}
+			err := cmd.PreRunE(cmd, cmd.Flags().Args())
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected PreRunE to succeed, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected PreRunE to fail with %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected PreRunE error to contain %q, got :%v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/docs/cli/descheduler.md
+++ b/docs/cli/descheduler.md
@@ -26,7 +26,10 @@ descheduler [flags]
       --feature-gates mapStringBool              A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                                  AllAlpha=true|false (ALPHA - default=false)
                                                  AllBeta=true|false (BETA - default=false)
+                                                 ContextualLogging=true|false (BETA - default=true)
                                                  EvictionsInBackground=true|false (ALPHA - default=false)
+                                                 LoggingAlphaOptions=true|false (ALPHA - default=false)
+                                                 LoggingBetaOptions=true|false (BETA - default=true)
   -h, --help                                     help for descheduler
       --http2-max-streams-per-connection int     The limit that the server gives to clients for the maximum number of streams in an HTTP/2 connection. Zero means to use golang's default.
       --kubeconfig string                        File with kube configuration. Deprecated, use client-connection-kubeconfig instead.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -46,4 +46,4 @@ var defaultDeschedulerFeatureGates = map[featuregate.Feature]featuregate.Feature
 // Tests that need to modify feature gates for the duration of their test should use:
 //
 //	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
-var DefaultMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+var DefaultMutableFeatureGate featuregate.MutableVersionedFeatureGate = featuregate.NewFeatureGate()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed -->
Using --feature-gates=LoggingAlphaOptions=true resulted in the descheduler not starting due to the feature gate not being recognised.

Partially addresses #1896

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?
