### PR TITLE
refactor(e2e): centralize kubevirt version from go.mod

### DIFF
--- a/test/e2e/e2e_evictioninbackground_test.go
+++ b/test/e2e/e2e_evictioninbackground_test.go
@@ -77,7 +77,7 @@ func virtualMachineInstance(idx int, namespace string) *kvcorev1.VirtualMachineI
 					Name: "containerdisk",
 					VolumeSource: kvcorev1.VolumeSource{
 						ContainerDisk: &kvcorev1.ContainerDiskSource{
-							Image: "quay.io/kubevirt/cirros-container-disk-demo:v1.9.0",
+							Image: kubevirtCirrosContainerDiskImage(),
 						},
 					},
 				},
@@ -484,6 +484,10 @@ func waitForVMIEvictionsWithNoLimits(t *testing.T, ctx context.Context, kubeClie
 }
 
 func TestLiveMigrationInBackground(t *testing.T) {
+	if *kubevirtVersionTag == "" {
+		t.Fatal("--kubevirt-version-tag must be set for KubeVirt e2e tests")
+	}
+
 	initPluginRegistry()
 
 	ctx := context.Background()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -68,10 +68,15 @@ import (
 )
 
 var (
-	deschedulerImage = flag.String("descheduler-image", "", "descheduler image to set in the pod spec")
-	podRunAsUserId   = flag.Int64("pod-run-as-user-id", 0, ".spec.securityContext.runAsUser setting, not set if 0")
-	podRunAsGroupId  = flag.Int64("pod-run-as-group-id", 0, ".spec.securityContext.runAsGroup setting, not set if 0")
+	deschedulerImage   = flag.String("descheduler-image", "", "descheduler image to set in the pod spec")
+	kubevirtVersionTag = flag.String("kubevirt-version-tag", "", "KubeVirt release tag for container disk images in KubeVirt e2e tests (e.g. v1.9.0)")
+	podRunAsUserId     = flag.Int64("pod-run-as-user-id", 0, ".spec.securityContext.runAsUser setting, not set if 0")
+	podRunAsGroupId    = flag.Int64("pod-run-as-group-id", 0, ".spec.securityContext.runAsGroup setting, not set if 0")
 )
+
+func kubevirtCirrosContainerDiskImage() string {
+	return fmt.Sprintf("quay.io/kubevirt/cirros-container-disk-demo:%s", *kubevirtVersionTag)
+}
 
 func TestMain(m *testing.M) {
 	flag.Parse()

--- a/test/run-e2e-tests.sh
+++ b/test/run-e2e-tests.sh
@@ -27,12 +27,12 @@ KIND_VERSION=${KIND_VERSION:-v0.31.0}
 SKIP_KUBECTL_INSTALL=${SKIP_KUBECTL_INSTALL:-}
 SKIP_KIND_INSTALL=${SKIP_KIND_INSTALL:-}
 SKIP_KUBEVIRT_INSTALL=${SKIP_KUBEVIRT_INSTALL:-}
-KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v1.9.0}
 K8S_VERSION=${KUBERNETES_VERSION:-}
 
 # Build a descheduler image
 IMAGE_TAG=v$(date +%Y%m%d)-$(git describe --tags)
 BASEDIR=$(dirname "$0")
+KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-$(grep 'kubevirt.io/api ' "${BASEDIR}/../go.mod" | awk '{print $2}')}
 VERSION="${IMAGE_TAG}" make -C ${BASEDIR}/.. image
 
 export DESCHEDULER_IMAGE="docker.io/library/descheduler:${IMAGE_TAG}"
@@ -115,4 +115,4 @@ kubectl patch -n kube-system deployment metrics-server --type=json \
 kubectl wait --timeout=180s --for=condition=Available -n kube-system deployment/metrics-server
 
 PRJ_PREFIX="sigs.k8s.io/descheduler"
-go test ${PRJ_PREFIX}/test/e2e/ -v -timeout 0 --args --descheduler-image ${DESCHEDULER_IMAGE} --pod-run-as-user-id 1000 --pod-run-as-group-id 1000
+go test ${PRJ_PREFIX}/test/e2e/ -v -timeout 0 --args --descheduler-image ${DESCHEDULER_IMAGE} --kubevirt-version-tag ${KUBEVIRT_VERSION} --pod-run-as-user-id 1000 --pod-run-as-group-id 1000


### PR DESCRIPTION
## Description

Centralizes the KubeVirt version used in e2e tests so it is not duplicated across `go.mod`, `test/run-e2e-tests.sh`, and test fixtures.

- `test/run-e2e-tests.sh` derives `KUBEVIRT_VERSION` from `go.mod` (`kubevirt.io/api`) when unset
- Passes `--kubevirt-version-tag` to e2e tests for KubeVirt container disk images
- `TestLiveMigrationInBackground` requires the flag so the cirros image tag stays aligned with the installed KubeVirt release

Depends on #1910. Rebase onto `master` after #1910 merges so this PR only contains the centralization commit.

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [ ] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?

## Test plan

- [ ] CI e2e after #1910 merges and this branch is rebased onto `master`