### PR TITLE
fix(test/e2e): make the tests more resilient when running with different container runtime/worker nodes size

### DIFF
--- a/kubernetes/base/rbac.yaml
+++ b/kubernetes/base/rbac.yaml
@@ -43,6 +43,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: descheduler-role
+  namespace: kube-system
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -71,6 +72,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: descheduler-role-binding
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/test/e2e/e2e_duplicatepods_test.go
+++ b/test/e2e/e2e_duplicatepods_test.go
@@ -91,6 +91,7 @@ func TestRemoveDuplicates(t *testing.T) {
 	}
 
 	_, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
+	lenWorkerNodes := len(workerNodes)
 
 	t.Log("Creating testing namespace")
 	testNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-" + strings.ToLower(t.Name())}}
@@ -101,24 +102,27 @@ func TestRemoveDuplicates(t *testing.T) {
 
 	t.Log("Creating duplicates pods")
 	testLabel := map[string]string{"app": "test-duplicate", "name": "test-duplicatePods"}
-	deploymentObj := buildTestDeployment("duplicate-pod", testNamespace.Name, 0, testLabel, nil)
 
 	tests := []struct {
 		name                    string
 		replicasNum             int
-		beforeFunc              func(deployment *appsv1.Deployment)
+		deploymentObj           *appsv1.Deployment
 		expectedEvictedPodCount int
 		removeDuplicatesArgs    *removeduplicates.RemoveDuplicatesArgs
 		evictorArgs             *defaultevictor.DefaultEvictorArgs
 	}{
 		{
 			name:        "Evict Pod even Pods schedule to specific node",
-			replicasNum: 4,
-			beforeFunc: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Replicas = utilptr.To[int32](4)
+			replicasNum: lenWorkerNodes * 2, // invariant: upper avg=2
+			deploymentObj: buildTestDeployment("duplicate-pod", testNamespace.Name, 0, testLabel, func(deployment *appsv1.Deployment) {
+				deployment.Spec.Replicas = utilptr.To(int32(lenWorkerNodes * 2))
 				deployment.Spec.Template.Spec.NodeName = workerNodes[0].Name
-			},
-			expectedEvictedPodCount: 2,
+			}),
+			// 1. all pods are scheduled to the same node
+			// 2. the number of duplicates is always replicasNum - 1
+			// 3. the number of evicted pods is always all the duplicates except the first one
+			// Thus, replicasNum - 2
+			expectedEvictedPodCount: lenWorkerNodes*2 - 2,
 			removeDuplicatesArgs:    &removeduplicates.RemoveDuplicatesArgs{},
 			evictorArgs: &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods: true,
@@ -127,9 +131,10 @@ func TestRemoveDuplicates(t *testing.T) {
 		},
 		{
 			name:        "Evict Pod even Pods with local storage",
-			replicasNum: 5,
-			beforeFunc: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Replicas = utilptr.To[int32](5)
+			replicasNum: lenWorkerNodes * 2, // invariant: upper avg=2
+			deploymentObj: buildTestDeployment("duplicate-pod", testNamespace.Name, 0, testLabel, func(deployment *appsv1.Deployment) {
+				deployment.Spec.Replicas = utilptr.To(int32(lenWorkerNodes * 2))
+				deployment.Spec.Template.Spec.NodeName = workerNodes[0].Name
 				deployment.Spec.Template.Spec.Volumes = []v1.Volume{
 					{
 						Name: "sample",
@@ -140,8 +145,12 @@ func TestRemoveDuplicates(t *testing.T) {
 						},
 					},
 				}
-			},
-			expectedEvictedPodCount: 2,
+			}),
+			// 1. all pods are scheduled to the same node
+			// 2. the number of duplicates is always replicasNum - 1
+			// 3. the number of evicted pods is always all the duplicates except the first one
+			// Thus, replicasNum - 2
+			expectedEvictedPodCount: lenWorkerNodes*2 - 2,
 			removeDuplicatesArgs:    &removeduplicates.RemoveDuplicatesArgs{},
 			evictorArgs: &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods: true,
@@ -149,39 +158,43 @@ func TestRemoveDuplicates(t *testing.T) {
 			},
 		},
 		{
-			name:        "Ignores eviction with minReplicas of 4",
-			replicasNum: 3,
-			beforeFunc: func(deployment *appsv1.Deployment) {
-				deployment.Spec.Replicas = utilptr.To[int32](3)
-			},
+			name:        "Ignores eviction with minReplicas",
+			replicasNum: lenWorkerNodes * 2, // invariant: upper avg=2
+			deploymentObj: buildTestDeployment("duplicate-pod", testNamespace.Name, 0, testLabel, func(deployment *appsv1.Deployment) {
+				deployment.Spec.Replicas = utilptr.To(int32(lenWorkerNodes * 2))
+				deployment.Spec.Template.Spec.NodeName = workerNodes[0].Name
+			}),
+			// 1. all pods are scheduled to the same node
+			// 2. the number of duplicates is always replicasNum - 1
+			// 3. the number of evicted pods is always all the duplicates except the first one
+			// Thus, replicasNum - 2
 			expectedEvictedPodCount: 0,
 			removeDuplicatesArgs:    &removeduplicates.RemoveDuplicatesArgs{},
 			evictorArgs: &defaultevictor.DefaultEvictorArgs{
 				EvictLocalStoragePods: true,
-				MinReplicas:           4,
+				MinReplicas:           uint(lenWorkerNodes*2 + 1),
 			},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Logf("Creating deployment %v in %v namespace", deploymentObj.Name, deploymentObj.Namespace)
-			tc.beforeFunc(deploymentObj)
+			t.Logf("Creating deployment %v in %v namespace", tc.deploymentObj.Name, tc.deploymentObj.Namespace)
 
-			_, err = clientSet.AppsV1().Deployments(deploymentObj.Namespace).Create(ctx, deploymentObj, metav1.CreateOptions{})
+			_, err = clientSet.AppsV1().Deployments(tc.deploymentObj.Namespace).Create(ctx, tc.deploymentObj, metav1.CreateOptions{})
 			if err != nil {
 				t.Logf("Error creating deployment: %v", err)
-				if err = clientSet.AppsV1().Deployments(deploymentObj.Namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
-					LabelSelector: labels.SelectorFromSet(deploymentObj.Labels).String(),
+				if err = clientSet.AppsV1().Deployments(tc.deploymentObj.Namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{
+					LabelSelector: labels.SelectorFromSet(tc.deploymentObj.Labels).String(),
 				}); err != nil {
 					t.Fatalf("Unable to delete deployment: %v", err)
 				}
 				return
 			}
 			defer func() {
-				clientSet.AppsV1().Deployments(deploymentObj.Namespace).Delete(ctx, deploymentObj.Name, metav1.DeleteOptions{})
-				waitForPodsToDisappear(ctx, t, clientSet, deploymentObj.Labels, deploymentObj.Namespace)
+				clientSet.AppsV1().Deployments(tc.deploymentObj.Namespace).Delete(ctx, tc.deploymentObj.Name, metav1.DeleteOptions{})
+				waitForPodsToDisappear(ctx, t, clientSet, tc.deploymentObj.Labels, tc.deploymentObj.Namespace)
 			}()
-			waitForPodsRunning(ctx, t, clientSet, deploymentObj.Labels, tc.replicasNum, deploymentObj.Namespace)
+			waitForPodsRunning(ctx, t, clientSet, tc.deploymentObj.Labels, tc.replicasNum, tc.deploymentObj.Namespace)
 
 			preRunNames := sets.NewString(getCurrentPodNames(ctx, clientSet, testNamespace.Name, t)...)
 

--- a/test/e2e/e2e_failedpods_test.go
+++ b/test/e2e/e2e_failedpods_test.go
@@ -181,6 +181,7 @@ func initFailedJob(name, namespace string) *batchv1.Job {
 	podSpec := makePodSpec("", nil)
 	podSpec.Containers[0].Command = []string{"/bin/false"}
 	podSpec.RestartPolicy = v1.RestartPolicyNever
+	podSpec.Containers[0].Image = "registry.k8s.io/e2e-test-images/busybox:1.36.1-1"
 	labelsSet := labels.Set{"test": name, "name": name}
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/e2e_podlifetime_test.go
+++ b/test/e2e/e2e_podlifetime_test.go
@@ -204,6 +204,7 @@ func TestPodLifeTime_SucceededPods(t *testing.T) {
 
 func initTransitionTestJob(name, namespace string) *batchv1.Job {
 	podSpec := makePodSpec("", nil)
+	podSpec.Containers[0].Image = "registry.k8s.io/e2e-test-images/busybox:1.36.1-1"
 	podSpec.Containers[0].Command = []string{"/bin/false"}
 	podSpec.RestartPolicy = v1.RestartPolicyNever
 	labelsSet := labels.Set{"test": name, "name": name}

--- a/test/e2e/e2e_podswithpvc_test.go
+++ b/test/e2e/e2e_podswithpvc_test.go
@@ -261,6 +261,7 @@ func TestProtectPodsWithPVC(t *testing.T) {
 				4,
 				map[string]string{"test": "restart-pod", "name": "test-toomanyrestarts"},
 				func(deployment *appsv1.Deployment) {
+					deployment.Spec.Template.Spec.Containers[0].Image = "registry.k8s.io/e2e-test-images/busybox:1.36.1-1"
 					deployment.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh"}
 					deployment.Spec.Template.Spec.Containers[0].Args = []string{"-c", "sleep 1s && exit 1"}
 				},

--- a/test/e2e/e2e_toomanyrestarts_test.go
+++ b/test/e2e/e2e_toomanyrestarts_test.go
@@ -105,6 +105,7 @@ func TestTooManyRestarts(t *testing.T) {
 	defer clientSet.CoreV1().Namespaces().Delete(ctx, testNamespace.Name, metav1.DeleteOptions{})
 
 	deploymentObj := buildTestDeployment("restart-pod", testNamespace.Name, deploymentReplicas, map[string]string{"test": "restart-pod", "name": "test-toomanyrestarts"}, func(deployment *appsv1.Deployment) {
+		deployment.Spec.Template.Spec.Containers[0].Image = "registry.k8s.io/e2e-test-images/busybox:1.36.1-1"
 		deployment.Spec.Template.Spec.Containers[0].Command = []string{"/bin/sh"}
 		deployment.Spec.Template.Spec.Containers[0].Args = []string{"-c", "sleep 1s && exit 1"}
 	})

--- a/test/e2e/e2e_topologyspreadconstraint_test.go
+++ b/test/e2e/e2e_topologyspreadconstraint_test.go
@@ -77,6 +77,8 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		t.Errorf("Error listing node with %v", err)
 	}
 	_, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
+	lenWorkerNodes := len(workerNodes)
+
 	t.Log("Creating testing namespace")
 	testNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-" + strings.ToLower(t.Name())}}
 	if _, err := clientSet.CoreV1().Namespaces().Create(ctx, testNamespace, metav1.CreateOptions{}); err != nil {
@@ -93,7 +95,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		{
 			name:                    "test-topology-spread-hard-constraint",
 			expectedEvictedPodCount: 1,
-			replicaCount:            4,
+			replicaCount:            lenWorkerNodes * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -108,7 +110,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		{
 			name:                    "test-topology-spread-soft-constraint",
 			expectedEvictedPodCount: 1,
-			replicaCount:            4,
+			replicaCount:            lenWorkerNodes * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -123,7 +125,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		{
 			name:                    "test-node-taints-policy-honor",
 			expectedEvictedPodCount: 1,
-			replicaCount:            4,
+			replicaCount:            lenWorkerNodes * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -139,7 +141,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		{
 			name:                    "test-node-affinity-policy-ignore",
 			expectedEvictedPodCount: 1,
-			replicaCount:            4,
+			replicaCount:            lenWorkerNodes * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -155,7 +157,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		{
 			name:                    "test-match-label-keys",
 			expectedEvictedPodCount: 0,
-			replicaCount:            4,
+			replicaCount:            lenWorkerNodes * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{

--- a/test/e2e/e2e_topologyspreadconstraint_test.go
+++ b/test/e2e/e2e_topologyspreadconstraint_test.go
@@ -79,6 +79,31 @@ func TestTopologySpreadConstraint(t *testing.T) {
 	_, workerNodes := splitNodesAndWorkerNodes(nodeList.Items)
 	lenWorkerNodes := len(workerNodes)
 
+	// Count unique zones among worker nodes
+	uniqueZones := sets.NewString()
+	for _, node := range workerNodes {
+		if zone, ok := node.Labels[zoneTopologyKey]; ok {
+			uniqueZones.Insert(zone)
+		}
+	}
+	numZones := uniqueZones.Len()
+
+	// Determine topology key and domain count based on cluster topology
+	var topologyKey string
+	var numDomains int
+
+	if numZones >= 2 {
+		// Multi-zone cluster: use zones as topology domain
+		topologyKey = zoneTopologyKey
+		numDomains = numZones
+		t.Logf("Found %d worker nodes in %d unique zones, using zone topology", lenWorkerNodes, numZones)
+	} else {
+		// Single-zone or no-zone cluster: fall back to node topology
+		topologyKey = v1.LabelHostname
+		numDomains = lenWorkerNodes
+		t.Logf("Found %d worker nodes in %d zone(s), falling back to node (hostname) topology", lenWorkerNodes, numZones)
+	}
+
 	t.Log("Creating testing namespace")
 	testNamespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-" + strings.ToLower(t.Name())}}
 	if _, err := clientSet.CoreV1().Namespaces().Create(ctx, testNamespace, metav1.CreateOptions{}); err != nil {
@@ -95,7 +120,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 		{
 			name:                    "test-topology-spread-hard-constraint",
 			expectedEvictedPodCount: 1,
-			replicaCount:            lenWorkerNodes * 2,
+			replicaCount:            numDomains * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -103,14 +128,14 @@ func TestTopologySpreadConstraint(t *testing.T) {
 					},
 				},
 				MaxSkew:           1,
-				TopologyKey:       zoneTopologyKey,
+				TopologyKey:       topologyKey,
 				WhenUnsatisfiable: v1.DoNotSchedule,
 			},
 		},
 		{
 			name:                    "test-topology-spread-soft-constraint",
 			expectedEvictedPodCount: 1,
-			replicaCount:            lenWorkerNodes * 2,
+			replicaCount:            numDomains * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -118,14 +143,14 @@ func TestTopologySpreadConstraint(t *testing.T) {
 					},
 				},
 				MaxSkew:           1,
-				TopologyKey:       zoneTopologyKey,
+				TopologyKey:       topologyKey,
 				WhenUnsatisfiable: v1.ScheduleAnyway,
 			},
 		},
 		{
 			name:                    "test-node-taints-policy-honor",
 			expectedEvictedPodCount: 1,
-			replicaCount:            lenWorkerNodes * 2,
+			replicaCount:            numDomains * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -134,30 +159,30 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				},
 				MaxSkew:           1,
 				NodeTaintsPolicy:  nodeInclusionPolicyRef(v1.NodeInclusionPolicyHonor),
-				TopologyKey:       zoneTopologyKey,
+				TopologyKey:       topologyKey,
 				WhenUnsatisfiable: v1.DoNotSchedule,
 			},
 		},
 		{
 			name:                    "test-node-affinity-policy-ignore",
 			expectedEvictedPodCount: 1,
-			replicaCount:            lenWorkerNodes * 2,
+			replicaCount:            numDomains * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"test": "node-taints-policy-honor",
+						"test": "node-affinity-policy-ignore",
 					},
 				},
 				MaxSkew:            1,
 				NodeAffinityPolicy: nodeInclusionPolicyRef(v1.NodeInclusionPolicyIgnore),
-				TopologyKey:        zoneTopologyKey,
+				TopologyKey:        topologyKey,
 				WhenUnsatisfiable:  v1.DoNotSchedule,
 			},
 		},
 		{
 			name:                    "test-match-label-keys",
 			expectedEvictedPodCount: 0,
-			replicaCount:            lenWorkerNodes * 2,
+			replicaCount:            numDomains * 2,
 			topologySpreadConstraint: v1.TopologySpreadConstraint{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -166,7 +191,7 @@ func TestTopologySpreadConstraint(t *testing.T) {
 				},
 				MatchLabelKeys:    []string{appsv1.DefaultDeploymentUniqueLabelKey},
 				MaxSkew:           1,
-				TopologyKey:       zoneTopologyKey,
+				TopologyKey:       topologyKey,
 				WhenUnsatisfiable: v1.DoNotSchedule,
 			},
 		},
@@ -178,6 +203,22 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			deployLabels["name"] = tc.name
 			deployment := buildTestDeployment(tc.name, testNamespace.Name, int32(tc.replicaCount), deployLabels, func(d *appsv1.Deployment) {
 				d.Spec.Template.Spec.TopologySpreadConstraints = []v1.TopologySpreadConstraint{tc.topologySpreadConstraint}
+				// Add tolerations so pods can be scheduled and rescheduled on all nodes (in case some of them are tainted)
+				d.Spec.Template.Spec.Tolerations = []v1.Toleration{
+					{Operator: v1.TolerationOpExists},
+				}
+				d.Spec.Template.Spec.Affinity = &v1.Affinity{
+					NodeAffinity: &v1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+							NodeSelectorTerms: []v1.NodeSelectorTerm{{
+								MatchExpressions: []v1.NodeSelectorRequirement{{
+									Key:      "node-role.kubernetes.io/control-plane",
+									Operator: v1.NodeSelectorOpDoesNotExist,
+								}},
+							}},
+						},
+					},
+				}
 			})
 			if _, err := clientSet.AppsV1().Deployments(deployment.Namespace).Create(ctx, deployment, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Error creating Deployment %s %v", tc.name, err)
@@ -188,12 +229,16 @@ func TestTopologySpreadConstraint(t *testing.T) {
 			}()
 			waitForPodsRunning(ctx, t, clientSet, deployment.Labels, tc.replicaCount, deployment.Namespace)
 
-			// Create a "Violator" Deployment that has the same label and is forced to be on the same node using a nodeSelector
+			// Create a "Violator" Deployment that has the same label and is forced to be on the same topology domain
 			violatorDeploymentName := tc.name + "-violator"
 			violatorDeployLabels := tc.topologySpreadConstraint.LabelSelector.DeepCopy().MatchLabels
 			violatorDeployLabels["name"] = violatorDeploymentName
 			violatorDeployment := buildTestDeployment(violatorDeploymentName, testNamespace.Name, tc.topologySpreadConstraint.MaxSkew+1, violatorDeployLabels, func(d *appsv1.Deployment) {
-				d.Spec.Template.Spec.NodeSelector = map[string]string{zoneTopologyKey: workerNodes[0].Labels[zoneTopologyKey]}
+				d.Spec.Template.Spec.NodeSelector = map[string]string{topologyKey: workerNodes[0].Labels[topologyKey]}
+				// Add tolerations so violator pods can be scheduled on all nodes (in case some of them are tainted)
+				d.Spec.Template.Spec.Tolerations = []v1.Toleration{
+					{Operator: v1.TolerationOpExists},
+				}
 			})
 			if _, err := clientSet.AppsV1().Deployments(violatorDeployment.Namespace).Create(ctx, violatorDeployment, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("Error creating Deployment %s: %v", violatorDeployment.Name, err)
@@ -264,19 +309,28 @@ func TestTopologySpreadConstraint(t *testing.T) {
 					t.Errorf("Error listing pods for %s: %v", tc.name, err)
 				}
 
-				nodePodCountMap := make(map[string]int)
-				for _, pod := range pods.Items {
-					nodePodCountMap[pod.Spec.NodeName]++
+				topologyPodCountMap := make(map[string]int)
+				nodeMap := make(map[string]*v1.Node)
+				for _, node := range workerNodes {
+					nodeMap[node.Name] = node
 				}
 
-				if len(nodePodCountMap) != len(workerNodes) {
-					t.Errorf("%s Pods were scheduled on only '%d' nodes and were not properly distributed on the nodes", tc.name, len(nodePodCountMap))
+				for _, pod := range pods.Items {
+					if node, ok := nodeMap[pod.Spec.NodeName]; ok {
+						if topologyValue, ok := node.Labels[topologyKey]; ok {
+							topologyPodCountMap[topologyValue]++
+						}
+					}
+				}
+
+				if len(topologyPodCountMap) != numDomains {
+					t.Logf("%s Pods were scheduled in only '%d' topology domains (expected %d domains) and were not properly distributed", tc.name, len(topologyPodCountMap), numDomains)
 					return false, nil
 				}
 
-				skewVal = getSkewValPodDistribution(nodePodCountMap)
+				skewVal = getSkewValPodDistribution(topologyPodCountMap)
 				if skewVal > int(tc.topologySpreadConstraint.MaxSkew) {
-					t.Errorf("Pod distribution for %s is still violating the max skew of %d as it is %d", tc.name, tc.topologySpreadConstraint.MaxSkew, skewVal)
+					t.Logf("Pod distribution for %s is still violating the max skew of %d as it is %d", tc.name, tc.topologySpreadConstraint.MaxSkew, skewVal)
 					return false, nil
 				}
 


### PR DESCRIPTION
## Description

- Some tests fail when run over 3 worker nodes cluster.
- pause image: depending on the container runtime a pod with a non-existing command may get stuck in Pending and not in Failed state.

## Checklist
Please ensure your pull request meets the following criteria before submitting
for review, these items will be used by reviewers to assess the quality and
completeness of your changes:

- [x] **Code Readability**: Is the code easy to understand, well-structured, and consistent with project conventions?
- [x] **Naming Conventions**: Are variable, function, and structs descriptive and consistent?
- [x] **Code Duplication**: Is there any repeated code that should be refactored?
- [x] **Function/Method Size**: Are functions/methods short and focused on a single task?
- [x] **Comments & Documentation**: Are comments clear, useful, and not excessive? Were comments updated where necessary?
- [x] **Error Handling**: Are errors handled appropriately ?
- [x] **Testing**: Are there sufficient unit/integration tests?
- [x] **Performance**: Are there any obvious performance issues or unnecessary computations?
- [x] **Dependencies**: Are new dependencies justified ?
- [x] **Logging & Monitoring**: Is logging used appropriately (not too verbose, not too silent)?
- [x] **Backward Compatibility**: Does this change break any existing functionality or APIs?
- [x] **Resource Management**: Are resources (files, connections, memory) managed and released properly?
- [x] **PR Description**: Is the PR description clear, providing enough context and explaining the motivation for the change?
- [x] **Documentation & Changelog**: Are README and docs updated if necessary?
