### PR TITLE
fix(node): Structure node condition logs

### DIFF
--- a/pkg/descheduler/node/node.go
+++ b/pkg/descheduler/node/node.go
@@ -95,6 +95,18 @@ func ReadyNodesFromInterfaces(nodeInterfaces []interface{}) ([]*v1.Node, error) 
 	return readyNodes, nil
 }
 
+// nodeConditionLog is the structured-log shape used for the "nodeCondition"
+// field. Nesting it under a single field prevents collisions with field names,
+// such as "status", that might be reserved by downstream log processors.
+type nodeConditionLog struct {
+	Type   v1.NodeConditionType `json:"type"`
+	Status v1.ConditionStatus   `json:"status"`
+}
+
+func newNodeConditionLog(cond *v1.NodeCondition) nodeConditionLog {
+	return nodeConditionLog{Type: cond.Type, Status: cond.Status}
+}
+
 // IsReady checks if the descheduler could run against given node.
 func IsReady(node *v1.Node) bool {
 	for i := range node.Status.Conditions {
@@ -104,19 +116,19 @@ func IsReady(node *v1.Node) bool {
 		// - NodeOutOfDisk condition status is ConditionFalse,
 		// - NodeNetworkUnavailable condition status is ConditionFalse.
 		if cond.Type == v1.NodeReady && cond.Status != v1.ConditionTrue {
-			klog.V(1).InfoS("Ignoring node", "node", klog.KObj(node), "condition", cond.Type, "status", cond.Status)
+			klog.V(4).InfoS("Ignoring node", "node", klog.KObj(node), "nodeCondition", newNodeConditionLog(cond))
 			return false
 		} /*else if cond.Type == v1.NodeOutOfDisk && cond.Status != v1.ConditionFalse {
-			klog.V(4).InfoS("Ignoring node with condition status", "node", klog.KObj(node.Name), "condition", cond.Type, "status", cond.Status)
+			klog.V(4).InfoS("Ignoring node with condition status", "node", klog.KObj(node), "nodeCondition", newNodeConditionLog(cond))
 			return false
 		} else if cond.Type == v1.NodeNetworkUnavailable && cond.Status != v1.ConditionFalse {
-			klog.V(4).InfoS("Ignoring node with condition status", "node", klog.KObj(node.Name), "condition", cond.Type, "status", cond.Status)
+			klog.V(4).InfoS("Ignoring node with condition status", "node", klog.KObj(node), "nodeCondition", newNodeConditionLog(cond))
 			return false
 		}*/
 	}
 	// Ignore nodes that are marked unschedulable
 	/*if node.Spec.Unschedulable {
-		klog.V(4).InfoS("Ignoring node since it is unschedulable", "node", klog.KObj(node.Name))
+		klog.V(4).InfoS("Ignoring node since it is unschedulable", "node", klog.KObj(node))
 		return false
 	}*/
 	return true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change and which issue is fixed -->
The "status" field is reserved by some log processors, so nest it under a "nodeCondition" field. In addition, reduce the log severity from 1 -> 4 because on very large clusters this can cause a lot of log noise/increased logging expense due to high rate of node churn.

For #1896

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?

Note: Backward Compatibility: This is technically backward incompatible depending on how users are consuming/querying logs as it'll change the log structure/log level for a single log line/entry. If you're happy with that then perhaps I should add an entry to the Changelog calling it out?